### PR TITLE
Upload: send each part's content_length to the signing service

### DIFF
--- a/MorphoDepot/MorphoDepot.py
+++ b/MorphoDepot/MorphoDepot.py
@@ -3429,7 +3429,10 @@ class MorphoDepotLogic(ScriptedLoadableModuleLogic):
         expectedMd5 = hashlib.md5(chunk).hexdigest()
         lastError = None
         for _attempt in range(4):
-            signed = post("sign", {"key": key, "upload_id": uploadId, "part_number": partNumber})
+            # Send the exact chunk length so the signing service binds it into the part URL
+            # (S3 then rejects a mismatched body) — part of the server-side per-file size cap.
+            signed = post("sign", {"key": key, "upload_id": uploadId, "part_number": partNumber,
+                                   "content_length": len(chunk)})
             try:
                 resp = requests.put(signed["url"], data=chunk, timeout=None)
             except Exception as e:


### PR DESCRIPTION
Passes `len(chunk)` on every `/uploads/multipart/sign` call so the intake app binds `ContentLength` into the presigned part URL — S3/RadosGW then rejects any part whose body length differs. This engages the server-side per-file size enforcement added in MorphoDepot/morphodepot-intake#16 (#1 of the size-cap fix).

One-line change in `_uploadOneVolumePart`. The field is **optional** on the server, so this is backward compatible — but a client that sends it gets the exact-size binding instead of relying solely on the complete-time HEAD-and-delete backstop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)