### PR TITLE
Add interactive @claude workflow (parity with MorphoCloudWorkflow)

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -1,0 +1,40 @@
+name: Claude Code
+
+# On-demand Claude: mention @claude in a PR/issue comment or review to ask
+# for a (re-)review, an explanation, or a change. Restricted to org members
+# and collaborators — this is a public repo, and without the guard any
+# GitHub account could burn the subscription quota (or steer Claude) by
+# commenting.
+
+on:
+  issue_comment:
+    types: [created]
+  pull_request_review_comment:
+    types: [created]
+  pull_request_review:
+    types: [submitted]
+
+jobs:
+  claude:
+    if: |
+      contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.comment.author_association || github.event.review.author_association) &&
+      ((github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
+      (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
+      (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')))
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+      issues: write
+      id-token: write
+      actions: read # lets Claude read CI results on PRs
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 1
+
+      - name: Run Claude Code
+        uses: anthropics/claude-code-action@11ba60486e4aec9ddfeafcf4bb3f00b028ac2c16 # v1
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}


### PR DESCRIPTION
Adds `.github/workflows/claude.yml` — the on-demand `@claude` action — so this
repo matches MorphoCloudWorkflow's review setup. The repo already has
`claude-code-review.yml` (auto-review on PRs); this adds the **interactive**
half: an org member/collaborator can comment `@claude` on a PR/issue/review to
ask for a re-review or to have a review finding fixed and pushed by the action
itself (it has `contents: write`).

Copied verbatim from `MorphoCloud/MorphoCloudWorkflow` (same pinned action SHA,
same author-association guard so only OWNER/MEMBER/COLLABORATOR can invoke it on
this public repo, same `CLAUDE_CODE_OAUTH_TOKEN` secret the review workflow
already uses). Goes on `main` because comment-triggered workflows run from the
default branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
