### PR TITLE
Show 3D rendering of segmentation when reviewing PRs

### DIFF
--- a/MorphoDepot/MorphoDepot.py
+++ b/MorphoDepot/MorphoDepot.py
@@ -2320,6 +2320,8 @@ class MorphoDepotLogic(ScriptedLoadableModuleLogic):
             if branchName in segmentationNodesByName.keys():
                 self.segmentationNode = segmentationNodesByName[branchName]
                 self.segmentationNode.GetDisplayNode().SetVisibility(True)
+                if configuration == "reviewer":
+                    self.segmentationNode.CreateClosedSurfaceRepresentation()
             else:
                 self.segmentationNode = slicer.mrmlScene.AddNewNodeByClass("vtkMRMLSegmentationNode")
                 self.segmentationNode.CreateDefaultDisplayNodes()


### PR DESCRIPTION
Create closed surface representation for the reviewer's segmentation so it is automatically visible in the 3D view.

Fixes #115