### PR TITLE
Release: prevent duplicate pre-release announcements (check state before posting)

### DIFF
--- a/MorphoDepot/MorphoDepot.py
+++ b/MorphoDepot/MorphoDepot.py
@@ -2461,6 +2461,30 @@ class MorphoDepotWidget(ScriptedLoadableModuleWidget, VTKObservationMixin, Enabl
         nameWithOwner = self.logic.nameWithOwner("origin")
         deadlineISO = self.releaseUI.announcementDeadline.date.toString(qt.Qt.ISODate)
         message = self.releaseUI.announcementMessageEdit.plainText
+
+        # Only one active pre-release announcement per repo: it is a repo-state signal (the
+        # pinned, release-pending issue), not a fire-and-forget post.  If one already exists,
+        # offer to REPLACE it rather than silently creating a duplicate.
+        existing = None
+        try:
+            existing = self.logic.findReleaseAnnouncement(nameWithOwner)
+        except Exception as e:
+            logging.warning(f"Could not check for an existing announcement: {e}")
+        if existing:
+            n = existing["number"]
+            existingDeadline = existing.get("deadline") or "unknown"
+            if not (self.testingMode or slicer.util.confirmOkCancelDisplay(
+                    f"This repository already has an active release announcement "
+                    f"(issue #{n}, deadline {existingDeadline}).\n\n"
+                    f"Replace it with a new announcement (deadline {deadlineISO})? "
+                    "The existing one will be closed first.",
+                    windowTitle="Announcement already exists")):
+                return
+            with slicer.util.tryWithErrorDisplay("Failed to retire the existing announcement", waitCursor=True):
+                self.logic.clearReleaseAnnouncement(
+                    nameWithOwner,
+                    message=f"Superseded by a new announcement (deadline {deadlineISO}); closing this one.")
+
         with slicer.util.tryWithErrorDisplay("Failed to query open items", waitCursor=True):
             issues, prs = self.logic.openIssuesAndPRs(nameWithOwner)
         if not issues and not prs:
@@ -4487,15 +4511,18 @@ class MorphoDepotLogic(ScriptedLoadableModuleLogic):
                         "deadline": deadlineMatch.group(1) if deadlineMatch else None}
         return None
 
-    def clearReleaseAnnouncement(self, nameWithOwner, tag=None):
-        """Retire the pre-release announcement after a release: unpin it, remove the
-        release-pending label, comment, and close it.  Best-effort and idempotent."""
+    def clearReleaseAnnouncement(self, nameWithOwner, tag=None, message=None):
+        """Retire the pre-release announcement: unpin it, remove the release-pending label,
+        comment, and close it.  Used both after a release (default message) and when an
+        announcement is superseded by a new one (caller passes `message`).  Best-effort and
+        idempotent."""
         announcement = self.findReleaseAnnouncement(nameWithOwner)
         if not announcement:
             return
         n = str(announcement["number"])
-        message = (f"Release {tag} has been published; closing this announcement." if tag
-                   else "The release has been published; closing this announcement.")
+        if message is None:
+            message = (f"Release {tag} has been published; closing this announcement." if tag
+                       else "The release has been published; closing this announcement.")
         for command in (
             ["issue", "unpin", n, "--repo", nameWithOwner],
             ["issue", "edit", n, "--repo", nameWithOwner, "--remove-label", self.releasePendingLabel],

--- a/MorphoDepot/MorphoDepot.py
+++ b/MorphoDepot/MorphoDepot.py
@@ -2465,11 +2465,8 @@ class MorphoDepotWidget(ScriptedLoadableModuleWidget, VTKObservationMixin, Enabl
         # Only one active pre-release announcement per repo: it is a repo-state signal (the
         # pinned, release-pending issue), not a fire-and-forget post.  If one already exists,
         # offer to REPLACE it rather than silently creating a duplicate.
-        existing = None
-        try:
-            existing = self.logic.findReleaseAnnouncement(nameWithOwner)
-        except Exception as e:
-            logging.warning(f"Could not check for an existing announcement: {e}")
+        # (findReleaseAnnouncement already swallows its own errors and returns None.)
+        existing = self.logic.findReleaseAnnouncement(nameWithOwner)
         if existing:
             n = existing["number"]
             existingDeadline = existing.get("deadline") or "unknown"
@@ -2480,10 +2477,18 @@ class MorphoDepotWidget(ScriptedLoadableModuleWidget, VTKObservationMixin, Enabl
                     "The existing one will be closed first.",
                     windowTitle="Announcement already exists")):
                 return
-            with slicer.util.tryWithErrorDisplay("Failed to retire the existing announcement", waitCursor=True):
-                self.logic.clearReleaseAnnouncement(
-                    nameWithOwner,
-                    message=f"Superseded by a new announcement (deadline {deadlineISO}); closing this one.")
+            self.logic.clearReleaseAnnouncement(
+                nameWithOwner,
+                message=f"Superseded by a new announcement (deadline {deadlineISO}); closing this one.")
+            # clearReleaseAnnouncement swallows its own gh errors, so verify the old announcement
+            # is actually gone before posting — otherwise a failed close would leave a duplicate
+            # (the very thing this guard exists to prevent).
+            if not self.testingMode and self.logic.findReleaseAnnouncement(nameWithOwner) is not None:
+                slicer.util.errorDisplay(
+                    f"Could not close the existing announcement (issue #{n}). Not posting a new "
+                    "one, to avoid duplicates — close it manually and try again.",
+                    windowTitle="Announcement not replaced")
+                return
 
         with slicer.util.tryWithErrorDisplay("Failed to query open items", waitCursor=True):
             issues, prs = self.logic.openIssuesAndPRs(nameWithOwner)


### PR DESCRIPTION
## Problem
The "Notify contributors" action (`onAnnounceUpcomingRelease`) posted a new
pinned `release-pending` announcement issue **every time**, without checking
whether one already existed. So a repo could accumulate multiple active
announcements with conflicting deadlines (reproduced on `amm554/delete-auto-assign`
and a MorphoDepot repo by announcing twice with different dates).

`findReleaseAnnouncement()` — the label + marker state read — works fine and is
already consulted at *release* time (#124), but the announce path never called
it. The `release-pending` label was meant to be the gate; nothing read it here.

## Fix
Add the missing state check to the announce path: if an active announcement
exists, offer to **replace** it (close the old one, then post the new) or
cancel. So changing the deadline updates the single announcement instead of
creating a duplicate. `clearReleaseAnnouncement` gains an optional `message`
so the superseded issue closes with an accurate "superseded by a new
announcement" comment (not the post-release wording).

## Testing
Needs an in-Slicer click-through: announce once → announce again with a
different date → should now prompt "Announcement already exists / replace?";
on replace, the old pinned issue closes and a single new one is posted.

Note: repos that already have duplicate announcements (e.g. the test repo) need
the extra one closed manually once.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
