### PR TITLE
Add Claude Code Review workflow (org-development)

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -1,6 +1,9 @@
 name: Claude Code Review
 
 # Automatically review every pull request with Claude (Max-subscription OAuth token).
+# No github_token override -> posts as the Claude GitHub App ("Claude"), not github-actions[bot].
+# NOTE: in app mode the action only runs when this file matches the default branch, so it does
+# NOT review PRs that modify the workflow itself; it reviews normal PRs after this is merged.
 on:
   pull_request:
     types: [opened, synchronize]
@@ -8,7 +11,6 @@ on:
 permissions:
   contents: read
   pull-requests: write
-  issues: write
   id-token: write
 
 jobs:
@@ -21,8 +23,8 @@ jobs:
 
       - uses: anthropics/claude-code-action@v1
         with:
-          github_token: ${{ github.token }}
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          track_progress: true
           prompt: |
             REPO: ${{ github.repository }}
             PR NUMBER: ${{ github.event.pull_request.number }}
@@ -30,10 +32,6 @@ jobs:
             Review this pull request for correctness bugs, security issues,
             edge cases, and regressions. Prefer a few high-confidence findings
             over many speculative ones. Follow the conventions in CLAUDE.md if present.
-
-            Use the `mcp__github_inline_comment__create_inline_comment` tool (with
-            confirmed: true) for specific line-level issues, and `gh pr comment` to post
-            a brief summary. Only post GitHub comments - do not return the review as chat
-            text. If you find no issues, post a short summary comment saying so.
+            Use inline comments for specific lines and a top-level comment for a brief summary.
           claude_args: |
             --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*)"

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -8,19 +8,32 @@ on:
 permissions:
   contents: read
   pull-requests: write
+  issues: write
+  id-token: write
 
 jobs:
   review:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
 
       - uses: anthropics/claude-code-action@v1
         with:
           github_token: ${{ github.token }}
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           prompt: |
+            REPO: ${{ github.repository }}
+            PR NUMBER: ${{ github.event.pull_request.number }}
+
             Review this pull request for correctness bugs, security issues,
             edge cases, and regressions. Prefer a few high-confidence findings
-            over many speculative ones. Follow the conventions in CLAUDE.md if
-            present in the repository.
+            over many speculative ones. Follow the conventions in CLAUDE.md if present.
+
+            Use the `mcp__github_inline_comment__create_inline_comment` tool (with
+            confirmed: true) for specific line-level issues, and `gh pr comment` to post
+            a brief summary. Only post GitHub comments - do not return the review as chat
+            text. If you find no issues, post a short summary comment saying so.
+          claude_args: |
+            --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*)"

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -1,0 +1,26 @@
+name: Claude Code Review
+
+# Automatically review every pull request with Claude (Max-subscription OAuth token).
+on:
+  pull_request:
+    types: [opened, synchronize]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  review:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: anthropics/claude-code-action@v1
+        with:
+          github_token: ${{ github.token }}
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          prompt: |
+            Review this pull request for correctness bugs, security issues,
+            edge cases, and regressions. Prefer a few high-confidence findings
+            over many speculative ones. Follow the conventions in CLAUDE.md if
+            present in the repository.


### PR DESCRIPTION
Adds `.github/workflows/claude-code-review.yml` to `org-development` so PRs targeting it are auto-reviewed by Claude (same workflow as #126, which targets `main`).

Once this merges, feature -> `org-development` PRs get a Claude review. (This PR isn't reviewed itself: for `pull_request`, GitHub runs the workflow from the base branch, which doesn't have it yet.)