### PR TITLE
Release: show existing pre-release announcement(s) on repo load

### DIFF
--- a/MorphoDepot/MorphoDepot.py
+++ b/MorphoDepot/MorphoDepot.py
@@ -544,6 +544,13 @@ class MorphoDepotWidget(ScriptedLoadableModuleWidget, VTKObservationMixin, Enabl
         self.releaseUI.announcementCounts = qt.QLabel("Targets: (load a repository)")
         announcementLayout.addRow(self.releaseUI.announcementCounts)
 
+        # Ambient state: shows whether a pre-release announcement already exists for the loaded
+        # repo (filled by updateAnnouncementState on load). The collapsible header also reflects
+        # it, so it is visible even when this section is collapsed.
+        self.releaseUI.announcementStateLabel = qt.QLabel("")
+        self.releaseUI.announcementStateLabel.setWordWrap(True)
+        announcementLayout.addRow(self.releaseUI.announcementStateLabel)
+
         self.releaseUI.announcementDeadline = qt.QDateEdit()
         self.releaseUI.announcementDeadline.calendarPopup = True
         self.releaseUI.announcementDeadline.displayFormat = "yyyy-MM-dd"
@@ -1987,6 +1994,7 @@ class MorphoDepotWidget(ScriptedLoadableModuleWidget, VTKObservationMixin, Enabl
                     self.releaseUI.newBaselineSelector.setCurrentNode(None)
                     self.releaseUI.newColorSelector.setCurrentNode(getattr(self.logic, 'colorTableNode', None))
                     self.updateAnnouncementCounts(repoData)
+                    self.updateAnnouncementState(repoData['nameWithOwner'])
                     self.updateReleaseNotesTemplate(repoData)
                     self.updateCurrentVersionLabel()
                     self.updateMakeReleaseEnabled()
@@ -2004,6 +2012,41 @@ class MorphoDepotWidget(ScriptedLoadableModuleWidget, VTKObservationMixin, Enabl
         issues = repoData.get('issues', {}).get('totalCount', 0)
         prs = repoData.get('pullRequests', {}).get('totalCount', 0)
         self.releaseUI.announcementCounts.text = f"Will post to {issues} open issues and {prs} open PRs."
+
+    def updateAnnouncementState(self, nameWithOwner):
+        """Reflect any EXISTING pre-release announcement in the UI when a repo is loaded — so a
+        user returning in a fresh session sees it without having to click anything. Reads live
+        repo state (the pinned release-pending issue(s)), so it is correct across sessions and
+        machines. Surfaces it in three places: the collapsible header (visible even collapsed),
+        a status line, and the button label; auto-expands the section when one exists."""
+        try:
+            announcements = self.logic.listReleaseAnnouncements(nameWithOwner)
+        except Exception as e:
+            logging.warning(f"Could not check existing release announcements: {e}")
+            announcements = []
+        header = self.releaseUI.announcementCollapsibleButton
+        label = self.releaseUI.announcementStateLabel
+        button = self.releaseUI.announceButton
+        if not announcements:
+            header.text = "Pre-release Announcement"
+            label.text = ""
+            label.setStyleSheet("")
+            button.text = "Notify contributors"
+            return
+        nums = ", ".join(f"#{a['number']}" for a in announcements)
+        deadlines = ", ".join(sorted({a['deadline'] for a in announcements if a['deadline']})) or "unknown"
+        if len(announcements) == 1:
+            header.text = f"Pre-release Announcement — ⚠ already announced (deadline {deadlines}, {nums})"
+            label.text = (f"An upcoming release is already announced ({nums}, deadline {deadlines}). "
+                          "Posting again will replace it.")
+        else:
+            header.text = f"Pre-release Announcement — ⚠ {len(announcements)} announcements exist ({nums})"
+            label.text = (f"⚠ {len(announcements)} active announcements exist ({nums}; deadlines "
+                          f"{deadlines}) — these are duplicates. Posting replaces the oldest; close the "
+                          "extras on GitHub.")
+        label.setStyleSheet("color: #b35900; font-weight: bold;")  # amber, draws attention
+        button.text = "Replace announcement…"
+        header.collapsed = False  # auto-expand so it is noticed
 
     def repoTooltip(self, repo):
         """Build a multiline tooltip listing open issues and PRs for a repo."""
@@ -2354,6 +2397,7 @@ class MorphoDepotWidget(ScriptedLoadableModuleWidget, VTKObservationMixin, Enabl
             # release exists — done unconditionally, independent of the optional item-close step
             # below, so the next cycle's announcement detection starts clean.
             self.logic.clearReleaseAnnouncement(nameWithOwner, createdTag)
+            self.updateAnnouncementState(nameWithOwner)  # announcement retired -> clear the indicator
             self.maybeCloseOpenItemsForRelease(nameWithOwner, createdTag)
             # Reset the in-session screenshots so the next release starts clean.
             self.screenshots = []
@@ -2543,6 +2587,7 @@ class MorphoDepotWidget(ScriptedLoadableModuleWidget, VTKObservationMixin, Enabl
         with slicer.util.tryWithErrorDisplay("Failed to post announcement", waitCursor=True):
             ni, np = self.logic.announceUpcomingRelease(nameWithOwner, deadlineISO, message)
             slicer.util.showStatusMessage(f"Posted announcement to {ni} issues and {np} PRs.")
+        self.updateAnnouncementState(nameWithOwner)  # reflect the just-posted announcement
 
     def previewRepository(self, repoNameWithOwner):
         """Clones a repository and loads its data for previewing."""
@@ -4541,22 +4586,30 @@ class MorphoDepotLogic(ScriptedLoadableModuleLogic):
             logging.warning(f"Could not pin announcement issue #{number}: {e}")
         return number
 
-    def findReleaseAnnouncement(self, nameWithOwner):
-        """Return {'number', 'deadline'} for the open release-pending announcement issue, or None.
-        Reads repo state only; returns None on any error (e.g. the label does not exist yet)."""
+    def listReleaseAnnouncements(self, nameWithOwner):
+        """All open release-pending announcement issues as [{'number','deadline'}], oldest first.
+        Reads repo state only; returns [] on any error (e.g. the label does not exist yet).
+        Normally 0 or 1, but a repo can carry duplicates from before the dedup guard."""
         try:
             items = self.ghJSON(["issue", "list", "--repo", nameWithOwner, "--state", "open",
                                  "--label", self.releasePendingLabel, "--json", "number,body"])
         except Exception:
-            return None
+            return []
+        found = []
         for item in items or []:
             body = item.get("body", "") or ""
             match = re.search(re.escape(self.releaseAnnounceMarkerName) + r"\b([^>]*)", body)
             if match:
                 deadlineMatch = re.search(r"deadline=(\S+)", match.group(1))
-                return {"number": item["number"],
-                        "deadline": deadlineMatch.group(1) if deadlineMatch else None}
-        return None
+                found.append({"number": item["number"],
+                              "deadline": deadlineMatch.group(1) if deadlineMatch else None})
+        return sorted(found, key=lambda a: a["number"])
+
+    def findReleaseAnnouncement(self, nameWithOwner):
+        """The open release-pending announcement {'number','deadline'}, or None (the first, if
+        several exist).  Reads repo state only."""
+        announcements = self.listReleaseAnnouncements(nameWithOwner)
+        return announcements[0] if announcements else None
 
     def clearReleaseAnnouncement(self, nameWithOwner, tag=None, message=None):
         """Retire the pre-release announcement: unpin it, remove the release-pending label,

--- a/MorphoDepot/MorphoDepot.py
+++ b/MorphoDepot/MorphoDepot.py
@@ -2019,11 +2019,11 @@ class MorphoDepotWidget(ScriptedLoadableModuleWidget, VTKObservationMixin, Enabl
         repo state (the pinned release-pending issue(s)), so it is correct across sessions and
         machines. Surfaces it in three places: the collapsible header (visible even collapsed),
         a status line, and the button label; auto-expands the section when one exists."""
-        try:
-            announcements = self.logic.listReleaseAnnouncements(nameWithOwner)
-        except Exception as e:
-            logging.warning(f"Could not check existing release announcements: {e}")
-            announcements = []
+        announcements = self.logic.listReleaseAnnouncements(nameWithOwner)
+        if announcements is None:
+            # The check itself failed (e.g. a transient gh/network error). Leave the indicator
+            # as-is rather than falsely resetting it to "no announcement" and hiding a real one.
+            return
         header = self.releaseUI.announcementCollapsibleButton
         label = self.releaseUI.announcementStateLabel
         button = self.releaseUI.announceButton
@@ -4588,13 +4588,16 @@ class MorphoDepotLogic(ScriptedLoadableModuleLogic):
 
     def listReleaseAnnouncements(self, nameWithOwner):
         """All open release-pending announcement issues as [{'number','deadline'}], oldest first.
-        Reads repo state only; returns [] on any error (e.g. the label does not exist yet).
-        Normally 0 or 1, but a repo can carry duplicates from before the dedup guard."""
+        Returns **None** if the check itself FAILED (e.g. transient gh/network error) vs **[]**
+        when there genuinely are none — so callers can tell "couldn't check" from "none exist"
+        and avoid falsely clearing UI state.  Normally 0 or 1, but a repo can carry duplicates
+        from before the dedup guard."""
         try:
             items = self.ghJSON(["issue", "list", "--repo", nameWithOwner, "--state", "open",
                                  "--label", self.releasePendingLabel, "--json", "number,body"])
-        except Exception:
-            return []
+        except Exception as e:
+            logging.warning(f"Could not list release announcements: {e}")
+            return None
         found = []
         for item in items or []:
             body = item.get("body", "") or ""
@@ -4612,27 +4615,26 @@ class MorphoDepotLogic(ScriptedLoadableModuleLogic):
         return announcements[0] if announcements else None
 
     def clearReleaseAnnouncement(self, nameWithOwner, tag=None, message=None):
-        """Retire the pre-release announcement: unpin it, remove the release-pending label,
-        comment, and close it.  Used both after a release (default message) and when an
-        announcement is superseded by a new one (caller passes `message`).  Best-effort and
-        idempotent."""
-        announcement = self.findReleaseAnnouncement(nameWithOwner)
-        if not announcement:
-            return
-        n = str(announcement["number"])
+        """Retire EVERY open pre-release announcement: unpin, remove the release-pending label,
+        comment, and close each.  Used both after a release (default message) and when an
+        announcement is superseded by a new one (caller passes `message`).  Clears ALL of them
+        (not just the oldest) so a repo carrying duplicates is fully cleaned up.  Best-effort
+        and idempotent."""
         if message is None:
             message = (f"Release {tag} has been published; closing this announcement." if tag
                        else "The release has been published; closing this announcement.")
-        for command in (
-            ["issue", "unpin", n, "--repo", nameWithOwner],
-            ["issue", "edit", n, "--repo", nameWithOwner, "--remove-label", self.releasePendingLabel],
-            ["issue", "comment", n, "--repo", nameWithOwner, "--body", message],
-            ["issue", "close", n, "--repo", nameWithOwner],
-        ):
-            try:
-                self.gh(command)
-            except Exception as e:
-                logging.warning(f"Announcement cleanup step failed ({command[1]}): {e}")
+        for announcement in (self.listReleaseAnnouncements(nameWithOwner) or []):
+            n = str(announcement["number"])
+            for command in (
+                ["issue", "unpin", n, "--repo", nameWithOwner],
+                ["issue", "edit", n, "--repo", nameWithOwner, "--remove-label", self.releasePendingLabel],
+                ["issue", "comment", n, "--repo", nameWithOwner, "--body", message],
+                ["issue", "close", n, "--repo", nameWithOwner],
+            ):
+                try:
+                    self.gh(command)
+                except Exception as e:
+                    logging.warning(f"Announcement cleanup step failed (#{n} {command[1]}): {e}")
 
     def closeOpenItemsForRelease(self, nameWithOwner, version, message=None):
         """Comment on and close every open issue and PR. PRs are closed without merging.


### PR DESCRIPTION
Closes the gap from the #130 discussion: previously a pending announcement was only detected **reactively** when you clicked "Notify contributors", so a user returning in a fresh session saw **no indication** that an announcement (or two) already existed.

**Now**, on loading a repo for Release, `updateAnnouncementState` reads the open `release-pending` issue(s) and surfaces them in three always-visible places:
- the **collapsible section header** — e.g. `Pre-release Announcement — ⚠ already announced (deadline 2026-07-02, #5)` (visible even when the section is collapsed);
- a bold amber **status line** inside;
- the **button** relabels to `Replace announcement…`;
- and the section **auto-expands** so it's noticed.

It **counts duplicates** too (e.g. the two announcements currently on `amm554/delete-auto-assign`) and tells you to close the extras on GitHub. Adds `MorphoDepotLogic.listReleaseAnnouncements`; `findReleaseAnnouncement` now delegates to it. Refreshed after posting and after a release retires the announcement.

Verified with standalone tests (none / single / duplicate-with-different-deadlines parsing + text). Needs an in-Slicer click-through to confirm the header/label/expand render.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
