### PR TITLE
Pin claude-code-review action to a SHA (main)

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -21,7 +21,7 @@ jobs:
         with:
           fetch-depth: 1
 
-      - uses: anthropics/claude-code-action@v1
+      - uses: anthropics/claude-code-action@11ba60486e4aec9ddfeafcf4bb3f00b028ac2c16 # v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           track_progress: true


### PR DESCRIPTION
Pin `anthropics/claude-code-action@v1` to commit `11ba604` in `claude-code-review.yml`, matching the pin `claude.yml` already uses. Supply-chain hardening: a tag can be moved; a SHA can't, and these workflows hold CLAUDE_CODE_OAUTH_TOKEN + write access. Applied to BOTH main and org-development (identical change via cherry-pick) so the workflow stays byte-identical across branches (required for app-mode review validation). Workflow-modifying PR, so the app-mode review is skipped by design.