### PR TITLE
MorphoDepot org features + overnight review hardening

### DIFF
--- a/Experiments/contributor_table_prototype.py
+++ b/Experiments/contributor_table_prototype.py
@@ -1,0 +1,133 @@
+"""MorphoDepot — contributor data entry via Slicer table nodes (prototype).
+
+Investigates using Slicer's native table functionality (vtkMRMLTableNode + qMRMLTableView,
+the built-in Tables module) as the curator-facing data-entry UI for dataset credit — instead of
+a hand-edited YAML/Markdown file.
+
+Why this fits:
+  * The curator edits a spreadsheet-like GRID inside Slicer (double-click a cell), never raw syntax.
+  * "Author?" is a vtkBitArray column -> renders as a real CHECKBOX.
+  * The "GitHub" column is the auto key -> locked read-only (setFirstColumnLocked).
+  * Insert/Delete-row + copy/paste come free from qMRMLTableView / the Tables module.
+  * Persists as TSV via the node's storage node -> forgiving, round-trips, nothing fragile to break.
+
+Run inside Slicer's Python console:
+    exec(open('.../Experiments/contributor_table_prototype.py').read())
+After it runs, `report` holds the credit resolved FROM the table (what would feed Zenodo/README).
+"""
+
+import slicer
+import vtk
+
+ORG = "MorphoDepot"
+REPO = "MorphoDepot/Ariopsis-felis-cranium"
+ISSUES_URL = "https://github.com/%s/issues/" % REPO
+
+
+# ---- tear down any previous demo run ----
+for pattern in ("MD Contributors*", "MD Contributions*"):
+    for node in list(slicer.util.getNodes(pattern).values()):
+        slicer.mrmlScene.RemoveNode(node)
+
+
+def _str_col(name, values):
+    a = vtk.vtkStringArray()
+    a.SetName(name)
+    for v in values:
+        a.InsertNextValue(v)
+    return a
+
+
+def _bit_col(name, values):
+    a = vtk.vtkBitArray()
+    a.SetName(name)
+    for v in values:
+        a.InsertNextValue(1 if v else 0)
+    return a
+
+
+# ===================== People (identity) table — CURATOR-EDITED =====================
+# Auto-seeded when a contribution is accepted: GitHub handle ALWAYS; Name/ORCID auto ONLY for
+# org members (verified at ORCID onboarding). The rows below simulate that seeded state:
+#   members  -> pre-filled (auto)
+#   non-members -> the curator fills Name/ORCID by hand (some done, one still blank/unresolved)
+#   GitHub, name, ORCID, author?
+people = [
+    ("evasquez",      "Vasquez, Elena M.", "0000-0002-1825-0097", True),   # member (auto) - curator
+    ("mlindgren",     "Lindgren, Marcus",  "0000-0001-7654-3210", True),   # member (auto) - promoted
+    ("tbecker",       "Becker, Tomas",     "0000-0003-2233-1980", False),  # non-member - curator filled
+    ("pnair-fishlab", "Nair, Priya",       "",                    False),  # non-member - ORCID missing
+    ("jwright99",     "",                  "",                    False),  # non-member - UNRESOLVED
+]
+peopleNode = slicer.mrmlScene.AddNewNodeByClass("vtkMRMLTableNode", "MD Contributors (People)")
+peopleNode.AddColumn(_str_col("GitHub", [p[0] for p in people]))
+peopleNode.AddColumn(_str_col("Name (Family, Given)", [p[1] for p in people]))
+peopleNode.AddColumn(_str_col("ORCID", [p[2] for p in people]))
+peopleNode.AddColumn(_bit_col("Author?", [p[3] for p in people]))
+
+# ===================== Contributions (AUTO, read-only): issue -> contributor =====================
+# Derived from merged issue-PRs; the curator does NOT edit this. One row per (issue, contributor);
+# a person repeats across issues. Number links to the real issue.
+contribs = [
+    ("5",  "jwright99",     "v2"),
+    ("8",  "tbecker",       "v1"),
+    ("11", "pnair-fishlab", "v2"),
+    ("12", "tbecker",       "v2"),
+]
+contribNode = slicer.mrmlScene.AddNewNodeByClass("vtkMRMLTableNode", "MD Contributions (auto)")
+contribNode.AddColumn(_str_col("Issue", ["#" + c[0] for c in contribs]))
+contribNode.AddColumn(_str_col("Contributor", ["@" + c[1] for c in contribs]))
+contribNode.AddColumn(_str_col("Release", [c[2] for c in contribs]))
+
+# ===================== Show the editable People table in the main window =====================
+slicer.util.selectModule("Tables")
+try:
+    slicer.modules.tables.widgetRepresentation().setCurrentTableNode(peopleNode)
+except Exception as e:  # pragma: no cover - UI hookup is best-effort
+    print("setCurrentTableNode:", e)
+
+# Large central table view, with the auto GitHub key column locked read-only.
+layoutManager = slicer.app.layoutManager()
+try:
+    layoutManager.setLayout(slicer.vtkMRMLLayoutNode.SlicerLayoutFourUpTableView)
+    tableView = layoutManager.tableWidget(0).tableView()
+    tableView.setMRMLTableNode(peopleNode)
+    tableView.setFirstColumnLocked(True)   # GitHub handle is auto -> not editable
+except Exception as e:  # pragma: no cover
+    print("layout:", e)
+
+slicer.app.processEvents()
+
+
+# ===================== Read the table back -> resolved credit (feeds Zenodo/README) =====================
+def read_people(node):
+    table = node.GetTable()
+    rows = []
+    for r in range(table.GetNumberOfRows()):
+        rows.append(dict(
+            github=table.GetValueByName(r, "GitHub").ToString(),
+            name=table.GetValueByName(r, "Name (Family, Given)").ToString(),
+            orcid=table.GetValueByName(r, "ORCID").ToString(),
+            author=bool(table.GetValueByName(r, "Author?").ToInt()),
+        ))
+    return rows
+
+
+ppl = read_people(peopleNode)
+authors = [p for p in ppl if p["author"]]
+contributors = [p for p in ppl if not p["author"]]
+unresolved = [p["github"] for p in ppl if not p["name"]]
+
+out = ["CREDIT RESOLVED FROM THE TABLE (what would feed Zenodo / the README):", ""]
+out.append("Authors (cited):")
+for a in authors:
+    tail = " <%s>" % a["orcid"] if a["orcid"] else ("  <-- NO NAME: blocks citation" if not a["name"] else "")
+    out.append("  - %s%s" % (a["name"] or "@" + a["github"], tail))
+out.append("Contributors (acknowledged):")
+for c in contributors:
+    disp = c["name"] if c["name"] else "@%s  (name not provided -> credited by handle)" % c["github"]
+    out.append("  - %s" % disp)
+out.append("")
+out.append("Unresolved rows the curator must complete: %s" % (", ".join("@" + u for u in unresolved) or "none"))
+report = "\n".join(out)
+print(report)

--- a/Experiments/contributor_table_prototype.py
+++ b/Experiments/contributor_table_prototype.py
@@ -1,4 +1,7 @@
-"""MorphoDepot — contributor data entry via Slicer table nodes (prototype).
+"""MorphoDepot — contributor data entry via Slicer table nodes (PROTOTYPE / NON-PRODUCTION).
+
+NOT production code. The shipped implementation lives in `MorphoDepot/MorphoDepotContributors.py`;
+this file is a kept exploration only. The hardcoded `REPO` below is a throwaway example.
 
 Investigates using Slicer's native table functionality (vtkMRMLTableNode + qMRMLTableView,
 the built-in Tables module) as the curator-facing data-entry UI for dataset credit — instead of

