### PR TITLE
Add Claude Code Review workflow (automatic PR review)

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -1,0 +1,26 @@
+name: Claude Code Review
+
+# Automatically review every pull request with Claude (Max-subscription OAuth token).
+on:
+  pull_request:
+    types: [opened, synchronize]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  review:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: anthropics/claude-code-action@v1
+        with:
+          github_token: ${{ github.token }}
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          prompt: |
+            Review this pull request for correctness bugs, security issues,
+            edge cases, and regressions. Prefer a few high-confidence findings
+            over many speculative ones. Follow the conventions in CLAUDE.md if
+            present in the repository.


### PR DESCRIPTION
Adds `.github/workflows/claude-code-review.yml` so Claude reviews every pull request automatically.

- Triggers on `pull_request` (opened / synchronize).
- Uses `anthropics/claude-code-action@v1`, authenticated with the `CLAUDE_CODE_OAUTH_TOKEN` repo secret (Max subscription) — no API key needed.
- Claude posts findings as PR review comments.

Note: this PR adds the workflow to `main`, so it will start reviewing PRs **whose base branch contains it** — i.e. after this merges, new/updated PRs into `main` get reviewed. (This PR itself is not reviewed, because for `pull_request` GitHub runs the workflow from the base branch, which doesn't have it yet.)

If we also want PRs into `org-development` reviewed before it merges to main, add the same file to `org-development`.