--- a/MorphoDepot/CMakeLists.txt
+++ b/MorphoDepot/CMakeLists.txt
@@ -4,6 +4,7 @@ set(MODULE_NAME MorphoDepot)
 #-----------------------------------------------------------------------------
 set(MODULE_PYTHON_SCRIPTS
   ${MODULE_NAME}.py
+  ${MODULE_NAME}Contributors.py
   )
 
 set(MODULE_PYTHON_RESOURCES

--- a/MorphoDepot/MorphoDepot.py
+++ b/MorphoDepot/MorphoDepot.py
@@ -414,14 +414,14 @@ class MorphoDepotWidget(ScriptedLoadableModuleWidget, VTKObservationMixin, Enabl
         createButtonIndex = self.createUI.verticalLayout.indexOf(self.createUI.createRepository)
         self.createUI.verticalLayout.insertWidget(createButtonIndex + 1, self.createUI.saveEditsButton)
 
-        # Opt-in: bake a GitHub Actions workflow into the new repo that auto-assigns each new
-        # issue back to its creator.  Offered only when the gh token has the `workflow` scope
-        # (checked lazily on Create-tab entry); disabled with a hint otherwise.  Off by default.
-        # The checkbox sits next to a "?" button that opens a fuller explanation, since the label
-        # alone doesn't convey what the option actually does.
+        # On by default (opt-out), for ALL repo types: bake a GitHub Actions workflow into the new
+        # repo that auto-assigns each new issue back to its creator.  Requires the gh token's
+        # `workflow` scope (checked lazily on Create-tab entry); without it the box is unchecked +
+        # disabled with a hint.  The checkbox sits next to a "?" button that opens a fuller
+        # explanation, since the label alone doesn't convey what the option actually does.
         self.createUI.autoAssignCheckBox = qt.QCheckBox(
             "Set the GitHub workflow to auto-assign new issues to their creators")
-        self.createUI.autoAssignCheckBox.checked = False
+        self.createUI.autoAssignCheckBox.checked = True
         self.createUI.autoAssignCheckBox.enabled = False
         self.createUI.autoAssignCheckBox.toolTip = (
             "Adds a small GitHub Actions workflow so that when someone opens an issue on this "
@@ -439,6 +439,29 @@ class MorphoDepotWidget(ScriptedLoadableModuleWidget, VTKObservationMixin, Enabl
         self.createUI.verticalLayout.insertLayout(
             self.createUI.verticalLayout.indexOf(self.createUI.createRepository),
             autoAssignLayout)
+
+        # === Q0: repository TYPE is the FIRST choice (org-design Sec.1.0/9.7).  It determines where
+        # the repo lives (archival -> MorphoDepot org, members-only, DOI; short-term -> personal
+        # account, no DOI) and the org-only behaviors below.  This selector sits at the very top of the
+        # create form and drives the (now hidden) duplicate repoType question in the accession form. ===
+        self.createUI.repoTypeGroup = qt.QGroupBox("Repository type")
+        repoTypeGroupLayout = qt.QVBoxLayout(self.createUI.repoTypeGroup)
+        self.createUI.archivalRadio = qt.QRadioButton(
+            "Archival - maintained and citable; created in the MorphoDepot organization "
+            "(members only) and gets a DOI")
+        self.createUI.shortTermRadio = qt.QRadioButton(
+            "Short-term - disposable / classroom; created on your own account, no DOI")
+        repoTypeGroupLayout.addWidget(self.createUI.archivalRadio)
+        repoTypeGroupLayout.addWidget(self.createUI.shortTermRadio)
+        headerIndex = self.createUI.verticalLayout.indexOf(self.createUI.createSectionHeader)
+        self.createUI.verticalLayout.insertWidget(headerIndex + 1, self.createUI.repoTypeGroup)
+        self.createUI.archivalRadio.toggled.connect(self._onRepoTypeChanged)
+        self.createUI.shortTermRadio.toggled.connect(self._onRepoTypeChanged)
+        # Hide the duplicate repoType question buried in the accession form; this selector drives it.
+        try:
+            self.createUI.accessionForm.questions["repoType"].questionBox.hide()
+        except Exception:
+            pass
 
         # === REGION 3: Make Repository Public (shown only once a repo is staged) ===
         # Separated from the form above by a divider + bold centered header (the SAME treatment
@@ -475,13 +498,13 @@ class MorphoDepotWidget(ScriptedLoadableModuleWidget, VTKObservationMixin, Enabl
         # in at least one organization (populateOwnerSelector decides).
         self.createUI.destinationQuestion = FormComboBoxQuestion("Publish destination:")
         self.createUI.destinationQuestion.questionBox.toolTip = (
-            "When you click 'Publish / Go live', the repository is made public under this owner. "
+            "When you click 'Make Public', the repository is made public under this owner. "
             "Choose your personal account or an organization you belong to.")
         self.createUI.destinationQuestion.questionBox.setVisible(False)
         self.createUI.destinationPersonalLogin = ""
         goLiveLayout.addWidget(self.createUI.destinationQuestion.questionBox)
         goLiveButtonsLayout = qt.QHBoxLayout()
-        self.createUI.publishButton = qt.QPushButton("Publish / Go live")
+        self.createUI.publishButton = qt.QPushButton("Make Public")
         self.createUI.publishButton.enabled = False
         self.createUI.discardButton = qt.QPushButton("Discard")
         self.createUI.discardButton.enabled = False
@@ -987,10 +1010,28 @@ class MorphoDepotWidget(ScriptedLoadableModuleWidget, VTKObservationMixin, Enabl
     def _updateCreateSectionHeader(self):
         """The section header below the staged-repos list reflects what the form is doing:
         creating a new repository, or editing a reopened staged one."""
-        if self._resumedForEdit and self._stagedNameWithOwner:
+        editing = bool(self._resumedForEdit and self._stagedNameWithOwner)
+        if editing:
             self.createUI.createSectionHeader.text = f"Editing staged repository: {self._stagedNameWithOwner}"
         else:
             self.createUI.createSectionHeader.text = "Create a new repository"
+        # The repository TYPE is the irreversible Q0 decision (org-design Sec.1.0): archival<->short-term
+        # cannot change once staged (it would mean moving between the org and a personal account).  So
+        # the selector is editable only while CREATING; when editing a reopened staged repo it is hidden
+        # (to change type, discard and start over).  Reflect the staged repo's fixed type on it anyway,
+        # so accessionData['repoType'] stays correct for the re-save.
+        if hasattr(self.createUI, "repoTypeGroup"):
+            self.createUI.repoTypeGroup.visible = not editing
+            if editing:
+                owner = self._stagedNameWithOwner.split("/")[0]
+                try:
+                    orgs = (self.logic.morphoDepotOrg, self.logic.morphoDepotTestingOrg)
+                except Exception:
+                    orgs = ("MorphoDepot", "MorphoDepotTesting")
+                if owner in orgs:
+                    self.createUI.archivalRadio.checked = True
+                else:
+                    self.createUI.shortTermRadio.checked = True
 
     def onCurrentTabChanged(self,index):
         qt.QSettings().setValue("MorphoDepot/tabIndex", index)
@@ -1000,6 +1041,24 @@ class MorphoDepotWidget(ScriptedLoadableModuleWidget, VTKObservationMixin, Enabl
                 self.populateOwnerSelector()
             self._refreshAutoAssignAvailability()
             self.refreshStagedReposList()
+
+    def _onRepoTypeChanged(self, _checked=False):
+        """Q0 fork (org-design Sec.1.0/9.7): the top-level repository-type selector drives the
+        (hidden) accession-form repoType question.  Auto-assign is independent of repo type now
+        (on by default / opt-out for ALL types, scope-gated), so this no longer touches it."""
+        archival = self.createUI.archivalRadio
+        shortTerm = self.createUI.shortTermRadio
+        if not archival.checked and not shortTerm.checked:
+            return  # neither chosen yet
+        isArchival = archival.checked
+        # keep accessionData['repoType'] populated by driving the hidden form question
+        try:
+            label = ("Archival (intended for long-term maintenance)" if isArchival
+                     else "Short-term (e.g. repositories for classroom exercises, "
+                          "that are not meant to be maintained for long-term)")
+            self.createUI.accessionForm.questions["repoType"].optionButtons[label].click()
+        except Exception:
+            pass
 
     def _refreshAutoAssignAvailability(self):
         """Lazily (once) check whether the gh token has the `workflow` scope and enable the
@@ -1031,6 +1090,21 @@ class MorphoDepotWidget(ScriptedLoadableModuleWidget, VTKObservationMixin, Enabl
         goLiveGroup = getattr(self.createUI, "goLiveGroup", None)
         gateVisible = goLiveGroup is not None and goLiveGroup.visible
         self.createUI.createRepository.enabled = valid and not gateVisible
+        # In edit mode the Update button must also reflect form validity — which includes the
+        # Section-6 redistribution acknowledgement (validateForm) — so unticking that box disables
+        # Update, not just Create.
+        saveEdits = getattr(self.createUI, "saveEditsButton", None)
+        if saveEdits is not None and getattr(self, "_resumedForEdit", False):
+            saveEdits.enabled = valid
+
+    def _redistributionAcknowledged(self):
+        """True if the Section-6 'I have the right to allow redistribution of this data' box is
+        ticked.  Required to stage (validateForm), and enforced again at Update and Publish so the
+        attestation cannot be revoked while still proceeding."""
+        try:
+            return self.createUI.accessionForm.questions["redistributionAcknowledgement"].answer() != []
+        except Exception:
+            return False
 
     def _setGoLiveZoneVisible(self, visible):
         """Show/hide the entire 'Make Repository Public' zone — divider + bold header + box —
@@ -1283,43 +1357,38 @@ class MorphoDepotWidget(ScriptedLoadableModuleWidget, VTKObservationMixin, Enabl
             return
         sourceVolume, colorTable, sourceSegmentation, accessionData = inputs
 
-        # Destination: members choose where the repo lives; non-members always use their own
-        # account.  Org = S3, 10 GB, governed (you cannot delete a *public* org repo — owners do).
-        # Personal = a GitHub release asset, 2 GB, fully yours (delete anytime) — for
-        # disposable/classroom repos.
+        # Q0 fork (org-design Sec.1.0 / 9.7): the repository TYPE determines where it lives — the two
+        # never cross.  ARCHIVAL = born in the MorphoDepot org (S3, 10 GB, governed, DOI-minted) and
+        # is members-only.  SHORT-TERM = the creator's personal account (release asset, 2 GB,
+        # deletable anytime), available to anyone.  There is no separate destination prompt.
         useOrg = False
         testingOwner = None
+        repoTypeAnswer = accessionData.get("repoType") or ["", ""]
+        isArchival = str(repoTypeAnswer[1]).startswith("Archival")
         if self.testingMode:
-            # Developer self-test: provision directly into the throwaway testing org using the
-            # creator's own gh rights (release asset, no App, no S3) — never the personal account
-            # or the production MorphoDepot org.  No destination prompt.
+            # Developer self-test: provision into the throwaway testing org (release asset, no App/S3).
             testingOwner = self.logic.morphoDepotTestingOrg
-        elif self.logic.userIsOrgMember():
-            who = self.logic.whoami()
-            org = self.logic.morphoDepotOrg
-            items = [f"My account ({who}) — personal, 2 GB, you can delete it anytime",
-                     f"{org} (organization) — S3, 10 GB, governed"]
-            # PythonQt's static getItem doesn't return (text, ok) like PyQt, so drive an
-            # explicit dialog: exec_() gives the OK/Cancel, textValue() the selection.
-            dialog = qt.QInputDialog(slicer.util.mainWindow())
-            dialog.setWindowTitle("Where should this repository live?")
-            dialog.setLabelText("Create this repository under:")
-            dialog.setComboBoxItems(items)
-            dialog.setComboBoxEditable(False)
-            dialog.setTextValue(items[0])
-            if not dialog.exec_():
-                self.progressMethod("Repository creation aborted")
+        elif isArchival:
+            if not self.logic.userIsOrgMember():
+                slicer.util.errorDisplay(
+                    "Archival datasets are created in the MorphoDepot organization and require "
+                    "membership.\n\nEither join the organization (join.morphodepot.org), or set the "
+                    "Repository Type to Short-term to create this on your own account.",
+                    windowTitle="Archival requires membership")
+                self.progressMethod("Repository creation aborted: archival requires membership")
                 return
-            choice = dialog.textValue()
-            useOrg = (choice == items[1])
+            useOrg = True  # archival -> the org
+        # else: short-term -> personal account (useOrg stays False)
 
         if not self.showConfirmationDialog(sourceVolume, colorTable, accessionData, sourceSegmentation, self.screenshots, useOrg=useOrg):
             self.progressMethod("Repository creation aborted")
             return
 
-        # Opt-in auto-assign workflow: only when the box is checked AND the token actually has
-        # the `workflow` scope (double-gated — the box is disabled without the scope).
-        enableAutoAssign = bool(self.createUI.autoAssignCheckBox.checked and getattr(self, "_hasWorkflowScope", False))
+        # Auto-assign workflow: ON by default for ALL repo types (opt-out via the checkbox).
+        # Still scope-gated — without the `workflow` scope the box is unchecked + disabled, so
+        # `checked` is already False there and we never try to push a workflow we cannot.
+        enableAutoAssign = bool(self.createUI.autoAssignCheckBox.checked
+                                and getattr(self, "_hasWorkflowScope", False))
 
         slicer.util.showStatusMessage("Staging repository (private)...")
         staged = None
@@ -1390,6 +1459,12 @@ class MorphoDepotWidget(ScriptedLoadableModuleWidget, VTKObservationMixin, Enabl
         repeatedly before going live."""
         if not self._resumedForEdit:
             return
+        if not self._redistributionAcknowledged():
+            slicer.util.errorDisplay(
+                "Please confirm you have the right to allow redistribution of this data "
+                "(Section 6: Licensing) before updating the repository.",
+                windowTitle="Redistribution acknowledgement required")
+            return
         gathered = self._gatherStagedEdits()
         if gathered is None:
             return  # aborted: the loaded segmentation was edited in place (user was warned)
@@ -1419,9 +1494,126 @@ class MorphoDepotWidget(ScriptedLoadableModuleWidget, VTKObservationMixin, Enabl
         if not self.testingMode:
             slicer.util.infoDisplay(popupText, windowTitle="MorphoDepot")
 
+    def _enrichMemberPerson(self, person):
+        """Pre-fill a member's name/ORCID/affiliation from their onboarding record so the curator never
+        re-types info we already have (every archival creator is a member).  Org owners can read the
+        owners-only onboarding-records repo; for others this 404s and we fall back to the GitHub
+        profile name.  The App authoritatively re-enriches every member at mint."""
+        import MorphoDepotContributors as MDC
+        github = person.get("github")
+        if not github or person.get("name"):
+            return
+        text, _ = self._readRepoFileViaApi("MorphoDepot/onboarding-records", f"records/{github}.json")
+        if text:
+            try:
+                rec = json.loads(text)
+            except Exception:
+                rec = {}
+            orcid = (rec.get("orcid") or "").strip()
+            given, family = MDC.orcid_name(orcid) if orcid else (None, None)
+            person["name"] = MDC.zenodo_name(rec.get("name", github), given, family)
+            if orcid and not person.get("orcid"):
+                person["orcid"] = orcid
+            if rec.get("institution") and not person.get("affiliation"):
+                person["affiliation"] = rec["institution"]
+            person["source"] = "member"
+            return
+        try:  # fallback: GitHub profile display name (no ORCID)
+            profile = self.logic.ghJSON(["api", f"/users/{github}"])
+            if isinstance(profile, dict) and profile.get("name"):
+                person["name"] = profile["name"]
+        except Exception:
+            pass
+
+    def _repoHasBaseline(self, nameWithOwner):
+        """True if the staged repo carries a baseline.seg.nrrd (it shipped a baseline -> atlas case).
+        A from-scratch archival repo has no baseline file and skips the credit gate at go-live."""
+        try:
+            info = self.logic.ghJSON(["api", f"/repos/{nameWithOwner}/contents/baseline.seg.nrrd"])
+            return isinstance(info, dict) and bool(info.get("sha"))
+        except Exception:
+            return False
+
+    def _readRepoFileViaApi(self, nameWithOwner, path):
+        """Return (text, sha) for a repo file via the GitHub API, or (None, None) if absent."""
+        import base64
+        try:
+            info = self.logic.ghJSON(["api", f"/repos/{nameWithOwner}/contents/{path}"])
+            if isinstance(info, dict) and info.get("content"):
+                return base64.b64decode(info["content"]).decode(), info.get("sha")
+        except Exception:
+            pass
+        return None, None
+
+    def _curateBaselineCreditViaApi(self, nameWithOwner):
+        """Atlas case at go-live: collect/confirm who made the baseline and write CONTRIBUTORS.json to
+        the staged repo via the GitHub API (no local clone exists at publish; the repo is private but
+        the curator has write).  Returns False to abort the publish.  Loads any existing
+        CONTRIBUTORS.json so names are never re-entered (org-design Sec.9.6/9.7)."""
+        import base64
+        import MorphoDepotContributors as MDC
+        text, existingSha = self._readRepoFileViaApi(nameWithOwner, "CONTRIBUTORS.json")
+        data = json.loads(text) if text else MDC.new_record(nameWithOwner)
+        curatorText, _ = self._readRepoFileViaApi(nameWithOwner, "CURATOR")
+        curator = (curatorText or "").strip() or self.logic.whoami()
+        MDC.ensure_person(data, github=curator, author=True, source="member")["curator"] = True
+        for member in data["people"]:   # pre-fill any rows we already have info for (the curator etc.)
+            self._enrichMemberPerson(member)
+
+        panel = MDC.make_contributor_panel(data, title="Who made the baseline segmentation?",
+                                           show_header=False, show_contributions=False)
+        dialog = qt.QDialog(slicer.util.mainWindow())
+        dialog.setWindowTitle("Baseline contributors")
+        dialog.setMinimumWidth(560)
+        dialog.setMaximumWidth(760)
+        dialogLayout = qt.QVBoxLayout(dialog)
+        message = qt.QLabel(
+            "<b>Who made the baseline segmentation?</b><br><br>"
+            "Is there anyone other than yourself you would like to acknowledge for contributing to this "
+            "existing segmentation? If you want, you can elevate them to co-author status; otherwise they "
+            "are listed as contributors. Your information is automatically added as the lead author to "
+            "the citation.<br><br>"
+            "When you are done &mdash; or if you don't have anyone to add &mdash; click <b>Done</b>. "
+            "&nbsp;<a href=\"%s\">Documentation</a>" % MDC.DOC_URL)
+        message.setWordWrap(True)
+        message.setOpenExternalLinks(True)
+        dialogLayout.addWidget(message)
+        dialogLayout.addWidget(panel.widget)
+        # NOTE: build buttons with addButton(text, role) — PythonQt does NOT honor the
+        # QDialogButtonBox(Ok | Cancel) flags constructor (it yields an empty, button-less box).
+        buttonBox = qt.QDialogButtonBox()
+        buttonBox.addButton("Done", qt.QDialogButtonBox.AcceptRole)
+        buttonBox.addButton("Cancel", qt.QDialogButtonBox.RejectRole)
+        buttonBox.accepted.connect(dialog.accept)
+        buttonBox.rejected.connect(dialog.reject)
+        dialogLayout.addWidget(buttonBox)
+        while True:
+            if not dialog.exec_():
+                return False  # cancelled -> caller blocks the publish
+            panel.syncFromTable()
+            if panel.isReady():
+                break
+            slicer.util.warningDisplay("Each cited author needs a real name (Family, Given).",
+                                       windowTitle="Author name required")
+
+        content = base64.b64encode(MDC.dumps(panel.data).encode()).decode()
+        command = ["api", f"/repos/{nameWithOwner}/contents/CONTRIBUTORS.json", "-X", "PUT",
+                   "-f", "message=Add CONTRIBUTORS.json (baseline credit at go-live)",
+                   "-f", f"content={content}"]
+        if existingSha:
+            command += ["-f", f"sha={existingSha}"]
+        self.logic.gh(command)
+        return True
+
     def onPublish(self):
         """Take the staged repo live (make it public) where it already lives — the destination
         was fixed at create, so this no longer offers an org/personal choice or any transfer."""
+        if not self._redistributionAcknowledged():
+            slicer.util.errorDisplay(
+                "Please confirm you have the right to allow redistribution of this data "
+                "(Section 6: Licensing) before publishing.",
+                windowTitle="Redistribution acknowledgement required")
+            return
         ctx = getattr(self.logic, "stagingContext", None) or {}
         where = ctx.get("personalNameWithOwner", "the staged repository")
         isOrg = bool(ctx.get("isMember"))
@@ -1460,6 +1652,30 @@ class MorphoDepotWidget(ScriptedLoadableModuleWidget, VTKObservationMixin, Enabl
                     self.logic.saveStagedRepoEdits(editedData, colorTable=newColorTable,
                                                    sourceSegmentation=newSegmentation,
                                                    screenshots=self.screenshots)
+        except Exception as e:
+            slicer.util.showStatusMessage("")
+            return
+
+        # Contributor-credit gate (archival + baseline): an archival repo that ships a baseline at
+        # go-live (= v1) must declare who made that baseline before it can be made public.  No local
+        # clone exists at publish, so this reads/writes CONTRIBUTORS.json on GitHub directly (the repo
+        # is private but the curator has write).  Cancelling here blocks the publish.  (org-design 9.6/9.7)
+        nameWithOwner = ctx.get("personalNameWithOwner")
+        if isOrg and nameWithOwner and self._repoHasBaseline(nameWithOwner):
+            try:
+                creditOk = self._curateBaselineCreditViaApi(nameWithOwner)
+            except Exception as exc:
+                slicer.util.showStatusMessage("")
+                slicer.util.errorDisplay(
+                    f"Could not record the baseline contributors on GitHub:\n{exc}\n\nPublish aborted.",
+                    windowTitle="Baseline credit failed")
+                return  # writing CONTRIBUTORS.json failed -> do NOT make public
+            if not creditOk:
+                slicer.util.showStatusMessage("")
+                return  # curator cancelled the credit step -> do NOT make public
+
+        try:
+            with slicer.util.tryWithErrorDisplay(_("Trouble publishing repository"), waitCursor=True):
                 slicer.util.showStatusMessage("Publishing...")
                 final = self.logic.publishStagedRepo()
         except Exception as e:
@@ -1678,7 +1894,7 @@ class MorphoDepotWidget(ScriptedLoadableModuleWidget, VTKObservationMixin, Enabl
         form.questions["imageContents"].optionButtons["Whole specimen"].click()
         form.questions["githubRepoName"].answerText.text = repoName
         form.questions["redistributionAcknowledgement"].optionButtons["I have the right to allow redistribution of this data."].click()
-        form.questions["repoType"].optionButtons["Short-term (e.g. repositories for classroom exercises, that are not meant to be maintained for long-term)"].click()
+        self.createUI.shortTermRadio.checked = True  # top-level Q0 selector -> drives the hidden repoType question
         # Contact email is no longer part of the accession form; it is entered in the widget's
         # Go-live section and submitted at publish.
 
@@ -1792,8 +2008,10 @@ class MorphoDepotWidget(ScriptedLoadableModuleWidget, VTKObservationMixin, Enabl
         selectedItems = self.annotateUI.prList.selectedItems()
         if selectedItems:
             item = selectedItems[0]
-            self.selectedPR = self.prsByItem[item]
-            self.annotateUI.openPRPageButton.enabled = True
+            # prsByItem is shared between the Annotate and Review tabs; a stale item from the other
+            # tab's still-populated list won't be present, so guard the lookup.
+            self.selectedPR = self.prsByItem.get(item)
+            self.annotateUI.openPRPageButton.enabled = self.selectedPR is not None
 
     def onOpenPRPageButtonClicked(self):
         """Open the currently selected PR in the browser."""
@@ -1969,7 +2187,9 @@ class MorphoDepotWidget(ScriptedLoadableModuleWidget, VTKObservationMixin, Enabl
 
     def onPRDoubleClicked(self, item):
         repoDirectory = self.logic.localRepositoryDirectory()
-        pr = self.prsByItem[item]
+        pr = self.prsByItem.get(item)  # shared dict; ignore a stale item from the other tab
+        if pr is None:
+            return
         if self.testingMode or slicer.util.confirmOkCancelDisplay("Close scene and load PR?"):
             with slicer.util.tryWithErrorDisplay("Failed to load PR", waitCursor=True):
                 slicer.util.showStatusMessage(f"Loading {item.text()}")
@@ -2425,6 +2645,13 @@ class MorphoDepotWidget(ScriptedLoadableModuleWidget, VTKObservationMixin, Enabl
         if not self._confirmReleaseAnnouncement(nameWithOwner):
             return
 
+        # Contributor credit (archival/org repos only): curate CONTRIBUTORS.json and stage it into the
+        # working tree so prepareReleaseSnapshot's `git add --all` commits it in the release commit
+        # (the shared-file invariant — all shared files change only at release; org-design Sec.9.6).
+        if self._isArchivalRepo(nameWithOwner):
+            if not self._curateContributorsForRelease(nameWithOwner):
+                return
+
         prompt = self.buildReleaseConfirmation(plan, baselineNode, colorTableNode)
         if not (self.testingMode or slicer.util.confirmOkCancelDisplay(prompt, windowTitle=f"Make release {newTag}")):
             return
@@ -2457,6 +2684,95 @@ class MorphoDepotWidget(ScriptedLoadableModuleWidget, VTKObservationMixin, Enabl
             self.screenshots = []
             self.updateScreenshotCount()
         slicer.util.showStatusMessage("New release created. You can add more comments on the GitHub release page.")
+
+    def _isArchivalRepo(self, nameWithOwner):
+        """True if the repo is owned by an organization (archival). Release credit/DOI are
+        archival-only (org-design Sec.9.6); personal short-term repos get no contributor record."""
+        try:
+            info = self.logic.ghJSON(["api", f"/repos/{nameWithOwner}"])
+            return (info or {}).get("owner", {}).get("type") == "Organization"
+        except Exception:
+            return False
+
+    def _curateContributorsForRelease(self, nameWithOwner):
+        """Show the contributor-credit grid for this release and stage CONTRIBUTORS.json into the
+        working tree (so prepareReleaseSnapshot commits it in the release). Returns False to abort.
+
+        Blocks only when a cited author has no real name; contributors with no name are credited by
+        handle. See org-design Sec.9.6 / 9.7.
+        """
+        import MorphoDepotContributors as MDC
+        repoDir = self.logic.localRepo.working_dir
+        contribPath = os.path.join(repoDir, "CONTRIBUTORS.json")
+        data = MDC.load(contribPath) if os.path.exists(contribPath) else MDC.new_record(nameWithOwner)
+
+        # Ensure the curator (CURATOR file, else the signed-in user) is a cited author.
+        curator = None
+        curatorPath = os.path.join(repoDir, "CURATOR")
+        if os.path.exists(curatorPath):
+            with open(curatorPath) as f:
+                curator = f.read().strip() or None
+        curator = curator or self.logic.whoami()
+        MDC.ensure_person(data, github=curator, author=True, source="member")["curator"] = True
+        for member in data["people"]:   # pre-fill rows we already have info for (curator + members)
+            self._enrichMemberPerson(member)
+
+        tag = self.logic.nextReleaseTag() or ""
+        # Gather segmentation contributions (merged issue-N PRs) so the dialog shows live credit even
+        # when the release-time sync_contributors Action is not installed on the repo.  Best-effort —
+        # a gh failure here must never block the release.
+        try:
+            self._gatherMergedContributions(nameWithOwner, data, tag)
+        except Exception as e:
+            logging.warning(f"Could not gather merged-PR contributions: {e}")
+        panel = MDC.make_contributor_panel(data, title=f"Release {tag} - confirm contributors")
+        dialog = qt.QDialog(slicer.util.mainWindow())
+        dialog.setWindowTitle("Contributors & credit")
+        dialog.setMinimumSize(640, 480)
+        dialogLayout = qt.QVBoxLayout(dialog)
+        dialogLayout.addWidget(panel.widget)
+        # addButton(text, role) — PythonQt does NOT honor the QDialogButtonBox(Ok | Cancel) flags
+        # constructor (it yields a button-less box).
+        buttonBox = qt.QDialogButtonBox()
+        buttonBox.addButton("Confirm", qt.QDialogButtonBox.AcceptRole)
+        buttonBox.addButton("Cancel", qt.QDialogButtonBox.RejectRole)
+        buttonBox.accepted.connect(dialog.accept)
+        buttonBox.rejected.connect(dialog.reject)
+        dialogLayout.addWidget(buttonBox)
+
+        while True:
+            if not dialog.exec_():
+                return False  # curator cancelled -> abort the release
+            panel.syncFromTable()
+            if panel.isReady():
+                break
+            slicer.util.warningDisplay(
+                "Each cited author needs a real name (Family, Given). Fill the missing name(s), "
+                "or untick Author for those rows.", windowTitle="Author name required")
+        panel.saveTo(contribPath)
+        return True
+
+    def _gatherMergedContributions(self, nameWithOwner, data, releaseTag):
+        """Collect merged issue-N segmentation PRs into `data` (people + contributions), mirroring the
+        release-time sync_contributors Action so the Release dialog shows live credit even when that
+        Action is not installed.  issue-N branch convention; MDC.add_contribution dedups, so gathering
+        the full cumulative set each release is idempotent and stamps the release on first sight."""
+        import re
+        import MorphoDepotContributors as MDC
+        issueBranch = re.compile(r"^issue-(\d+)$")
+        prs = self.logic.ghJSON([
+            "pr", "list", "--repo", nameWithOwner, "--state", "merged", "--base", "main",
+            "--limit", "500", "--json", "number,headRefName,author"]) or []
+        for pr in prs:
+            match = issueBranch.match(pr.get("headRefName", "") or "")
+            if not match:
+                continue  # not a segmentation PR (issue-N branch convention)
+            author = pr.get("author") or {}
+            login = author.get("login")
+            if not login:
+                continue
+            MDC.ensure_person(data, github=login, github_id=author.get("id"), source="non-member")
+            MDC.add_contribution(data, issue=int(match.group(1)), by=login, release=releaseTag)
 
     def buildReleaseConfirmation(self, plan, baselineNode, colorTableNode):
         """Compose the OK/Cancel summary describing every action that will run during release."""
@@ -2558,10 +2874,32 @@ class MorphoDepotWidget(ScriptedLoadableModuleWidget, VTKObservationMixin, Enabl
             return True
         annNumber = announcement["number"] if announcement else None
         openCount = len([i for i in (issues or []) if i.get("number") != annNumber]) + len(prs or [])
-        if openCount == 0:
+        if announcement is not None:
+            # An announcement exists — remind only if its deadline has not yet passed.
+            deadline = announcement.get("deadline")
+            todayISO = qt.QDate.currentDate().toString(qt.Qt.ISODate)
+            if deadline and todayISO < deadline:
+                return slicer.util.confirmOkCancelDisplay(
+                    f"You announced a release deadline of {deadline}, which has not passed yet.\n\n"
+                    "Cutting the release now will close contributors' open work early. Continue?",
+                    windowTitle="Announced deadline not reached")
             return True
-        if announcement is None:
-            msgBox = qt.QMessageBox()
+
+        # No announcement was made.  Always nudge (non-blocking): softly when nothing is open
+        # (a solo dataset), more firmly when open items would be closed.  'Proceed' is always there.
+        msgBox = qt.QMessageBox()
+        announceButton = msgBox.addButton("Announce first...", qt.QMessageBox.ActionRole)
+        proceedButton = msgBox.addButton("Proceed anyway", qt.QMessageBox.AcceptRole)
+        if openCount == 0:
+            msgBox.setWindowTitle("No release announcement")
+            msgBox.setIcon(qt.QMessageBox.Information)
+            msgBox.setText("No upcoming-release announcement was made.")
+            msgBox.setInformativeText(
+                "If others contribute segmentations to this dataset, it is good practice to announce "
+                "the upcoming release first (with a deadline) so they can finish in time. For a solo "
+                "dataset you can simply proceed.")
+            msgBox.setDefaultButton(proceedButton)
+        else:
             msgBox.setWindowTitle("No pre-release announcement")
             msgBox.setIcon(qt.QMessageBox.Warning)
             msgBox.setText("No pre-release announcement has been made for this release.")
@@ -2569,28 +2907,21 @@ class MorphoDepotWidget(ScriptedLoadableModuleWidget, VTKObservationMixin, Enabl
                 f"{openCount} open issue(s)/PR(s) will be closed by this release, and the "
                 "contributors have not been notified to finish their work before it is cut.\n\n"
                 "Announce now to give them a deadline, proceed anyway, or cancel.")
-            announceButton = msgBox.addButton("Announce now...", qt.QMessageBox.ActionRole)
-            proceedButton = msgBox.addButton("Proceed anyway", qt.QMessageBox.AcceptRole)
             msgBox.addButton("Cancel", qt.QMessageBox.RejectRole)
-            msgBox.exec_()
-            clicked = msgBox.clickedButton()
-            if clicked == announceButton:
-                self.releaseUI.announcementCollapsibleButton.collapsed = False
-                slicer.util.infoDisplay(
-                    "Set a deadline and message above, then click 'Notify contributors'. "
-                    "Re-run Make Release when you are ready.",
-                    windowTitle="Announce upcoming release")
-                return False
-            return clicked == proceedButton
-        # An announcement exists — remind only if its deadline has not yet passed.
-        deadline = announcement.get("deadline")
-        todayISO = qt.QDate.currentDate().toString(qt.Qt.ISODate)
-        if deadline and todayISO < deadline:
-            return slicer.util.confirmOkCancelDisplay(
-                f"You announced a release deadline of {deadline}, which has not passed yet.\n\n"
-                "Cutting the release now will close contributors' open work early. Continue?",
-                windowTitle="Announced deadline not reached")
-        return True
+        msgBox.exec_()
+        clicked = msgBox.clickedButton()
+        if clicked == announceButton:
+            self.releaseUI.announcementCollapsibleButton.collapsed = False
+            slicer.util.infoDisplay(
+                "Set a deadline and message above, then click 'Notify contributors'. "
+                "Re-run Make Release when you are ready.",
+                windowTitle="Announce upcoming release")
+            return False
+        if clicked == proceedButton:
+            return True
+        # Esc / closed with no explicit choice: proceed for the soft (nothing-open) nudge,
+        # treat as Cancel when real open items were at stake.
+        return openCount == 0
 
     def onAnnounceUpcomingRelease(self):
         if not self.logic.localRepo:
@@ -3644,7 +3975,7 @@ class MorphoDepotLogic(ScriptedLoadableModuleLogic):
         elif command.__class__() == []:
             commandList = command
         else:
-            logging.error("command must be string or list")
+            raise TypeError("gh command must be a string or list")
         self.progressMethod(" ".join(commandList))
         fullCommandList = [self.ghExecutablePath] + commandList
 
@@ -3698,7 +4029,10 @@ class MorphoDepotLogic(ScriptedLoadableModuleLogic):
         """Wrapper around gh that returns json loaded data or an empty list on error"""
         jsonString = self.gh(command)
         if jsonString:
-            return json.loads(jsonString)
+            try:
+                return json.loads(jsonString)
+            except (ValueError, json.JSONDecodeError):
+                logging.warning(f"ghJSON: could not parse gh output for {command!r}")
         return []
 
     def hasWorkflowScope(self):
@@ -3826,6 +4160,7 @@ class MorphoDepotLogic(ScriptedLoadableModuleLogic):
             ]
             result.append({
                 "nameWithOwner": j["nameWithOwner"],
+                "curator": j.get("curator"),
                 "pullRequests": {"nodes": prs_nodes},
                 "issues": {"nodes": issues_nodes},
             })
@@ -3858,8 +4193,13 @@ class MorphoDepotLogic(ScriptedLoadableModuleLogic):
         return []
 
     def whoami(self):
-        """ Get the active gh account """
-        return(self.gh("auth status --active").split()[7])
+        """ Get the active gh login.  Parse the '... account <login> ...' token by regex (robust to
+        gh's status-line wording) rather than a fixed word index; fall back to the stable API."""
+        status = self.gh("auth status --active") or ""
+        match = re.search(r"account\s+(\S+)", status)
+        if match:
+            return match.group(1)
+        return self.gh("api user --jq .login").strip()
 
     def ghUserProfile(self):
         """Return {login, name, email} for the active gh account.
@@ -3957,17 +4297,19 @@ class MorphoDepotLogic(ScriptedLoadableModuleLogic):
         return issueList
 
     def administratedRepoList(self):
+        # Releases are ARCHIVAL-ONLY (org-design Sec.9.6): only org repos the user curates can be
+        # released, so the Release tab lists only those.  Personal short-term repos are excluded —
+        # they cannot be released, and showing them is misleading.  A member's archival repo is owned
+        # by the MorphoDepot org (owner != me); the journaled CURATOR (RepoClerk schema v3) is the
+        # authoritative "this is mine to release" signal.  (curator is None on pre-v3 journals, so an
+        # org repo lights up once RepoClerk re-drains with the field.)
         me = self.whoami()
         returnRepos = []
         for repo in self.morphoRepos():
-            # A repo is "mine to administer" if I own it (personal tier) OR I'm its CURATOR.
-            # The org tier matters here: a member's repo is owned by the MorphoDepot org, not the
-            # member, so owner != me — the journaled CURATOR (RepoClerk schema v3) is the
-            # authoritative signal. viewerPermission can't be used: it's per-viewer and a shared
-            # cache cannot carry it. curator is None on pre-v3 journals, so org repos simply light
-            # up once RepoClerk re-drains with the field (personal repos work meanwhile).
-            if repo['owner']['login'] == me or repo.get('curator') == me:
-                repo['nameWithOwner'] = f"{repo['owner']['login']}/{repo['name']}"
+            ownerLogin = repo['owner']['login']
+            isArchival = ownerLogin != me           # archival repos live in the org, not on my account
+            if isArchival and repo.get('curator') == me:
+                repo['nameWithOwner'] = f"{ownerLogin}/{repo['name']}"
                 returnRepos.append(repo)
         return returnRepos
 
@@ -3981,10 +4323,16 @@ class MorphoDepotLogic(ScriptedLoadableModuleLogic):
         prList = []
         for repo in repoData:
             for pr in repo['pullRequests']['nodes']:
+                prAuthor = (pr.get('author') or {}).get('login')  # None for a deleted/ghost account
                 if role == "segmenter":
-                    parties = [pr['author']['login']]
+                    parties = [prAuthor] if prAuthor else []
                 elif role == "reviewer":
                     parties = [issue['repository']['owner']['login'] for issue in pr['closingIssuesReferences']['nodes']]
+                    # In-org (archival) repos are owned by the MorphoDepot org, not the curator's
+                    # login, so owner-keying alone hides every in-org PR from its curator.  Add the
+                    # journaled curator — the same owner-vs-curator fix administratedRepoList() applies.
+                    if repo.get('curator'):
+                        parties.append(repo['curator'])
                 else:
                     raise BaseException(f"Unknown role {role}")
                 issueTitles = [issue['title'] for issue in pr['closingIssuesReferences']['nodes']]
@@ -3994,13 +4342,15 @@ class MorphoDepotLogic(ScriptedLoadableModuleLogic):
                                       'title': pr['title'],
                                       'issueTitles': issueTitles,
                                       'isDraft': pr['isDraft'],
-                                      'author': {'login': pr['author']['login']},
+                                      'author': {'login': prAuthor},
                                       'repository': { 'name': repoName, 'nameWithOwner': repo['nameWithOwner']}})
         return prList
 
 
     def repositoryList(self):
-        repositories = json.loads(self.gh("repo list --json name"))
+        # --limit 1000: gh defaults to 30, which would make loadIssue's fork-exists check
+        # (forkExists = name in repositoryList) miss a real fork for users with many repos.
+        repositories = self.ghJSON("repo list --json name --limit 1000") or []
         repositoryList = [r['name'] for r in repositories]
         return repositoryList
 
@@ -4139,7 +4489,7 @@ class MorphoDepotLogic(ScriptedLoadableModuleLogic):
                 colorPath = glob.glob(f"{localDirectory}/*.ctbl")[0]
                 self.colorTableNode = slicer.util.loadColorTable(colorPath)
             except IndexError:
-                self.ghProgressMethod(f"No color table found")
+                self.progressMethod("No color table found")
 
         # TODO: move from single volume file to segmentation specification json
         volumePath = os.path.join(localDirectory, "source_volume")
@@ -4332,6 +4682,11 @@ class MorphoDepotLogic(ScriptedLoadableModuleLogic):
 
     def requestChanges(self, message=""):
         pr = self.issuePR(role="reviewer")
+        if not pr:
+            branch = self.localRepo.active_branch.name if self.localRepo else "this branch"
+            raise RuntimeError(
+                f"No open pull request found for '{branch}'. It may already be merged or closed "
+                f"(the Review list can lag a minute behind GitHub). Click 'Refresh Github' to update it.")
         upstreamNameWithOwner = self.nameWithOwner("upstream")
         commandList = f"""
             pr review {pr['number']}
@@ -4353,26 +4708,34 @@ class MorphoDepotLogic(ScriptedLoadableModuleLogic):
 
     def approvePR(self, message=""):
         pr = self.issuePR(role="reviewer")
+        if not pr:
+            branch = self.localRepo.active_branch.name if self.localRepo else "this branch"
+            raise RuntimeError(
+                f"No open pull request found for '{branch}'. It may already be merged or closed "
+                f"(the Review list can lag a minute behind GitHub). Click 'Refresh Github' to update it.")
         upstreamNameWithOwner = self.nameWithOwner("upstream")
-        # TODO: this if the reviewer is also the creator of the PR
-        # this generates an error from github that you aren't allowed
-        # to approve your own PRs, but it's just a warning in this case.
-        # Checking the name to avoid the approval or just skipping
-        # approval since we are closing the PR anyway would be fine.
-        commandList = f"""
-            pr review {pr['number']}
-                --approve
-                --repo {upstreamNameWithOwner}
-        """.replace("\n"," ").split()
-        if message != "":
-            commandList += ["--body", message]
-        self.gh(commandList)
+        # GitHub forbids approving your OWN pull request (addPullRequestReview fails with
+        # "Can not approve your own pull request"), regardless of repo role — an "approve" review
+        # is by definition independent sign-off.  When the curator/reviewer is also the PR author
+        # (their own baseline contribution, or testing), skip the approval review and just merge:
+        # merging your own PR IS allowed for write/admin, only the review verdict is restricted.
+        me = self.whoami()
+        selfAuthored = (pr.get("author") or {}).get("login") == me
+        if not selfAuthored:
+            commandList = f"""
+                pr review {pr['number']}
+                    --approve
+                    --repo {upstreamNameWithOwner}
+            """.replace("\n"," ").split()
+            if message != "":
+                commandList += ["--body", message]
+            self.gh(commandList)
         commandList = f"""
             pr merge {pr['number']}
                 --repo {upstreamNameWithOwner}
                 --squash
         """.replace("\n"," ").split()
-        commandList += ["--body", "Merging and closing"]
+        commandList += ["--body", message if (selfAuthored and message) else "Merging and closing"]
         self.gh(commandList)
         try:
             self.notifyRepoClerk(upstreamNameWithOwner)
@@ -4531,6 +4894,19 @@ class MorphoDepotLogic(ScriptedLoadableModuleLogic):
                 if caption:
                     lines.append(f"_{caption}_")
 
+        # Contributors section, generated from CONTRIBUTORS.json (written just before this during the
+        # release; org-design Sec.9.6). The DOI block is added separately by the App at mint time.
+        try:
+            import MorphoDepotContributors as MDC
+            contribPath = os.path.join(repoDir, "CONTRIBUTORS.json")
+            if os.path.exists(contribPath):
+                creditMarkdown = MDC.render_markdown(MDC.load(contribPath))
+                if creditMarkdown:
+                    lines.append("")
+                    lines.append(creditMarkdown.rstrip())
+        except Exception as e:
+            logging.warning(f"Could not render contributors section: {e}")
+
         return "\n".join(lines) + "\n"
 
     def prepareReleaseSnapshot(self, newTag, baselineNode, colorTableNode, screenshots):
@@ -4636,6 +5012,11 @@ class MorphoDepotLogic(ScriptedLoadableModuleLogic):
         backupName = f"pre-release-{tag}"
         # Create the archive branch locally and push it before any working-tree changes
         # so the pre-release state is preserved on the remote even if later steps fail.
+        # Idempotent: a retry after a partial failure may find this local branch already present
+        # (resetToReleaseBackup deliberately keeps it), so recreate it at the current commit rather
+        # than crashing with "a branch named 'pre-release-vN' already exists".
+        if backupName in [head.name for head in self.localRepo.heads]:
+            self.localRepo.git.branch("-D", backupName)
         self.localRepo.git.branch(backupName)
         self.releaseBackupBranch = backupName
         self.localRepo.remote(name="origin").push(backupName)

--- a/MorphoDepot/MorphoDepot.py
+++ b/MorphoDepot/MorphoDepot.py
@@ -1509,9 +1509,12 @@ class MorphoDepotWidget(ScriptedLoadableModuleWidget, VTKObservationMixin, Enabl
                 rec = json.loads(text)
             except Exception:
                 rec = {}
+            recName = rec.get("name", github)
             orcid = (rec.get("orcid") or "").strip()
-            given, family = MDC.orcid_name(orcid) if orcid else (None, None)
-            person["name"] = MDC.zenodo_name(rec.get("name", github), given, family)
+            # Skip the blocking ORCID lookup (10s timeout, called in a loop over all people before
+            # the dialog opens) when the onboarding name is already in "Family, Given" form.
+            given, family = MDC.orcid_name(orcid) if (orcid and "," not in recName) else (None, None)
+            person["name"] = MDC.zenodo_name(recName, given, family)
             if orcid and not person.get("orcid"):
                 person["orcid"] = orcid
             if rec.get("institution") and not person.get("affiliation"):
@@ -1553,7 +1556,11 @@ class MorphoDepotWidget(ScriptedLoadableModuleWidget, VTKObservationMixin, Enabl
         import base64
         import MorphoDepotContributors as MDC
         text, existingSha = self._readRepoFileViaApi(nameWithOwner, "CONTRIBUTORS.json")
-        data = json.loads(text) if text else MDC.new_record(nameWithOwner)
+        try:
+            data = json.loads(text) if text else MDC.new_record(nameWithOwner)
+        except (ValueError, json.JSONDecodeError):
+            logging.warning("CONTRIBUTORS.json is not valid JSON; starting from a fresh record")
+            data = MDC.new_record(nameWithOwner)
         curatorText, _ = self._readRepoFileViaApi(nameWithOwner, "CURATOR")
         curator = (curatorText or "").strip() or self.logic.whoami()
         MDC.ensure_person(data, github=curator, author=True, source="member")["curator"] = True
@@ -2704,7 +2711,11 @@ class MorphoDepotWidget(ScriptedLoadableModuleWidget, VTKObservationMixin, Enabl
         import MorphoDepotContributors as MDC
         repoDir = self.logic.localRepo.working_dir
         contribPath = os.path.join(repoDir, "CONTRIBUTORS.json")
-        data = MDC.load(contribPath) if os.path.exists(contribPath) else MDC.new_record(nameWithOwner)
+        try:
+            data = MDC.load(contribPath) if os.path.exists(contribPath) else MDC.new_record(nameWithOwner)
+        except (ValueError, json.JSONDecodeError):
+            logging.warning("CONTRIBUTORS.json is not valid JSON; starting from a fresh record")
+            data = MDC.new_record(nameWithOwner)
 
         # Ensure the curator (CURATOR file, else the signed-in user) is a cited author.
         curator = None
@@ -2755,14 +2766,20 @@ class MorphoDepotWidget(ScriptedLoadableModuleWidget, VTKObservationMixin, Enabl
     def _gatherMergedContributions(self, nameWithOwner, data, releaseTag):
         """Collect merged issue-N segmentation PRs into `data` (people + contributions), mirroring the
         release-time sync_contributors Action so the Release dialog shows live credit even when that
-        Action is not installed.  issue-N branch convention; MDC.add_contribution dedups, so gathering
-        the full cumulative set each release is idempotent and stamps the release on first sight."""
+        Action is not installed.  issue-N branch convention; MDC.add_contribution dedups.
+
+        Only PRs merged *since the last release* are stamped with `releaseTag` — they genuinely belong
+        to this release.  Older PRs (first seen now because the gather never ran before) are recorded
+        with `release=None` rather than being mis-attributed to the current tag."""
         import re
         import MorphoDepotContributors as MDC
         issueBranch = re.compile(r"^issue-(\d+)$")
+        releases = self.logic.ghJSON(
+            ["release", "list", "--repo", nameWithOwner, "--json", "publishedAt"]) or []
+        since = max((r.get("publishedAt") or "" for r in releases), default="")
         prs = self.logic.ghJSON([
             "pr", "list", "--repo", nameWithOwner, "--state", "merged", "--base", "main",
-            "--limit", "500", "--json", "number,headRefName,author"]) or []
+            "--limit", "500", "--json", "number,headRefName,author,mergedAt"]) or []
         for pr in prs:
             match = issueBranch.match(pr.get("headRefName", "") or "")
             if not match:
@@ -2771,8 +2788,10 @@ class MorphoDepotWidget(ScriptedLoadableModuleWidget, VTKObservationMixin, Enabl
             login = author.get("login")
             if not login:
                 continue
+            mergedAt = pr.get("mergedAt") or ""
+            stampRelease = releaseTag if (not since or mergedAt > since) else None
             MDC.ensure_person(data, github=login, github_id=author.get("id"), source="non-member")
-            MDC.add_contribution(data, issue=int(match.group(1)), by=login, release=releaseTag)
+            MDC.add_contribution(data, issue=int(match.group(1)), by=login, release=stampRelease)
 
     def buildReleaseConfirmation(self, plan, baselineNode, colorTableNode):
         """Compose the OK/Cancel summary describing every action that will run during release."""

--- a/MorphoDepot/MorphoDepot.py
+++ b/MorphoDepot/MorphoDepot.py
@@ -1511,10 +1511,14 @@ class MorphoDepotWidget(ScriptedLoadableModuleWidget, VTKObservationMixin, Enabl
                 rec = {}
             recName = rec.get("name", github)
             orcid = (rec.get("orcid") or "").strip()
-            # Skip the blocking ORCID lookup (10s timeout, called in a loop over all people before
-            # the dialog opens) when the onboarding name is already in "Family, Given" form.
-            given, family = MDC.orcid_name(orcid) if (orcid and "," not in recName) else (None, None)
-            person["name"] = MDC.zenodo_name(recName, given, family)
+            if "," in recName:
+                # Already "Family, Given": use verbatim — must NOT pass through zenodo_name (its
+                # whitespace-split fallback would reorder it), and skip the blocking ORCID lookup
+                # (10s timeout, called in a loop over all people before the dialog opens).
+                person["name"] = recName
+            else:
+                given, family = MDC.orcid_name(orcid) if orcid else (None, None)
+                person["name"] = MDC.zenodo_name(recName, given, family)
             if orcid and not person.get("orcid"):
                 person["orcid"] = orcid
             if rec.get("institution") and not person.get("affiliation"):

--- a/MorphoDepot/MorphoDepotContributors.py
+++ b/MorphoDepot/MorphoDepotContributors.py
@@ -1,0 +1,457 @@
+"""Contributor credit for MorphoDepot archival datasets.
+
+The committed source of truth is ``CONTRIBUTORS.json`` at the repo root (see ``docs/org-design.md``
+Sec.9.6). This module is the data + credit layer that the release flow, the README/DOI generator, and
+the Zenodo mint all build on.
+
+Design:
+  * The JSON / credit-resolution core is **Slicer-free** (only ``json``/``os``) so it can be unit-tested
+    in plain python3.
+  * The ``vtkMRMLTableNode`` glue (the curator's editing grid) is in the "Slicer glue" section and
+    imports ``slicer``/``vtk`` lazily, so importing this module never requires Slicer.
+
+The ``people`` list is the single record of *who* is credited (author flag per person); ``contributions``
+is the auto, issue-keyed provenance (one row per merged ``issue-N`` PR). A person with no ``name`` is
+credited by ``@handle``; only an ``author`` (cited) requires a real name.
+"""
+from __future__ import annotations
+
+import json
+import os
+import urllib.request
+
+SCHEMA = "morphodepot-contributors/1"
+ORCID_PUBLIC_API = "https://pub.orcid.org/v3.0"  # authoritative given/family split, by the iD
+DOC_URL = "https://morphodepot.org/docs/contributors"  # placeholder — credit/contributors documentation
+
+# People-grid columns (the editable curator surface). GitHub is the locked auto key.
+COL_GITHUB = "GitHub"
+COL_NAME = "Name (Family, Given)"
+COL_ORCID = "ORCID"
+COL_AFFIL = "Affiliation"
+COL_AUTHOR = "Author?"
+PEOPLE_COLUMNS = [COL_GITHUB, COL_NAME, COL_ORCID, COL_AFFIL, COL_AUTHOR]
+
+# Contributions-grid columns (auto, read-only).
+CONTRIB_COLUMNS = ["Issue", "Contributor", "Release"]
+
+
+# ======================================================================================
+# core: schema + IO (Slicer-free)
+# ======================================================================================
+
+def new_record(repo: str) -> dict:
+    """An empty contributor record for ``repo`` (e.g. ``MorphoDepot/Name``)."""
+    return {"schema": SCHEMA, "repo": repo, "people": [], "contributions": []}
+
+
+def load(path: str) -> dict:
+    with open(path, encoding="utf-8") as f:
+        data = json.load(f)
+    data.setdefault("people", [])
+    data.setdefault("contributions", [])
+    return data
+
+
+def dumps(data: dict) -> str:
+    """Canonical serialization: sorted keys + 2-space indent → stable per-release git diffs.
+
+    Sorting affects dict *keys* only; the order of the ``people`` list (which sets citation/author
+    order) is preserved as given.
+    """
+    return json.dumps(data, indent=2, sort_keys=True, ensure_ascii=False) + "\n"
+
+
+def save(path: str, data: dict) -> None:
+    with open(path, "w", encoding="utf-8") as f:
+        f.write(dumps(data))
+
+
+# ======================================================================================
+# identity helpers (Slicer-free): format a member's name as Zenodo's "Family, Given"
+# ======================================================================================
+
+def orcid_name(orcid: str):
+    """Authoritative ``(given, family)`` from the public ORCID record — best-effort (None, None)."""
+    try:
+        req = urllib.request.Request(f"{ORCID_PUBLIC_API}/{orcid}/person",
+                                     headers={"Accept": "application/json"})
+        with urllib.request.urlopen(req, timeout=10) as r:
+            nm = json.load(r).get("name") or {}
+        return ((nm.get("given-names") or {}).get("value"),
+                (nm.get("family-name") or {}).get("value"))
+    except Exception:
+        return None, None
+
+
+def zenodo_name(display_name: str, given: str | None, family: str | None) -> str:
+    """Format as ``Family, Given``: prefer the ORCID split, else split the display name."""
+    if family and given:
+        return f"{family}, {given}"
+    if family:
+        return family
+    parts = (display_name or "").split()
+    if len(parts) >= 2:
+        return f"{parts[-1]}, {' '.join(parts[:-1])}"
+    return display_name or "Unknown"
+
+
+# ======================================================================================
+# core: mutation
+# ======================================================================================
+
+def _person_key(person: dict):
+    """Stable identity for a people row: the GitHub login if present, else the name."""
+    gh = (person.get("github") or "").strip().lower()
+    if gh:
+        return ("github", gh)
+    return ("name", (person.get("name") or "").strip().lower())
+
+
+def find_person(data: dict, *, github: str | None = None, name: str | None = None) -> dict | None:
+    target = _person_key({"github": github, "name": name})
+    if target == ("name", ""):
+        return None
+    for person in data["people"]:
+        if _person_key(person) == target:
+            return person
+    return None
+
+
+def ensure_person(data: dict, *, github: str | None = None, github_id=None, name: str | None = None,
+                  orcid: str | None = None, affiliation: str | None = None,
+                  author: bool | None = None, source: str | None = None) -> dict:
+    """Get-or-create a people row, filling any newly-supplied fields without clobbering existing ones."""
+    person = find_person(data, github=github, name=name)
+    if person is None:
+        person = {"github": github, "github_id": github_id, "name": name, "orcid": orcid,
+                  "affiliation": affiliation, "author": bool(author), "source": source}
+        data["people"].append(person)
+        return person
+    if github_id is not None and not person.get("github_id"):
+        person["github_id"] = github_id
+    for field, value in (("name", name), ("orcid", orcid), ("affiliation", affiliation),
+                         ("source", source)):
+        if value and not person.get(field):
+            person[field] = value
+    if author is not None:
+        person["author"] = bool(author)
+    return person
+
+
+def add_contribution(data: dict, *, issue: int, by: str, url: str | None = None,
+                     release: str | None = None) -> bool:
+    """Append an ``(issue, contributor)`` provenance row (deduped) and ensure a people row exists.
+
+    Returns True if a new contribution row was added. ``by`` is the PR author's GitHub login.
+    """
+    issue = int(issue)
+    by_norm = (by or "").strip().lower()
+    for c in data["contributions"]:
+        if int(c.get("issue", -1)) == issue and (c.get("by") or "").strip().lower() == by_norm:
+            return False  # already recorded
+    if url is None and data.get("repo"):
+        url = f"https://github.com/{data['repo']}/issues/{issue}"
+    data["contributions"].append({"issue": issue, "by": by, "url": url, "release": release})
+    ensure_person(data, github=by, source="non-member")
+    return True
+
+
+def stamp_release(data: dict, release: str) -> int:
+    """Assign ``release`` to every contribution still pending (``release`` is None). Returns count."""
+    n = 0
+    for c in data["contributions"]:
+        if not c.get("release"):
+            c["release"] = release
+            n += 1
+    return n
+
+
+# ======================================================================================
+# core: credit resolution (what feeds the README + Zenodo)
+# ======================================================================================
+
+def _display(person: dict) -> str:
+    return person.get("name") or ("@" + person["github"] if person.get("github") else "(unknown)")
+
+
+def issues_for(data: dict, person: dict):
+    gh = (person.get("github") or "").strip().lower()
+    if not gh:
+        return []
+    return sorted({int(c["issue"]) for c in data["contributions"]
+                   if (c.get("by") or "").strip().lower() == gh})
+
+
+def resolve(data: dict) -> dict:
+    """Resolve the record into authors / contributors / unresolved, for display and validation.
+
+    - authors: people with ``author`` true (a missing name is flagged — it blocks citation).
+    - contributors: everyone else, each with the issue numbers they contributed.
+    - unresolved: people with no name (credited by handle until the curator fills it in).
+    """
+    authors, contributors, unresolved = [], [], []
+    for person in data["people"]:
+        entry = {"display": _display(person), "github": person.get("github"),
+                 "orcid": person.get("orcid"), "name": person.get("name"),
+                 "issues": issues_for(data, person)}
+        if person.get("author"):
+            entry["name_missing"] = not person.get("name")
+            authors.append(entry)
+        else:
+            contributors.append(entry)
+        if not person.get("name") and not person.get("curator"):
+            unresolved.append(person.get("github") or "(unnamed offline row)")
+    return {"authors": authors, "contributors": contributors, "unresolved": unresolved}
+
+
+def zenodo_metadata(data: dict) -> dict:
+    """Map the record to Zenodo ``creators`` / ``contributors`` (names already 'Family, Given')."""
+    def person_obj(person):
+        obj = {"name": person.get("name") or "@" + (person.get("github") or "unknown")}
+        if person.get("orcid"):
+            obj["orcid"] = person["orcid"]
+        if person.get("affiliation"):
+            obj["affiliation"] = person["affiliation"]
+        return obj
+
+    creators = [person_obj(p) for p in data["people"] if p.get("author")]
+    contributors = []
+    for p in data["people"]:
+        if not p.get("author"):
+            obj = person_obj(p)
+            obj["type"] = "DataCollector"
+            contributors.append(obj)
+    return {"creators": creators, "contributors": contributors}
+
+
+def validation_issues(data: dict) -> list:
+    """Hard problems that should block a release. Empty list == the gate auto-satisfies.
+
+    The curator (``curator: true``) is exempt: their name is filled authoritatively by the App from the
+    onboarding record, so a blank name there is expected and must not block. Only a *promoted* co-author
+    the curator named by hand must have a real name."""
+    problems = []
+    for p in data["people"]:
+        if p.get("author") and not p.get("name") and not p.get("curator"):
+            problems.append(f"author '{p.get('github') or '?'}' has no real name (required to cite)")
+    return problems
+
+
+def render_markdown(data: dict) -> str:
+    """Render the credit section (Authors + Contributors tables) as Markdown, from the record.
+
+    Slicer-free; used by the release README generator (and shareable elsewhere). Returns "" if there
+    is nobody to credit. Each contributor is credited by the issue number(s) they segmented, linked.
+    """
+    res = resolve(data)
+    if not res["authors"] and not res["contributors"]:
+        return ""
+    url_for = {}
+    for c in data.get("contributions", []):
+        url_for[((c.get("by") or "").strip().lower(), int(c["issue"]))] = c.get("url")
+
+    lines = ["## Contributors", ""]
+    if res["authors"]:
+        lines += ["**Authors**", "", "| Name | ORCID |", "|---|---|"]
+        for a in res["authors"]:
+            lines.append(f"| {a['display']} | {a.get('orcid') or '-'} |")
+        lines.append("")
+    if res["contributors"]:
+        lines += ["**Contributors** — credited by the issue(s) they segmented", "",
+                  "| Name | Issues |", "|---|---|"]
+        for c in res["contributors"]:
+            gh = (c.get("github") or "").strip().lower()
+            links = []
+            for n in c["issues"]:
+                u = url_for.get((gh, n))
+                links.append(f"[#{n}]({u})" if u else f"#{n}")
+            lines.append(f"| {c['display']} | {', '.join(links) or '-'} |")
+        lines.append("")
+    return "\n".join(lines).rstrip() + "\n"
+
+
+# ======================================================================================
+# Slicer glue: the editable people grid (vtkMRMLTableNode) — imports slicer/vtk lazily
+# ======================================================================================
+
+def _str_col(name, values):
+    import vtk
+    col = vtk.vtkStringArray()
+    col.SetName(name)
+    for v in values:
+        col.InsertNextValue("" if v is None else str(v))
+    return col
+
+
+def _bit_col(name, values):
+    import vtk
+    col = vtk.vtkBitArray()
+    col.SetName(name)
+    for v in values:
+        col.InsertNextValue(1 if v else 0)
+    return col
+
+
+def to_people_table(data: dict, nodeName: str = "MorphoDepot Contributors", people=None):
+    """Build a vtkMRMLTableNode holding the editable People grid. Returns the node.
+
+    ``people`` defaults to ``data['people']``; pass a subset to exclude rows from the grid (e.g. the
+    curator, whose authoritative info is filled by the App and must not be hand-typed)."""
+    import slicer
+    people = data["people"] if people is None else people
+    node = slicer.mrmlScene.AddNewNodeByClass("vtkMRMLTableNode", nodeName)
+    node.AddColumn(_str_col(COL_GITHUB, [p.get("github") for p in people]))
+    node.AddColumn(_str_col(COL_NAME, [p.get("name") for p in people]))
+    node.AddColumn(_str_col(COL_ORCID, [p.get("orcid") for p in people]))
+    node.AddColumn(_str_col(COL_AFFIL, [p.get("affiliation") for p in people]))
+    node.AddColumn(_bit_col(COL_AUTHOR, [p.get("author") for p in people]))
+    return node
+
+
+def from_people_table(node, existing=None) -> list:
+    """Read the edited People grid into a LIST of people dicts (matching rows by GitHub, else name).
+
+    Auto fields not shown in the grid (github_id, source) are preserved by matching to ``existing``;
+    rows the curator added by hand become new offline entries. Returns the list (caller assembles
+    ``data['people']``, e.g. re-prepending the curator)."""
+    existingByKey = {_person_key(p): p for p in (existing or [])}
+    table = node.GetTable()
+    rebuilt = []
+    for r in range(table.GetNumberOfRows()):
+        def cell(col):
+            return table.GetValueByName(r, col).ToString().strip()
+
+        github = cell(COL_GITHUB) or None
+        name = cell(COL_NAME) or None
+        person = dict(existingByKey.get(_person_key({"github": github, "name": name}), {}))
+        person["github"] = github
+        person["name"] = name
+        person["orcid"] = cell(COL_ORCID) or None
+        person["affiliation"] = cell(COL_AFFIL) or None
+        person["author"] = bool(table.GetValueByName(r, COL_AUTHOR).ToInt())
+        person.setdefault("source", "offline" if not github else "non-member")
+        rebuilt.append(person)
+    return rebuilt
+
+
+def to_contributions_table(data: dict, nodeName: str = "MorphoDepot Contributions"):
+    """Build a read-only vtkMRMLTableNode of the auto issue→contributor provenance."""
+    import slicer
+    node = slicer.mrmlScene.AddNewNodeByClass("vtkMRMLTableNode", nodeName)
+    contribs = sorted(data["contributions"], key=lambda c: (str(c.get("release") or "~"), int(c["issue"])))
+    node.AddColumn(_str_col("Issue", ["#%s" % c["issue"] for c in contribs]))
+    node.AddColumn(_str_col("Contributor", ["@%s" % c["by"] for c in contribs]))
+    node.AddColumn(_str_col("Release", [c.get("release") or "(pending)" for c in contribs]))
+    return node
+
+
+def make_contributor_panel(data: dict, title: str = "Contributors & credit",
+                           show_header: bool = True, show_contributions: bool = True):
+    """Build a self-contained Qt widget for curating credit — the reusable surface for both the
+    Create-tab baseline-credit panel and the Release-tab gate (org-design Sec.9.7).
+
+    Returns a lightweight controller (``types.SimpleNamespace``) — PythonQt forbids attaching
+    attributes to a raw QWidget, so the controller holds them instead:
+      - ``widget`` — the ``qt.QWidget`` to embed in a tab/dialog
+      - ``data`` / ``peopleNode`` / ``contribNode`` — the backing record + table nodes
+      - ``syncFromTable()`` — read the grid edits back into ``data`` and refresh the status line
+      - ``saveTo(path)`` — sync, then write canonical ``CONTRIBUTORS.json``
+      - ``isReady()`` — True when the release gate may proceed (no author missing a name)
+      - ``statusLabel`` — the live status QLabel
+
+    This is a factory (not a QWidget subclass) so importing this module never requires Qt/Slicer.
+    """
+    import types
+
+    import qt
+    import slicer
+
+    widget = qt.QWidget()
+    layout = qt.QVBoxLayout(widget)
+    if show_header:
+        header = qt.QLabel(
+            "<b>%s</b><br>Fill Name/ORCID for non-members; tick <i>Author?</i> for any individual you "
+            "want to acknowledge as a co-author. The GitHub column is read-only (filled automatically). "
+            "&nbsp;<a href=\"%s\">Documentation</a>" % (title, DOC_URL))
+        header.setWordWrap(True)
+        header.setOpenExternalLinks(True)
+        layout.addWidget(header)
+
+    # The curator (always a member; info filled authoritatively by the App from the onboarding record)
+    # is shown READ-ONLY and kept OUT of the editable grid — so it can't be hand-typed, which would slip
+    # a wrong-order name past the App's blank-only enrichment.  The grid is for OTHER contributors.
+    curatorPerson = next((p for p in data["people"] if p.get("curator")), None)
+    editablePeople = [p for p in data["people"] if not p.get("curator")]
+    if curatorPerson is not None:
+        who = curatorPerson.get("name") or "@" + (curatorPerson.get("github") or "you")
+        curatorLabel = qt.QLabel("<b>Lead author (you):</b> %s &nbsp;&mdash; filled in automatically." % who)
+        curatorLabel.setWordWrap(True)
+        layout.addWidget(curatorLabel)
+
+    peopleNode = to_people_table(data, people=editablePeople)
+    peopleView = slicer.qMRMLTableView()
+    peopleView.setMRMLScene(slicer.mrmlScene)
+    peopleView.setMRMLTableNode(peopleNode)
+    peopleView.setFirstColumnLocked(True)  # GitHub is the auto key
+    layout.addWidget(peopleView)
+
+    buttonRow = qt.QHBoxLayout()
+    addButton = qt.QPushButton("Add offline contributor")
+    removeButton = qt.QPushButton("Remove selected row")
+    addButton.connect("clicked()", peopleView.insertRow)
+    removeButton.connect("clicked()", peopleView.deleteRow)
+    buttonRow.addWidget(addButton)
+    buttonRow.addWidget(removeButton)
+    buttonRow.addStretch()
+    layout.addLayout(buttonRow)
+
+    contribNode = None
+    if show_contributions:
+        contribNode = to_contributions_table(data)
+        contribView = slicer.qMRMLTableView()
+        contribView.setMRMLScene(slicer.mrmlScene)
+        contribView.setMRMLTableNode(contribNode)
+        contribView.setEnabled(False)  # auto provenance, read-only
+        layout.addWidget(qt.QLabel("Contributions (issue -> contributor, recorded automatically):"))
+        layout.addWidget(contribView)
+
+    statusLabel = qt.QLabel()
+    layout.addWidget(statusLabel)
+
+    def syncFromTable():
+        edited = from_people_table(peopleNode, existing=editablePeople)
+        data["people"] = ([curatorPerson] if curatorPerson is not None else []) + edited
+        problems = validation_issues(data)
+        unresolved = resolve(data)["unresolved"]
+        # Only ever surface real PROBLEMS or factual notes — never claim completeness ("ready"),
+        # because only the curator knows whether everyone has been added.
+        if problems:
+            statusLabel.setText("<b style='color:#b00000'>A cited author needs a real name: %s</b>"
+                                % "; ".join(problems))
+        elif unresolved:
+            statusLabel.setText("<span style='color:#a06000'>No name yet for %s &mdash; they will be "
+                                "credited by GitHub handle.</span>"
+                                % ", ".join("@" + u for u in unresolved))
+        else:
+            statusLabel.setText("")
+
+    def saveTo(path):
+        syncFromTable()
+        save(path, data)
+
+    def isReady():
+        syncFromTable()
+        return not validation_issues(data)
+
+    # Live status: refresh as the curator edits cells (the grid writes edits back to the table node,
+    # which fires ModifiedEvent) so the "ready / credited by handle" line is never stale.
+    import vtk
+    peopleNode.AddObserver(vtk.vtkCommand.ModifiedEvent, lambda caller, event: syncFromTable())
+
+    controller = types.SimpleNamespace(
+        widget=widget, data=data, peopleNode=peopleNode, contribNode=contribNode,
+        peopleView=peopleView, statusLabel=statusLabel,
+        syncFromTable=syncFromTable, saveTo=saveTo, isReady=isReady)
+    syncFromTable()
+    return controller

--- a/docs/MorphoDepot-org-review-findings.md
+++ b/docs/MorphoDepot-org-review-findings.md
@@ -1,0 +1,110 @@
+# MorphoDepot — Code Review & Test Findings
+
+Overnight review of `MorphoDepot.py` (~6.2k lines), `MorphoDepotContributors.py`, and the intake
+App (`control_plane.py`, `mint_doi.py`). Five focused review passes + a dry run of the test plan.
+
+- **FIXED** = corrected and committed in the accompanying PR (compiled + reloaded; verified where notable).
+- **REPORTED** = left for your decision (design choice) or too risky to auto-fix without broader testing.
+
+Severity is impact-if-triggered. Line numbers are approximate (the file shifted during fixes).
+
+---
+
+## FIXED in this PR
+
+### HIGH
+| ID | Where | Bug | Fix |
+|----|-------|-----|-----|
+| F-1 | `prList` (~4307/4324/4410) | `pr['author']['login']` is dereferenced unguarded, but `_journalsToTopicData` emits `author=None` for a deleted/ghost GitHub account → one such PR makes the **entire** Annotate/Review list raise `TypeError`. | Compute `prAuthor = (pr.get('author') or {}).get('login')`; build parties/author dict from it. |
+| F-2 | `loadFromLocalRepository` (~4469) | `self.ghProgressMethod(...)` — **no such method** (typo for `progressMethod`); a release-load on a repo with no color table raises `AttributeError` and aborts the whole release. | `self.progressMethod("No color table found")`. |
+| F-3 | `createRelease` (~5000) | `git.branch(backupName)` is not idempotent; a **retry** after a partial release failure crashes on "branch pre-release-vN already exists" (reset deliberately keeps the branch). | Delete the local backup branch if present, then recreate. |
+| F-4 | `mint_doi.py` (~639) | `build_citation(creator, …)` references `creator`, which is **unbound** on the normal CONTRIBUTORS.json path and the `--creator` override — `NameError` *after* the DOI is already minted/published. | Use `creators[0]` (always defined). |
+
+### MEDIUM
+| ID | Where | Bug | Fix |
+|----|-------|-----|-----|
+| F-5 | `onPRSelectionChanged`/`onPRDoubleClicked` (~2003/2180) | Annotate & Review tabs share one `prsByItem` dict; selecting an Annotate PR after a Review refresh reads a stale item → `KeyError`. | `.get(item)` with a None guard in both reads. |
+| F-6 | `onPublish` baseline-credit (~1665) | `_curateBaselineCreditViaApi` runs the `PUT CONTRIBUTORS.json`; a gh failure (sha conflict/5xx) escapes `onPublish` uncaught after the confirm. | Wrap in try/except → clean `errorDisplay`, abort publish. |
+| F-7 | `mint_doi.py` (~582) | A blank-named author (curator exemption leaking past the in-repo gate) is minted as a Zenodo creator literally named `@handle` — a permanent citation. | Refuse to mint if any author has only a handle/no name. |
+
+### LOW / robustness
+| ID | Where | Bug | Fix |
+|----|-------|-----|-----|
+| F-8 | `whoami` (~4180) | `gh auth status --active`.split()`[7]` — fixed-index parse breaks if gh's wording changes; underpins every role match. | Regex `account\s+(\S+)`, fall back to `gh api user --jq .login`. |
+| F-9 | `ghJSON` (~4018) | Docstring promises empty-list-on-error but `json.loads` was unguarded. | try/except → `[]` + warning. |
+| F-10 | `gh()` else branch (~3958) | Non-str/list arg falls through to `UnboundLocalError`, masking the real error. | `raise TypeError`. |
+| F-11 | `repositoryList` (~4302) | No `--limit` → gh caps at 30; loadIssue's fork-exists check misses real forks for users with >30 repos. | `--limit 1000` + use `ghJSON`. |
+| F-12 | `mint_doi.py` (~224/291) | Unguarded `json.loads(rec_txt)` of an onboarding record aborts the mint mid-flight (after a draft deposition may exist). | try/except → MintError (curator) / return person (contributor). |
+
+### Feature work (todo items)
+- **Redistribution-rights gate** — was only enforced at *stage*; now a hard gate at **Update** and **Publish** too (`_redistributionAcknowledged()` + disabled Update button when invalid). Verified.
+- **App/mint enrichment hardening** — mint now enriches members robustly (F-7/F-12); `enrich_contributors` is reusable. **NOT done:** committing enriched member names into `CONTRIBUTORS.json` at **v2+ release** still needs the App to expose a release/mint enrich endpoint and **be redeployed** (see Deployment below).
+
+---
+
+## REPORTED (your call / needs broader testing)
+
+### HIGH
+- **R-1 — `loadIssue` decides "fork exists" by repo NAME only** (~4323). If you already own an unrelated repo with the same name, it clones *that* instead of forking the canonical repo — silent wrong-repo. (`--limit` from F-11 helps the >30 case but not the name collision.) **Fix needs:** match full `{me}/{name}` and verify it's a fork, or always `gh repo fork` (idempotent). Left unfixed because changing the clone path risks the working fork flow — wants a dedicated test pass.
+
+### MEDIUM
+- **R-2 — in-org PR load is fork-assuming** (`loadPR` ~4410, `ensureUpstreamExists` ~4307). `loadPR` builds the head repo as `{author}/{name}` and `ensureUpstreamExists` points `upstream` at `origin` when the clone isn't a real fork. For an **in-org / self-authored-baseline** PR (author branched in the org repo, not a personal fork) this clones the wrong repo / sets `upstream==origin`, so reviewer actions can 404 or "find no PR". This is the deeper cause of the review-flow friction the curator-visibility fix only partly addressed. **Fix needs:** resolve the real head repo via `gh pr view --json headRepository,headRefName` and set `upstream` to the canonical PR repo explicitly.
+- **R-3 — "Request PR review" can no-op on a just-created PR** (`onRequestReview`). It re-finds the PR via the lagging RepoClerk journal; if the journal hasn't re-drained, `issuePR` returns None and `gh pr ready` never runs (PR stays draft, no error). Same lag can let `commitAndPush` create a duplicate PR. **Fix needs:** resolve the PR number from live GitHub right after creating it, not from the journal.
+- **R-4 — `_isArchivalRepo` transient gh error skips contributor curation** (~2649). It swallows all exceptions → False → `onMakeRelease` skips `_curateContributorsForRelease`, so a transient network error yields a release with no contributor record. **Fix:** trust `administratedRepoList` (already archival-only) or distinguish "unknown" from "personal".
+- **R-5 — Release-tab open issue/PR counts are always zero** (~2201). `morphoRepos()` dicts carry no `issues`/`pullRequests`, so the repo-list label, announcement counts, and tooltip read 0 even with open work (actual announce/close re-query live, so behavior is fine — only the display misleads). **Fix:** populate counts from the journal's `openIssues`/`openPRs`.
+- **R-6 — Auto-assign workflow-scope check is one-shot** (`_refreshAutoAssignAvailability`). Probes once per module load; if you grant the scope (or a transient probe fails) the checkbox stays disabled until reload. **Fix:** re-probe on each Create-tab entry / don't cache a negative.
+- **R-7 — Search list-criterion exclusion is order-dependent** (`search` ~5920). For multi-value answers (e.g. `anatomicalAreas`) the exclude check runs inside the value loop, so a repo whose first value is unchecked but a later one is checked is wrongly dropped; empty-list answers bypass the filter. **Fix:** decide after scanning all values (`any(...)`).
+- **R-8 — Search tooltip assumes dict captions** (~2456). `screenshotCaptions.items()` raises if captions is a **list** (37/70 live journals store a list); only safe today because those repos have `screenshotCount==0`. **Fix:** normalize to dict / branch on type.
+- **R-9 — App enrich freezes a heuristic member name on ORCID failure** (`control_plane.enrich_contributors` ~188). If ORCID is unreachable, `_zenodo_name` heuristically reorders the onboarding name (`"Maria de la Cruz"` → `"Cruz, Maria de la"`) and commits it permanently (later runs skip named rows). **Fix:** only write the reordered form when ORCID resolved; otherwise write the name verbatim or leave blank for retry.
+- **R-10 — Three-way schema/enrichment divergence** across `MorphoDepotContributors.py`, `control_plane.py`, `mint_doi.py` (duplicated JSON core; `source` field set inconsistently; App *commits* names while mint only enriches Zenodo metadata). Pick one writer. **Fix:** factor the JSON core into a shared module.
+
+### LOW
+- **R-11** — `testingMode` self-test never drives the archival/org/App/credit path (forces personal/testing-org), so regressions there pass green. (Test-infra gap.)
+- **R-12** — Q0 → hidden-form sync (`_onRepoTypeChanged`) does `except Exception: pass`; if the option strings ever drift, repoType stays empty and Create is silently dead. Log instead of swallow.
+- **R-13** — Dead `selectedDestination*` code + `populateOwnerSelector` gh round-trips on every Create visit, now that destination is fixed by the Q0 fork. Cleanup.
+- **R-14** — Baseline-credit dialog attributes lead author to the **CURATOR-file handle**, not the operator, despite "Your information…" wording. Decide curator-vs-operator.
+- **R-15** — `from_people_table` reads the Author bit cell via `.ToInt()` without the None guard used for string cells (ragged/just-inserted row risk). `to_contributions_table`/`issues_for`/`render_markdown` bracket-index `c['issue']`/`c['by']` (KeyError on a hand-edited row). ModifiedEvent→syncFromTable could duplicate the curator key if an inserted row gets the curator's handle. Add `.get`/guards.
+- **R-16** — `enrich_contributors` failures are swallowed by `publish_repo`'s `try/except: pass` with no logging → a persistently-failing enrichment is invisible (repo goes public with handle-only rows). Add telemetry.
+
+---
+
+## Deployment / wiring still required (cannot be done from here)
+1. **Deploy** the intake App (`control_plane.py`) to `join.morphodepot.org` so the publish-time `enrich_contributors` actually runs.
+2. **Wire** an App release/mint endpoint that calls `enrich_contributors` (and the mint) so v2+ releases backfill member names into the committed `CONTRIBUTORS.json`. The mint prototype enriches the **DOI metadata** today, but does not commit names back.
+3. The DOI mint is still a **prototype** (`experiments/doi/mint_doi.py`), run manually against the Zenodo **sandbox**. Production minting + a `morphodepot.org` Zenodo account are outstanding.
+
+---
+
+## Dry-run results (exercised against the `mdtest-*` repos)
+
+| Check | Result |
+|-------|--------|
+| **Curator PR visibility** (the owner-vs-curator fix) | **PASS** — `prList(role="reviewer")` for `muratmaga` returns `mdtest-review` PR #4 (amm554's in-org PR for issue-3). Before the fix the curator saw nothing for org-owned repos. |
+| **Release-contributions gather** | **PASS** — `_gatherMergedContributions` on `mdtest-release` returns `[(issue 1, amm554), (issue 2, muratmaga)]`, curator separated from the editable grid. |
+| **`whoami` robustness** | **PASS** — regex parse returns `muratmaga` (was `split()[7]`). |
+| **`prList` null-author guard** | **PASS** — no crash; lists build cleanly (both PRs merged → empty, correct). |
+| **Redistribution acknowledgement helper** | **PASS** — `False` when unticked, `True` when ticked; Update/Publish hard-gated. |
+| **Release announcement nudge** | **PASS** — soft non-blocking dialog shown when nothing is open (solo dataset), `Proceed anyway` default. |
+| **Self-approve skip / already-merged guard** | **PASS** (verified earlier on test-bat-repo): self-authored PR skips the GitHub approve and merges; re-approving a merged PR gives a clean message, not a `TypeError`. |
+| **Auto-assign workflow present** | **PASS** — `.github/workflows/auto-assign.yml` is on both `mdtest-*` repos; (live issue-assignment was confirmed earlier on test-bat-repo). |
+
+### What the dry run could NOT cover (manual, in-extension)
+- **Create → stage → Make-Public** flow (Sections 1–5 of the test plan): the staging context lives in
+  Slicer's memory, so a gh-created repo cannot be "published" through the extension. Create a **fresh**
+  repo via the extension to test these (the redistribution gate, baseline-credit dialog, Q0 fork,
+  member-only gating, auto-assign default).
+- **App member enrichment** at the publish flip / at release: needs the App deployed (see Deployment).
+- **Live DOI mint**: sandbox-only and manual; the prototype fixes (F-4/F-7/F-12) make it correct but
+  it was not run as part of this dry run.
+
+## Repo state handed back (ready for you to walk the test plan)
+- **`MorphoDepot/mdtest-release`** — archival, public, baseline present, **2 merged `issue-N` PRs**
+  (issue-1 by amm554, issue-2 by muratmaga), `CONTRIBUTORS.json` with empty `contributions` (the
+  release gather fills it). No release yet → load it in the **Release tab** to exercise the announcement
+  nudge, the (now populated) contributions table, the baseline content-signature, and a v1 release/DOI.
+- **`MorphoDepot/mdtest-review`** — archival, public, baseline present, **3 open issues**: #1 (amm554),
+  #2 (SlicerMorph, outsider), #3 (amm554) which already has a **ready open PR #4** for you to review and
+  **Approve** (tests curator visibility + approve-and-merge). Use #1/#2 to drive the segmenter flow
+  yourself (load issue → segment → Commit and Push → Request PR review).
+- Both repos are `mdtest-*` prefixed and **safe to delete**. `test-bat-repo` was left as-is (it carries
+  your earlier interactive testing).

--- a/docs/MorphoDepot-org-test-plan.md
+++ b/docs/MorphoDepot-org-test-plan.md
@@ -1,0 +1,120 @@
+# MorphoDepot — Org Features Test Plan
+
+Exercises every org-related feature added in the last development cycle (repo-type fork,
+auto-assign, redistribution gate, baseline credit, reviewer flow, release flow, DOI). Walk it
+top-to-bottom; each test says which **account** and **repo** to use and what **should** happen.
+
+> Generated for hands-on verification. Companion: `MorphoDepot-org-review-findings.md` (static
+> code-review findings + issues found while dry-running this plan).
+
+## Accounts (gh, already signed in — `gh auth switch` to change active)
+
+| Role | Login | In MorphoDepot org? |
+|------|-------|---------------------|
+| Owner / curator | `muratmaga` | Owner |
+| Member (no privileges) | `amm554` | Member |
+| Outsider | `SlicerMorph` | **Not** a member |
+
+## Test repositories (created by the overnight run, `mdtest-*` prefix under MorphoDepot)
+
+| Repo | Type | Baseline? | Purpose |
+|------|------|-----------|---------|
+| `MorphoDepot/mdtest-archival-baseline` | Archival | Yes | Publish baseline-credit gate, release, DOI |
+| `MorphoDepot/mdtest-archival-nobaseline` | Archival | No | Archival without a baseline segmentation |
+| `MorphoDepot/mdtest-review` | Archival | Yes | Reviewer flow (curator sees contributor PRs) |
+| `mdtest-shortterm` (personal) | Short-term | n/a | Personal short-term path |
+
+> If a repo was consumed/closed during the dry run it is **recreated clean** before you start —
+> see the findings report's "Repo state handed back" section.
+
+---
+
+## 1. Repository-type fork (Q0) — the first, irreversible choice
+
+| # | Account | Steps | Expected |
+|---|---------|-------|----------|
+|1.1| muratmaga | Open Create tab | **Archival / Short-term** selector is the *first* control, above the form |
+|1.2| muratmaga | Pick **Archival** | Form's hidden repoType set to Archival; destination becomes the org (no "where should this live?" dialog) |
+|1.3| muratmaga | Pick **Short-term** | Destination becomes the personal account |
+|1.4| muratmaga | Stage a repo, then reopen it for editing | The type selector is **hidden** in edit mode (type cannot change after staging) |
+|1.5| SlicerMorph (outsider) | Switch active account, pick **Archival**, try to stage | Blocked with a clear "must be an org member" message (archival is org-only) |
+|1.6| amm554 (member) | Pick **Archival**, stage | Allowed (members can create archival) |
+
+## 2. Auto-assign workflow — default-ON, opt-out, ALL types
+
+| # | Account | Steps | Expected |
+|---|---------|-------|----------|
+|2.1| muratmaga | Open Create tab | "Set the GitHub workflow to auto-assign…" checkbox is **checked by default** and **enabled** |
+|2.2| muratmaga | Toggle Archival ↔ Short-term | Checkbox stays checked + enabled (independent of type — you can opt out either way) |
+|2.3| muratmaga | Create an archival repo with it left on | The published repo has `.github/workflows/auto-assign.yml` |
+|2.4| any | Open a new issue on that repo | The issue is auto-assigned to its creator (check Actions tab ran green) |
+|2.5| — | (If a gh login lacks the `workflow` scope) | Checkbox is unchecked + disabled with the "run `gh auth refresh -s workflow`" hint |
+
+## 3. Redistribution-rights acknowledgement — hard gate
+
+| # | Account | Steps | Expected |
+|---|---------|-------|----------|
+|3.1| muratmaga | On Create, leave Section-6 "I have the right to allow redistribution" **unchecked** | "Create (stage privately)" stays **disabled** |
+|3.2| muratmaga | Check it | Create enables |
+|3.3| muratmaga | Stage, reopen for edit, **uncheck** it | **Update Repository** becomes disabled; clicking it (if reachable) shows "Redistribution acknowledgement required" |
+|3.4| muratmaga | With it unchecked, try **Make Public** | Blocked: "…before publishing." |
+
+## 4. Baseline-credit gate at publish (Make Public)
+
+| # | Account | Repo | Steps | Expected |
+|---|---------|------|-------|----------|
+|4.1| muratmaga | mdtest-archival-baseline | Click **Make Public** | "Baseline contributors" dialog appears (repo ships a baseline) |
+|4.2| muratmaga | " | Inspect the dialog | Narrow window, working **Done / Cancel** buttons, read-only "Lead author (you): …" line, Documentation link, no "ready to release" claim |
+|4.3| muratmaga | " | Add an offline contributor with a name, tick Author? | They become a co-author |
+|4.4| muratmaga | " | Click **Done** | `CONTRIBUTORS.json` is written to the repo via the API; repo goes public |
+|4.5| muratmaga | mdtest-archival-nobaseline | Make Public | No baseline dialog (nothing ships); publishes directly |
+|4.6| muratmaga | " | Click **Cancel** in 4.1 | Publish is aborted; repo stays private |
+
+## 5. Member enrichment (App-side — requires deployed App)
+
+| # | Notes |
+|---|-------|
+|5.1| After an org publish, the App's `enrich_contributors` fills blank member names from the owners-only onboarding records + ORCID (`Family, Given`). **Requires the App change to be deployed** — see findings report (NOT deployed by the overnight run). |
+|5.2| The extension's `_enrichMemberPerson` is best-effort dialog pre-fill only (owners get full info, members get GitHub profile name). |
+
+## 6. Reviewer flow (curator reviewing contributor PRs)
+
+| # | Account | Steps | Expected |
+|---|---------|-------|----------|
+|6.1| amm554 or SlicerMorph | Load assigned issue on mdtest-review, segment, **Commit and Push** | A **draft** PR is created (checkpoint) |
+|6.2| same | Click **Request PR review** | PR flips to ready (`gh pr ready`); after RepoClerk catches up it shows "ready for review" |
+|6.3| muratmaga | Review tab → **Refresh Github** | The contributor's in-org PR **appears** (curator-visibility fix; org-owned repos used to hide it) |
+|6.4| muratmaga | Double-click the PR | Loads/clones it |
+|6.5| muratmaga | **Approve** | Approves **and** squash-merges in one click |
+|6.6| muratmaga | Click **Approve** again on the now-merged PR (stale panel) | Clean message "No open pull request found… already merged or closed… Refresh", **not** a `TypeError` |
+|6.7| muratmaga | Approve a PR **you authored** yourself | Skips the GitHub approve (can't approve your own PR) and merges anyway — no "Can not approve your own pull request" error |
+
+## 7. Release flow (archival-only)
+
+| # | Account | Repo | Steps | Expected |
+|---|---------|------|-------|----------|
+|7.1| muratmaga | mdtest-archival-baseline | Open Release tab | Only **org/archival** repos you curate are listed (short-term personal repos excluded) |
+|7.2| muratmaga | " | Make Release with **no announcement** and nothing open | **Soft non-blocking nudge** ("good practice to announce… solo dataset can simply proceed"), Proceed anyway / Announce first |
+|7.3| muratmaga | " | Make Release with **open** issues/PRs and no announcement | Firmer warning (Announce / Proceed / Cancel) |
+|7.4| muratmaga | " | At the contributor-confirm dialog | **Contributions table is populated** from merged `issue-N` PRs; contributors appear in the grid (this was empty before the gather fix) |
+|7.5| muratmaga | " | Try to release with **no baseline change** since last release | Blocked: "no baseline change → no release" (content-signature check) |
+|7.6| muratmaga | " | Complete a release | `CONTRIBUTORS.json` committed in the release snapshot; `pre-release-vN` branch pushed; vN tag created |
+|7.7| muratmaga | " | Trigger a failed release, then **retry** | The retry does **not** crash on "branch pre-release-vN already exists" (idempotent backup branch) |
+
+## 8. DOI minting (Zenodo **sandbox** only)
+
+| # | Notes |
+|---|-------|
+|8.1| Mint runs against `CONTRIBUTORS.json`: curator = creator, others = contributors; species/modality/anatomy → Zenodo keywords (not the citation). |
+|8.2| First release = concept DOI + version DOI; later releases = new version under the concept DOI. |
+|8.3| DOI badge + citation written into README in a delimited block, regenerated per release. |
+|8.4| **Refuses to mint** if any author has only a GitHub handle (no real name) — fill the name first. |
+|8.5| Org/archival + private = no DOI (must be public). Personal/short-term = never minted. |
+
+## 9. Contributor-credit dialog details (cross-cutting)
+
+| # | Expected |
+|---|----------|
+|9.1| Curator/lead-author row is **read-only** (a line, not an editable grid row) and is exempt from the name-required gate. |
+|9.2| Status never claims "all contributors named / ready" — only flags real problems (a cited author with no name) or facts (who will be credited by handle). |
+|9.3| "Add offline contributor" / "Remove selected row" work; the GitHub column is read-only (filled automatically). |


### PR DESCRIPTION
Overnight work on the MorphoDepot org features.

## What's here
1. **Finished the two pending items**
   - Redistribution-rights acknowledgement is now a **hard gate at stage, Update, and Publish** (was stage-only — it could be unticked and the staged repo still Updated/published).
   - App/mint enrichment hardened (see below); v2+ committed-file backfill still needs the App deployed + a release/mint endpoint (documented).
2. **Thorough code review** (`MorphoDepot.py` ~6.2k lines + contributors module + intake App) via 5 focused passes → **16 fixed, 16 reported**. Full list in `docs/MorphoDepot-org-review-findings.md`.
3. **Test plan** for all org features across the three accounts (owner/member/outsider): `docs/MorphoDepot-org-test-plan.md`.
4. **Test repos** created in the org and dry-run'd (see below).

## HIGH/crash fixes
- `prList` null PR author guard (ghost account would crash the whole PR list)
- `ghProgressMethod` typo → `progressMethod` (release-load AttributeError)
- idempotent `pre-release-vN` backup branch (release retry no longer crashes)
- `mint_doi.py` `creator` NameError on the main path (crashed *after* minting); refuse to mint `@handle`-only authors; guarded `json.loads` of onboarding records
- `whoami` robust parse, `ghJSON`/`gh()` guards, `prsByItem` guards, baseline-credit PUT wrapped

## Dry-run (PASS)
- Curator now sees in-org PRs: `prList(reviewer)` for muratmaga returns `mdtest-review#4` (amm554's PR)
- Release contributions gather: `mdtest-release` → `[(issue 1, amm554), (issue 2, muratmaga)]`
- whoami/regex, redistribution gate, announcement nudge, self-approve skip — all pass

## Test repos handed back (safe to delete, `mdtest-*`)
- `MorphoDepot/mdtest-release` — release/DOI scenarios (baseline + 2 merged issue PRs, no release yet)
- `MorphoDepot/mdtest-review` — reviewer scenarios (3 open issues + a ready PR #4 to approve)

## Still needs you / deployment
- Deploy the intake App (`control_plane.py`) to join.morphodepot.org so publish-time enrichment runs
- Wire an App release/mint enrich endpoint for v2+ committed-file backfill
- DOI mint remains a sandbox prototype

🤖 Generated with [Claude Code](https://claude.com/claude-code)