### PR TITLE
Publish/release review gate, Option C release, create-tab name suggestion, credit fixes

### DIFF
--- a/MorphoDepot/MorphoDepot.py
+++ b/MorphoDepot/MorphoDepot.py
@@ -883,30 +883,88 @@ class MorphoDepotWidget(ScriptedLoadableModuleWidget, VTKObservationMixin, Enabl
                 logging.warning(f"Could not load staged screenshots: {e}")
         self.updateScreenshotCount()
 
-    def _committedBaselineSignature(self, path, referenceVolume):
-        """Content signature of the baseline currently committed on disk (baseline.seg.nrrd),
-        loaded into a temporary node so it can be compared by CONTENT against the
-        about-to-be-released segmentation.  Returns None if there is no committed baseline."""
-        if not path or not os.path.exists(path):
-            return None
-        tmpNode = None
+    def _baselineMatchesCommittedFile(self, node, committedPath):
+        """M6 no-change check (org-design M6), done CHEAPLY: save the candidate baseline to a temp
+        COMPRESSED .seg.nrrd and compare its SIZE to the committed baseline.seg.nrrd.  A compressed
+        segmentation is small (KB-MB), so this is file I/O on a small file -- the previous approach
+        resampled every segment onto the full source-volume voxel grid and SHA-256'd it, which pegged
+        every core for minutes and froze the UI.  A single changed voxel changes the compressed size,
+        and size is immune to gzip-header timestamp non-determinism.  Returns True only when the sizes
+        match exactly (no new work -> not a release); ANY save/read failure returns False so a tooling
+        hiccup never blocks a real release.  (A different-content / same-compressed-size collision is
+        astronomically unlikely; add a decompressed-voxel tiebreak on a size match if ever needed.)"""
+        import tempfile
+        if not committedPath or not os.path.exists(committedPath):
+            return False
+        # Segment count: a reliable signal that adding/removing segments ALWAYS changes -- the
+        # compressed size alone can miss it, and Slicer's modified flag can miss copy/merge edits.
         try:
-            tmpNode = slicer.util.loadSegmentation(path)
-            return self._segmentationContentSignature(tmpNode, referenceVolume)
+            committedCount = self._committedSegmentCount(committedPath)
+            if committedCount is not None and node is not None \
+                    and node.GetSegmentation().GetNumberOfSegments() != committedCount:
+                return False  # different number of segments -> definitely changed
         except Exception as e:
-            logging.warning(f"Could not compute committed-baseline signature: {e}")
-            return None
+            logging.warning(f"Baseline segment-count check failed: {e}")
+        tmpDir = tempfile.mkdtemp()
+        try:
+            tmpPath = os.path.join(tmpDir, "candidate.seg.nrrd")
+            if not slicer.util.saveNode(node, tmpPath, {'useCompression': True}):
+                return False
+            return os.path.getsize(tmpPath) == os.path.getsize(committedPath)
+        except Exception as e:
+            logging.warning(f"Baseline file comparison failed; treating as changed: {e}")
+            return False
         finally:
-            if tmpNode is not None:
-                slicer.mrmlScene.RemoveNode(tmpNode)
+            shutil.rmtree(tmpDir, ignore_errors=True)
+
+    def _committedSegmentCount(self, path):
+        """Number of segments in a committed .seg.nrrd, parsed from its (uncompressed) NRRD text
+        header (Segment{N}_* custom fields).  Returns None if it cannot be determined."""
+        try:
+            import re
+            with open(path, "rb") as f:
+                head = f.read(524288)
+            header = head.split(b"\n\n", 1)[0]
+            indices = set(re.findall(rb"Segment(\d+)_", header))
+            return len(indices) if indices else None
+        except Exception as e:
+            logging.warning(f"Could not read committed segment count from {path}: {e}")
+            return None
+
+    def _colorTableMatchesCommitted(self, colorNode):
+        """True if the picked color table is byte-identical to the repository's committed color file
+        (so a release would not actually change it -- only the node name differs).  Saves the picked
+        node to a temp file of the same extension and compares bytes.  Returns False when there is no
+        committed color file or on any error, so it never falsely blocks a real color change."""
+        import tempfile
+        if colorNode is None or not (self.logic and self.logic.localRepo):
+            return False
+        repoDir = self.logic.localRepo.working_dir
+        committed = glob.glob(f"{repoDir}/*.csv") or glob.glob(f"{repoDir}/*.ctbl")
+        if not committed:
+            return False
+        committedPath = committed[0]
+        tmpDir = tempfile.mkdtemp()
+        try:
+            tmpPath = os.path.join(tmpDir, "candidate" + os.path.splitext(committedPath)[1])
+            if not slicer.util.saveNode(colorNode, tmpPath):
+                return False
+            with open(tmpPath, "rb") as a, open(committedPath, "rb") as b:
+                return a.read() == b.read()
+        except Exception as e:
+            logging.warning(f"Color-table comparison failed; assuming changed: {e}")
+            return False
+        finally:
+            shutil.rmtree(tmpDir, ignore_errors=True)
 
     def _segmentationContentSignature(self, segNode, referenceVolume=None):
-        """A content signature of a segmentation (segment ids + binary-labelmap voxels), used
-        to detect whether the loaded baseline was edited in the scene.  Hashes content, not
-        file bytes, so it is robust to save non-determinism.  A referenceVolume is required to
-        sample each segment's labelmap (the segmentation carries no reference geometry of its
-        own) — the source volume serves that role.  Falls back to the source volume if not
-        given, then to a modified-time string only as a last resort."""
+        """A content signature of a segmentation (segment ids + binary-labelmap voxels), used to
+        detect whether the loaded baseline was edited in the scene (publish-edit path only; the
+        release no-change check now compares compressed file sizes instead).  Falls back to a
+        modified-time string if no reference geometry is available.  NOTE: when a referenceVolume is
+        present this resamples each segment onto it (can be slow for a large volume) -- the same
+        pre-existing cost the release path moved away from; left as-is here since this path is not
+        currently exercised, and a file-size approach should be applied here too if it ever is."""
         if segNode is None:
             return ""
         if referenceVolume is None:
@@ -1143,6 +1201,56 @@ class MorphoDepotWidget(ScriptedLoadableModuleWidget, VTKObservationMixin, Enabl
         saveEdits = getattr(self.createUI, "saveEditsButton", None)
         if saveEdits is not None and getattr(self, "_resumedForEdit", False):
             saveEdits.enabled = valid
+        self._scheduleRepoNameAvailabilityCheck()   # F4: advisory availability of the suggested name
+
+    def _scheduleRepoNameAvailabilityCheck(self):
+        """Debounce an advisory GitHub availability check for the (possibly auto-suggested) repo
+        name -- fired ~0.7s after the user stops changing the form, so it never blocks typing."""
+        form = getattr(self.createUI, "accessionForm", None)
+        if form is None or not hasattr(form, "repoNameStatus"):
+            return
+        timer = getattr(self, "_repoNameCheckTimer", None)
+        if timer is None:
+            timer = qt.QTimer()
+            timer.setSingleShot(True)
+            timer.setInterval(700)
+            timer.connect("timeout()", self._checkSuggestedRepoNameAvailability)
+            self._repoNameCheckTimer = timer
+        timer.start()
+
+    def _checkSuggestedRepoNameAvailability(self):
+        """Tell the user whether the current repo name is free on their account (advisory only --
+        the authoritative check happens at create time).  Best-effort: stays silent on any error."""
+        form = getattr(self.createUI, "accessionForm", None)
+        if form is None or not hasattr(form, "repoNameStatus"):
+            return
+        name = (form.questions["githubRepoName"].answer() or "").strip()
+        if not name:
+            form.repoNameStatus.text = ""
+            return
+        if name == getattr(self, "_lastCheckedRepoName", None):
+            return
+        self._lastCheckedRepoName = name
+        try:
+            owner = self.logic.whoami()
+        except Exception:
+            owner = None
+        if not owner:
+            return
+        try:
+            taken = self.logic.repoExists(f"{owner}/{name}")
+        except Exception as e:
+            logging.warning(f"Repo-name availability check failed: {e}")
+            form.repoNameStatus.text = ""
+            return
+        if taken:
+            form.repoNameStatus.text = (
+                f"<span style='color:#a4671a;'>‘{name}’ already exists in your account "
+                "— edit the name below.</span>")
+        else:
+            form.repoNameStatus.text = (
+                f"<span style='color:#2a7a2a;'>‘{name}’ is available — you can edit "
+                "it if you like.</span>")
 
     def _redistributionAcknowledged(self):
         """True if the Section-6 'I have the right to allow redistribution of this data' box is
@@ -1589,6 +1697,47 @@ class MorphoDepotWidget(ScriptedLoadableModuleWidget, VTKObservationMixin, Enabl
         except Exception:
             pass
 
+    def _enrichMembersViaApi(self, data):
+        """Resolve every contributor handle to a member identity in ONE App call (the App checks org
+        membership and reads the owners-only onboarding records, which a non-owner curator cannot).
+        Members get name/ORCID/affiliation and source='member'; true outsiders stay handle-only.
+        Falls back to the per-person _enrichMemberPerson (owner-readable records + GitHub profile) if
+        the App is unreachable, so the dialog still degrades gracefully offline.  (org-design 9.5/9.6)
+        """
+        people = data.get("people", [])
+        # Resolve EVERY GitHub handle (even already-named rows) so the stable numeric github_id gets
+        # filled for all of them (Sec.9.5 C5); names/ORCID are still only filled for blank rows.
+        handles = [p["github"] for p in people if p.get("github")]
+        resolved = None
+        if handles:
+            try:
+                resolved = self.logic.controlPlaneRequest("contributors/resolve", {"handles": handles})
+            except Exception as e:
+                logging.warning(f"Could not resolve member identities via the App: {e}")
+        for person in people:
+            github = person.get("github")
+            if not github:
+                continue
+            info = (resolved or {}).get(github)
+            if info is None:
+                if not person.get("name"):
+                    self._enrichMemberPerson(person)  # App unreachable -> best-effort local
+                continue
+            if info.get("github_id") and not person.get("github_id"):
+                person["github_id"] = info["github_id"]   # stable id, even for already-named rows
+            if info.get("is_member"):
+                person["source"] = "member"
+            if person.get("name"):
+                continue  # already named -> keep it (id filled above)
+            if info.get("name"):
+                person["name"] = info["name"]
+                if info.get("orcid") and not person.get("orcid"):
+                    person["orcid"] = info["orcid"]
+                if info.get("affiliation") and not person.get("affiliation"):
+                    person["affiliation"] = info["affiliation"]
+            elif not info.get("is_member"):
+                self._enrichMemberPerson(person)  # confirmed outsider -> try a profile display name
+
     def _repoHasBaseline(self, nameWithOwner):
         """True if the staged repo carries a baseline.seg.nrrd (it shipped a baseline -> atlas case).
         A from-scratch archival repo has no baseline file and skips the credit gate at go-live."""
@@ -1751,6 +1900,30 @@ class MorphoDepotWidget(ScriptedLoadableModuleWidget, VTKObservationMixin, Enabl
             return
         slicer.util.showStatusMessage("")
         if not final:
+            return
+        # Org publish is routed through the MD-reviewers review gate (org-design 11.3): the App
+        # emailed an Approve link and did NOT make the repo public yet.  Report that review was
+        # requested and leave the repo staged; do NOT add a contact (the repo isn't public).
+        if isinstance(final, dict) and final.get("pending"):
+            where = final.get("nameWithOwner")
+            to = final.get("reviewSentTo") or "the MorphoDepot reviewers"
+            self._exitResumeMode()
+            self._stagedNameWithOwner = where
+            self.createUI.publishButton.enabled = False
+            self.createUI.discardButton.enabled = False
+            self.createUI.openRepository.enabled = False
+            self.createUI.stagingStatusLabel.text = (
+                f"Submitted for review: {where} becomes public once approved.")
+            self.refreshStagedReposList(force=True)
+            if not self.testingMode:
+                slicer.util.infoDisplay(
+                    f"'{where}' has been submitted for review.\n\n"
+                    f"A request was emailed to {to}. Once a reviewer approves, the repository is "
+                    "made public automatically and you'll get an email. Until then it stays "
+                    "private and remains in your unpublished list (reopen it there to make "
+                    "changes, which will require requesting review again).",
+                    windowTitle="Submitted for review")
+            slicer.mrmlScene.Clear()
             return
         # Now that the repo is actually public, add the creator to the contact list (best-effort,
         # background).  Done here — never at stage — so discarded/abandoned repos never leak a
@@ -2351,6 +2524,17 @@ class MorphoDepotWidget(ScriptedLoadableModuleWidget, VTKObservationMixin, Enabl
         hasColorTable = self.releaseUI.newColorSelector.currentNode() is not None
         self.releaseUI.makeReleaseButton.enabled = bool(hasRepo and hasSegmentation and hasColorTable)
 
+    def _resetReleaseInputs(self):
+        """After a release is submitted/created, clear the New-release inputs and (via the selector
+        change) disable Make Release, so the finished action can't be fired again by mistake.  The
+        loaded-repository context (Current release line) is left as-is."""
+        self.releaseUI.newBaselineSelector.setCurrentNode(None)
+        self.releaseUI.newColorSelector.setCurrentNode(None)
+        self.releaseUI.releaseCommentsEdit.plainText = ""
+        self.screenshots = []
+        self.updateScreenshotCount()
+        self.updateMakeReleaseEnabled()  # no segmentation/color selected now -> button disabled
+
     def updateAnnouncementCounts(self, repoData):
         issues = repoData.get('issues', {}).get('totalCount', 0)
         prs = repoData.get('pullRequests', {}).get('totalCount', 0)
@@ -2683,33 +2867,13 @@ class MorphoDepotWidget(ScriptedLoadableModuleWidget, VTKObservationMixin, Enabl
         if plan is None:
             return
 
-        # #123: guard against a release that carries no new segmentation work — decided by
-        # CONTENT, not node identity, so editing the loaded baseline in place is recognized.
-        #   Stage 1 (cheap): the picked node is the loaded baseline AND untouched since read →
-        #     certainly identical to the committed file; no hashing needed.
-        #   Stage 2 (precise, only otherwise): hash the picked segmentation's voxels and compare
-        #     to the committed baseline.seg.nrrd on disk.
-        loadedBaseline = getattr(self.logic, 'baselineSegmentationNode', None)
-        isLoadedNode = (loadedBaseline is not None and baselineNode.GetID() == loadedBaseline.GetID())
-        try:
-            untouched = isLoadedNode and not baselineNode.GetModifiedSinceRead()
-        except Exception as e:
-            logging.warning(f"GetModifiedSinceRead unavailable on baseline node; using content hash: {e}")
-            untouched = False
-        baselineUnchanged = untouched
-        if not untouched:
-            refVolume = getattr(self.logic, 'sourceVolumeNode', None)
-            if refVolume is None:
-                logging.warning("sourceVolumeNode not set on logic; baseline content check may be unreliable")
-            committedPath = os.path.join(self.logic.localRepo.working_dir, "baseline.seg.nrrd")
-            committedSig = self._committedBaselineSignature(committedPath, refVolume)
-            if committedSig is None:
-                # Committed baseline could not be read/hashed (missing file or load error);
-                # _committedBaselineSignature already logged why.  Default to "changed" so a
-                # tooling failure never silently blocks a legitimate release.
-                baselineUnchanged = False
-            else:
-                baselineUnchanged = (committedSig == self._segmentationContentSignature(baselineNode, refVolume))
+        # #123: guard against a release that carries no new segmentation work.  Compare CONTENT
+        # directly via _baselineMatchesCommittedFile (segment count + compressed file size).  Do NOT
+        # trust Slicer's GetModifiedSinceRead() as an "unchanged" shortcut: it does not reliably
+        # register copy/merge-segment edits, so it would short-circuit to "unchanged" and skip the
+        # comparison -- which wrongly reported a baseline with many added segments as no new work.
+        committedPath = os.path.join(self.logic.localRepo.working_dir, "baseline.seg.nrrd")
+        baselineUnchanged = self._baselineMatchesCommittedFile(baselineNode, committedPath)
         if baselineUnchanged:
             if not (self.testingMode or slicer.util.confirmOkCancelDisplay(
                     "The selected baseline is identical to the repository's current baseline, so "
@@ -2718,6 +2882,22 @@ class MorphoDepotWidget(ScriptedLoadableModuleWidget, VTKObservationMixin, Enabl
                     "build) the updated segmentation as the new baseline first.\n\n"
                     "Release with the unchanged baseline anyway?",
                     windowTitle="Baseline unchanged")):
+                return
+
+        # Color-table no-change feedback -- ONLY when the curator picked a DIFFERENT color node than
+        # the one loaded from the repo (so a change was intended) that turns out byte-identical: the
+        # case where a "fix" silently didn't take.  Releasing with the existing (loaded) color table
+        # unchanged is normal and must NOT warn -- unlike the baseline, the color table need not change.
+        loadedColor = getattr(self.logic, 'colorTableNode', None)
+        colorIsLoadedNode = (loadedColor is not None and colorTableNode.GetID() == loadedColor.GetID())
+        if not colorIsLoadedNode and self._colorTableMatchesCommitted(colorTableNode):
+            if not (self.testingMode or slicer.util.confirmOkCancelDisplay(
+                    f"The selected color table '{colorTableNode.GetName()}' is byte-identical to the "
+                    "repository's committed color table, so the release will NOT change it.\n\n"
+                    "If you meant to apply a color or terminology fix, click Cancel, correct the "
+                    "color table, and re-select it.\n\n"
+                    "Release with the unchanged color table anyway?",
+                    windowTitle="Color table unchanged")):
                 return
 
         # #124: non-blocking reminder if no pre-release announcement was made (or its deadline
@@ -2748,6 +2928,38 @@ class MorphoDepotWidget(ScriptedLoadableModuleWidget, VTKObservationMixin, Enabl
             )
         except Exception as e:
             self.handleReleaseFailure(e)
+            return
+
+        # Archival/org release is routed through the App's review gate (org-design Sec.11.3): the App
+        # emailed an Approve link and has NOT cut the tag or minted the DOI yet, so the release is not
+        # live.  Report that review was requested and skip the post-release cleanup (announcement
+        # retire, item close) — those belong to an actually-created release.
+        if isinstance(createdTag, dict) and createdTag.get("pending"):
+            to = createdTag.get("reviewSentTo") or "the MorphoDepot reviewers"
+            tag = createdTag.get("tag")
+            self.logic.discardReleaseBackup()
+            self.updateCurrentVersionLabel()
+            # Retire the pre-release announcement now (its contributions are gathered and the release
+            # is submitted) -- best-effort/idempotent.
+            try:
+                self.logic.clearReleaseAnnouncement(nameWithOwner)
+                self.updateAnnouncementState(nameWithOwner)
+            except Exception as e:
+                logging.warning(f"Could not retire the pre-release announcement: {e}")
+            slicer.util.showStatusMessage("Release submitted for review.")
+            if not self.testingMode:
+                slicer.util.infoDisplay(
+                    f"Release {tag} has been submitted for review.\n\n"
+                    f"A request was emailed to {to}. Once a reviewer approves, the release is cut and "
+                    "its DOI is minted automatically; if changes are requested you'll get an email "
+                    "with the details. The release commit is already pushed to the repository.",
+                    windowTitle="Release submitted for review")
+            # The contributions are merged into the release commit, so offer to close their open
+            # issues/PRs now -- the curator's token can close both (the App's token can't close PRs),
+            # and they should not linger waiting on approval.
+            self.maybeCloseOpenItemsForRelease(nameWithOwner, tag, created=False)
+            # Finished: clear the New-release inputs and disable Make Release so it can't re-fire.
+            self._resetReleaseInputs()
             return
 
         self.logic.discardReleaseBackup()
@@ -2805,17 +3017,20 @@ class MorphoDepotWidget(ScriptedLoadableModuleWidget, VTKObservationMixin, Enabl
                 curator = f.read().strip() or None
         curator = curator or self.logic.whoami()
         MDC.ensure_person(data, github=curator, author=True, source="member")["curator"] = True
-        for member in data["people"]:   # pre-fill rows we already have info for (curator + members)
-            self._enrichMemberPerson(member)
 
         tag = self.logic.nextReleaseTag() or ""
-        # Gather segmentation contributions (merged issue-N PRs) so the dialog shows live credit even
-        # when the release-time sync_contributors Action is not installed on the repo.  Best-effort —
+        # Gather segmentation contributions (merged issue-N PRs) FIRST so the member-resolution pass
+        # below sees every contributor (not just those already in CONTRIBUTORS.json).  Best-effort —
         # a gh failure here must never block the release.
         try:
             self._gatherMergedContributions(nameWithOwner, data, tag)
         except Exception as e:
             logging.warning(f"Could not gather merged-PR contributions: {e}")
+        # Pre-fill every contributor's identity AFTER gathering: members (the curator AND merged-PR
+        # authors like @muratmaga) are resolved to name/ORCID/affiliation; true outsiders stay
+        # handle-only.  Resolved via the App so it works even when the curator can't read the
+        # owners-only onboarding records.
+        self._enrichMembersViaApi(data)
         panel = MDC.make_contributor_panel(data, title=f"Release {tag} - confirm contributors")
         dialog = qt.QDialog(slicer.util.mainWindow())
         dialog.setWindowTitle("Contributors & credit")
@@ -2938,14 +3153,16 @@ class MorphoDepotWidget(ScriptedLoadableModuleWidget, VTKObservationMixin, Enabl
                 f"Release left mid-flight. Backup branch: {getattr(self.logic, 'releaseBackupBranch', None)}"
             )
 
-    def maybeCloseOpenItemsForRelease(self, nameWithOwner, version):
-        """After a release, offer to close all remaining open issues and PRs."""
+    def maybeCloseOpenItemsForRelease(self, nameWithOwner, version, created=True):
+        """After a release (or its submission for review), offer to close all remaining open issues
+        and PRs.  `created=False` for a gated release that has been *submitted* but not yet cut."""
         with slicer.util.tryWithErrorDisplay("Failed to query open items", waitCursor=True):
             issues, prs = self.logic.openIssuesAndPRs(nameWithOwner)
         if not issues and not prs:
             return
+        state = "created" if created else "submitted for review"
         prompt = (
-            f"Release {version} created.\n\n"
+            f"Release {version} {state}.\n\n"
             f"Close {len(issues)} open issues and {len(prs)} open PRs as part of the release?\n"
             f"(Open PRs will be closed without merging — contributors must rebase onto the new baseline.)"
         )
@@ -3321,6 +3538,18 @@ class MorphoDepotAccessionForm():
         self.questions["githubRepoName"] = FormTextQuestion(q, self.validateForm)
         self.questions["githubRepoName"].questionBox.toolTip = t
         layout.addWidget(self.questions["githubRepoName"].questionBox)
+        # F4: auto-suggest a descriptive, metadata-derived repo name (editable). The status line is
+        # filled by the widget's availability check; the link points at the naming guidelines.
+        self.userEditedRepoName = False
+        self._lastSuggestedName = ""
+        self.repoNameStatus = qt.QLabel("")
+        self.repoNameStatus.setWordWrap(True)
+        self.questions["githubRepoName"].questionLayout.addWidget(self.repoNameStatus)
+        namingGuidelines = qt.QLabel(
+            '<a href="https://github.com/MorphoDepot/MorphoDepot/wiki/Repository-naming">'
+            'MorphoDepot repository-naming guidelines</a>')
+        namingGuidelines.setOpenExternalLinks(True)
+        self.questions["githubRepoName"].questionLayout.addWidget(namingGuidelines)
         q,a,t = form["repoType"]
         self.questions["repoType"] = FormRadioQuestion(q, a, self.validateForm)
         layout.addWidget(self.questions["repoType"].questionBox)
@@ -3339,6 +3568,62 @@ class MorphoDepotAccessionForm():
             for sectionWidget in self.sectionWidgets.values():
                 sectionWidget.hide()
             self.sectionWidgets[section].show()
+
+    @staticmethod
+    def _slug(text):
+        """A GitHub-safe slug: lowercase, runs of non-alphanumerics collapsed to single dashes."""
+        import re
+        return re.sub(r"-+", "-", re.sub(r"[^a-z0-9]+", "-", (text or "").lower())).strip("-")
+
+    def suggestedRepoName(self):
+        """A descriptive default repo name from the accession metadata: ``genus-species[-modality]
+        [-contents]`` (e.g. ``mus-musculus-microct-whole``).  Deliberately longer than bare
+        genus-species so two scans of the same species are less likely to collide and the name is
+        self-describing.  Falls back to the free-text subject description for non-biological subjects.
+        Returns "" when there is nothing to base a name on yet."""
+        modalitySlug = {
+            "Micro CT (or synchrotron)": "microct",
+            "Medical CT": "medicalct",
+            "MRI": "mri",
+            "Lightsheet microscopy": "lightsheet",
+            "3D confocal microscopy": "confocal",
+            "Surface model (photogrammetry, structured light, or laser scanning)": "surface",
+        }
+        contentsSlug = {"Whole specimen": "whole", "Partial specimen": "partial"}
+        base = self._slug(self.questions["species"].answer())
+        if not base:
+            base = self._slug(self.questions["otherSubjectDescription"].answer())
+        if not base:
+            return ""
+        parts = [base]
+        modality = modalitySlug.get(self.questions["modality"].answer())
+        if modality:
+            parts.append(modality)
+        contents = contentsSlug.get(self.questions["imageContents"].answer())
+        if contents:
+            parts.append(contents)
+        return "-".join(parts)
+
+    def _applySuggestedRepoName(self):
+        """Prefill the GitHub repo-name field with suggestedRepoName(), refreshing it as more
+        metadata is entered -- but only until the user types their own value, after which their
+        entry is never overwritten.  Robust to Qt signal ordering: any field text we did not place
+        there ourselves is treated as the user's and locks the field."""
+        question = self.questions.get("githubRepoName")
+        if question is None:
+            return
+        field = question.answerText
+        current = field.text
+        if current and current != getattr(self, "_lastSuggestedName", ""):
+            self.userEditedRepoName = True
+        if getattr(self, "userEditedRepoName", False):
+            return
+        name = self.suggestedRepoName()
+        if name and current != name:
+            field.blockSignals(True)   # programmatic fill: no validateForm re-entry, not "user-edited"
+            field.text = name
+            field.blockSignals(False)
+            self._lastSuggestedName = name
 
     def validateForm(self, arguments=None):
 
@@ -3405,6 +3690,7 @@ class MorphoDepotAccessionForm():
             valid = valid and self.questions["imageContents"].answer() != ""
         valid = valid and self.questions["redistributionAcknowledgement"].answer() != []
         valid = valid and self.questions["license"].answer() != ""
+        self._applySuggestedRepoName()   # F4: prefill a metadata-derived name (until the user edits it)
         valid = valid and self.questions["githubRepoName"].answer() != ""
         valid = valid and self.questions["repoType"].answer() != ""
         repoNameRegex = r"^(?:([a-zA-Z\d]+(?:-[a-zA-Z\d]+)*)/)?([\w.-]+)$"
@@ -4784,6 +5070,21 @@ class MorphoDepotLogic(ScriptedLoadableModuleLogic):
                 issuePR = pr
         return issuePR
 
+    def _openPRForBranch(self, upstreamNameWithOwner, headOwner, branchName):
+        """Authoritative check for an already-open PR whose head is headOwner:branchName into the
+        upstream repo, queried DIRECTLY from GitHub (gh api) rather than the lagging RepoClerk
+        journal that prList()/issuePR() read.  Returns the PR dict or None (None also on any query
+        error, so the caller falls through to PR creation, which is itself guarded against
+        duplicates).  The journal lags minutes behind GitHub, so it cannot answer "does a PR exist
+        for this branch right now" — the moment that matters when deciding whether to open one."""
+        try:
+            prs = self.ghJSON(["api",
+                               f"repos/{upstreamNameWithOwner}/pulls?head={headOwner}:{branchName}&state=open"])
+        except Exception as e:
+            logging.warning(f"Could not check for an existing PR on {branchName}: {e}")
+            return None
+        return prs[0] if prs else None
+
     def cacheOldVersion(self, directoryPath):
         """If directoryPath exists, move it to an archive in the cache."""
         if os.path.exists(directoryPath):
@@ -4826,12 +5127,17 @@ class MorphoDepotLogic(ScriptedLoadableModuleLogic):
                     self.progressMethod(f"Push failed with {flag}")
                     return False
 
-        # create a PR if needed
-        if not self.issuePR():
+        # Create a PR if one does not already exist.  Check AUTHORITATIVELY (direct gh), NOT via the
+        # RepoClerk journal that issuePR()/prList() read: the journal lags minutes behind GitHub, so
+        # right after the first push it still reports "no PR" and the old `if not self.issuePR()`
+        # guard would try to open a SECOND PR for the same head->base.  gh rejects that ("a pull
+        # request ... already exists"), which surfaced as a spurious "Failed to commit and push"
+        # even though the push succeeded -- for repo owners and outside segmenters alike.
+        upstreamNameWithOwner = self.nameWithOwner("upstream")
+        originNameWithOwner = self.nameWithOwner("origin")
+        originOwner = originNameWithOwner.split("/")[0]
+        if not self._openPRForBranch(upstreamNameWithOwner, originOwner, branchName):
             issueNumber = branchName.split("-")[1]
-            upstreamNameWithOwner = self.nameWithOwner("upstream")
-            originNameWithOwner = self.nameWithOwner("origin")
-            originOwner = originNameWithOwner.split("/")[0]
             prBody = f"Fixes #{issueNumber}"
             if self.currentIssue and 'author' in self.currentIssue and 'login' in self.currentIssue['author']:
                 authorLogin = self.currentIssue['author']['login']
@@ -4845,7 +5151,15 @@ class MorphoDepotLogic(ScriptedLoadableModuleLogic):
                 --head {originOwner}:{branchName}
             """.replace("\n"," ").split()
             commandList += ["--body", prBody]
-            self.gh(commandList)
+            try:
+                self.gh(commandList)
+            except RuntimeError as e:
+                # Backstop for the race between the check above and now: gh refuses a duplicate
+                # head->base PR.  The push already updated that PR, so "already exists" is success;
+                # re-raise anything else.
+                if "already exists" not in str(e):
+                    raise
+                self.progressMethod("A pull request for this issue already exists; your push updated it.")
             try:
                 self.notifyRepoClerk(upstreamNameWithOwner)
             except Exception as e:
@@ -4853,12 +5167,19 @@ class MorphoDepotLogic(ScriptedLoadableModuleLogic):
         return True
 
     def requestReview(self):
+        upstreamNameWithOwner = self.nameWithOwner("upstream")
         pr = self.issuePR(role="segmenter")
+        if not pr:
+            # The RepoClerk journal that issuePR() reads lags, so a just-opened PR may not appear
+            # there yet -- fall back to an authoritative direct lookup before giving up (same root
+            # cause as the commitAndPush duplicate-PR bug).
+            branchName = self.localRepo.active_branch.name
+            originOwner = self.nameWithOwner("origin").split("/")[0]
+            pr = self._openPRForBranch(upstreamNameWithOwner, originOwner, branchName)
         if not pr:
             logging.error("No pull request found for the current issue branch.")
             return
 
-        upstreamNameWithOwner = self.nameWithOwner("upstream")
         self.gh(f"""
             pr ready {pr['number']}
                 --repo {upstreamNameWithOwner}
@@ -4876,14 +5197,25 @@ class MorphoDepotLogic(ScriptedLoadableModuleLogic):
                 f"No open pull request found for '{branch}'. It may already be merged or closed "
                 f"(the Review list can lag a minute behind GitHub). Click 'Refresh Github' to update it.")
         upstreamNameWithOwner = self.nameWithOwner("upstream")
-        commandList = f"""
-            pr review {pr['number']}
-                --request-changes
-                --repo {upstreamNameWithOwner}
-        """.replace("\n"," ").split()
-        if message != "":
-            commandList += ["--body", message]
-        self.gh(commandList)
+        # GitHub forbids submitting a review (--request-changes) on your OWN pull request, exactly like
+        # --approve (see approvePR).  When the reviewer is also the PR author (their own contribution,
+        # or testing), post the feedback as a plain comment instead; the PR is still set back to draft
+        # below so the contributor knows to revise.
+        me = self.whoami()
+        selfAuthored = (pr.get("author") or {}).get("login") == me
+        if selfAuthored:
+            if message != "":
+                self.gh(["pr", "comment", str(pr['number']), "--repo", upstreamNameWithOwner,
+                         "--body", message])
+        else:
+            commandList = f"""
+                pr review {pr['number']}
+                    --request-changes
+                    --repo {upstreamNameWithOwner}
+            """.replace("\n"," ").split()
+            if message != "":
+                commandList += ["--body", message]
+            self.gh(commandList)
         self.gh(f"""
             pr ready {pr['number']}
                 --undo
@@ -4939,17 +5271,22 @@ class MorphoDepotLogic(ScriptedLoadableModuleLogic):
 
     def closedIssuesSinceLastRelease(self, nameWithOwner):
         """Return a list of {number,title} for issues closed since the last published release.
-        If there is no prior release, returns all closed issues for the repo."""
+        If there is no prior release, returns all closed issues for the repo.  Pre-release
+        ANNOUNCEMENT issues are excluded: they carry the invisible release-announce marker and are
+        not contributions -- retiring an announcement closes it, which would otherwise make it show
+        up as a 'change in this release' in the next cycle (the bug this filters out)."""
         releases = self.ghJSON(f"release list --repo {nameWithOwner} --json tagName,publishedAt") or []
         sinceDate = releases[0].get('publishedAt') if releases else None
         if sinceDate:
             cmd = ["issue", "list", "--repo", nameWithOwner,
-                   "--json", "number,title",
+                   "--json", "number,title,body",
                    "--search", f"is:issue is:closed closed:>{sinceDate}"]
         else:
             cmd = ["issue", "list", "--repo", nameWithOwner, "--state", "closed",
-                   "--json", "number,title"]
-        return self.ghJSON(cmd) or []
+                   "--json", "number,title,body"]
+        issues = self.ghJSON(cmd) or []
+        return [{"number": i["number"], "title": i["title"]} for i in issues
+                if self.releaseAnnounceMarkerName not in (i.get("body") or "")]
 
     def nextReleaseTag(self):
         """Compute the next vN tag based on existing releases. Returns None if no repo loaded."""
@@ -5097,16 +5434,22 @@ class MorphoDepotLogic(ScriptedLoadableModuleLogic):
 
         return "\n".join(lines) + "\n"
 
-    def prepareReleaseSnapshot(self, newTag, baselineNode, colorTableNode, screenshots):
+    def prepareReleaseSnapshot(self, newTag, baselineNode, colorTableNode, screenshots, candidateBranch=None):
         """Stage the working tree for a release tag: write baseline.seg.nrrd from the picked
         segmentation, overwrite the repo's color table with the picked one, rotate README.md
         to README-{previousTag}.md and generate a fresh README.md, append new screenshots
         with sequential numbering (and update screenshots/captions.json), drop issue-*.seg.nrrd
-        from the working tree (still in git history). Then commit and push to origin/main."""
+        from the working tree (still in git history), and commit.
+
+        If `candidateBranch` is given (org/gated, Option C), the release commit is force-pushed to
+        that branch and local main + working tree are reset back to the pre-release state -- main is
+        NOT modified (the App archives main and fast-forwards it to the candidate on approval).
+        Otherwise (personal) the commit is pushed straight to origin/main as before."""
         if not self.localRepo:
             return None
         repoDir = self.localRepo.working_dir
         previousTag = self.previousReleaseTag()
+        baseSha = self.localRepo.head.commit.hexsha  # pre-release main, to restore in candidate mode
 
         # Baseline segmentation
         baselinePath = os.path.join(repoDir, "baseline.seg.nrrd")
@@ -5158,10 +5501,20 @@ class MorphoDepotLogic(ScriptedLoadableModuleLogic):
         for path in glob.glob(os.path.join(repoDir, "issue-*.seg.nrrd")):
             os.remove(path)
 
-        # Stage everything (added, modified, deleted), commit, push.
+        # Stage everything (added, modified, deleted), commit.
         self.localRepo.git.add("--all")
         self.localRepo.index.commit(f"Prepare release {newTag}")
-        self.localRepo.remote(name="origin").push("main")
+        if candidateBranch:
+            # Option C: publish the release commit to the candidate branch and leave main UNTOUCHED.
+            # Always reset local main + working tree back to the pre-release state afterward (even if
+            # the push fails), so an unapproved or re-submitted release never rewrites main.  The App
+            # archives main and fast-forwards it to this candidate on approval.
+            try:
+                self.localRepo.git.push("--force", "origin", f"HEAD:refs/heads/{candidateBranch}")
+            finally:
+                self.localRepo.git.reset("--hard", baseSha)
+        else:
+            self.localRepo.remote(name="origin").push("main")
 
     def resetToReleaseBackup(self):
         """Hard-reset main to the pre-release archive branch and discard untracked changes.
@@ -5182,13 +5535,16 @@ class MorphoDepotLogic(ScriptedLoadableModuleLogic):
         self.releaseBackupBranch = None
 
     def createRelease(self, releaseNotes="", baselineSegmentationNode=None, colorTableNode=None, screenshots=None):
-        """Create a new release: create and push a pre-release-{tag} archive branch
-        capturing main as it is right now (so per-issue segmentations and any other
-        about-to-be-removed files stay browsable on GitHub), prepare the working tree
-        (baseline, color table, README rotation, drop issue segmentations, screenshots),
-        commit, push to origin/main, then create the gh release tag at that commit.
-        On exception the archive branch is left in place so resetToReleaseBackup can
-        roll back the local repo. Returns the new tag on success."""
+        """Create a new release.
+
+        Org/archival repo (gated, Option C): the release commit is published to a
+        `release-candidate-{tag}` branch and **main is left untouched**.  On approval the App archives
+        the current main as `pre-release-{tag}` (preserving the per-issue contributions), fast-forwards
+        main to the candidate, cuts the tag, and mints the DOI.  This keeps main/history intact through
+        an unapproved or re-submitted (request-changes) release.  Returns a pending marker dict.
+
+        Personal/short-term repo: no gate -- archive main, rewrite main directly, and create the tag.
+        Returns the new tag."""
         if not self.localRepo:
             return None
         if baselineSegmentationNode is None or colorTableNode is None:
@@ -5196,24 +5552,31 @@ class MorphoDepotLogic(ScriptedLoadableModuleLogic):
         tag = self.nextReleaseTag()
         if tag is None:
             return None
+        originNameWithOwner = self.nameWithOwner("origin")
+        if releaseNotes == "":
+            releaseNotes = f"Version {tag} release."
+        originOwner = originNameWithOwner.split("/")[0]
 
+        if originOwner == self.morphoDepotOrg:
+            # Build the release commit on the candidate branch (main untouched), then request review.
+            candidate = f"release-candidate-{tag}"
+            self.prepareReleaseSnapshot(tag, baselineSegmentationNode, colorTableNode,
+                                        screenshots or [], candidateBranch=candidate)
+            repoName = originNameWithOwner.split("/")[1]
+            resp = self.controlPlaneRequest(
+                "repos/release", {"repo": repoName, "tag": tag, "notes": releaseNotes}) or {}
+            if resp.get("status") == "pending_review":
+                return {"pending": True, "tag": tag, "reviewSentTo": resp.get("review_sent_to")}
+            return tag
+
+        # Personal/short-term repo: archive main, rewrite main directly, then create the tag.
         backupName = f"pre-release-{tag}"
-        # Create the archive branch locally and push it before any working-tree changes
-        # so the pre-release state is preserved on the remote even if later steps fail.
-        # Idempotent: a retry after a partial failure may find this local branch already present
-        # (resetToReleaseBackup deliberately keeps it), so recreate it at the current commit rather
-        # than crashing with "a branch named 'pre-release-vN' already exists".
         if backupName in [head.name for head in self.localRepo.heads]:
             self.localRepo.git.branch("-D", backupName)
         self.localRepo.git.branch(backupName)
         self.releaseBackupBranch = backupName
         self.localRepo.remote(name="origin").push(backupName)
-
         self.prepareReleaseSnapshot(tag, baselineSegmentationNode, colorTableNode, screenshots or [])
-
-        originNameWithOwner = self.nameWithOwner("origin")
-        if releaseNotes == "":
-            releaseNotes = f"Version {tag} release."
         commandList = ["release", "create", tag, "--repo", originNameWithOwner]
         commandList += ["--notes", releaseNotes]
         self.gh(commandList)
@@ -5837,16 +6200,33 @@ jobs:
         return repoNameWithOwner
 
     def _publishStagedRepoInOrg(self, ctx):
-        """Member tier: publish via the App — one-way private->public + topic swap (the App owns
-        topics; members only have Write)."""
+        """Member tier: ask the App to make the staged org repo public.  Going public is a governed
+        event (org-design 11.3): the App routes the request through the MD-reviewers review gate —
+        it emails a signed Approve link and does NOT flip the repo now.  Returns a pending-review
+        dict in that case (the repo stays private + staged until a reviewer approves, after which
+        the App makes it public on its own).  A non-gated immediate publish (backstop) returns the
+        nameWithOwner string, as before."""
         repoName = ctx["repoName"]
         species = ctx.get("speciesTopicString")
         topics = ["morphodepot"] + ([f"md-{species}"] if species else [])
-        self.progressMethod(f"Publishing {ctx['personalNameWithOwner']} (making public)...")
-        self.controlPlaneRequest("repos/publish", {"repo": repoName, "topics": topics})
-        self.ghTopicClearCache()
         finalNameWithOwner = ctx["personalNameWithOwner"]
+        self.progressMethod(f"Submitting {finalNameWithOwner} for review...")
+        resp = self.controlPlaneRequest("repos/publish", {"repo": repoName, "topics": topics}) or {}
         repoDir = ctx.get("repoDir")
+
+        if resp.get("status") == "pending_review":
+            # Review requested.  The repo is still private and still carries morphodepot-staging,
+            # so it remains in the unpublished list; drop only the transient local clone (reopen
+            # re-clones).  Do NOT notify RepoClerk (nothing public to crawl) or add a contact.
+            self.localRepo = None
+            if repoDir and os.path.exists(repoDir):
+                shutil.rmtree(repoDir, ignore_errors=True)
+            self.stagingContext = None
+            return {"pending": True, "nameWithOwner": finalNameWithOwner,
+                    "reviewSentTo": resp.get("review_sent_to")}
+
+        # Backstop: an immediate (non-gated) publish actually made it public — clean up as before.
+        self.ghTopicClearCache()
         self.localRepo = None
         if repoDir and os.path.exists(repoDir):
             shutil.rmtree(repoDir, ignore_errors=True)

--- a/MorphoDepot/MorphoDepot.py
+++ b/MorphoDepot/MorphoDepot.py
@@ -922,9 +922,17 @@ class MorphoDepotWidget(ScriptedLoadableModuleWidget, VTKObservationMixin, Enabl
         header (Segment{N}_* custom fields).  Returns None if it cannot be determined."""
         try:
             import re
+            # Read until the NRRD header terminator (\n\n), not a fixed slice: a segmentation with many
+            # DICOM-derived per-segment tag strings can push the header past a fixed cap, which would
+            # undercount segments and let the no-change guard silently pass. Cap at 8 MB as a backstop.
+            header = b""
             with open(path, "rb") as f:
-                head = f.read(524288)
-            header = head.split(b"\n\n", 1)[0]
+                while b"\n\n" not in header and len(header) < 8 * 1024 * 1024:
+                    chunk = f.read(262144)
+                    if not chunk:
+                        break
+                    header += chunk
+            header = header.split(b"\n\n", 1)[0]
             indices = set(re.findall(rb"Segment(\d+)_", header))
             return len(indices) if indices else None
         except Exception as e:
@@ -943,6 +951,10 @@ class MorphoDepotWidget(ScriptedLoadableModuleWidget, VTKObservationMixin, Enabl
         committed = glob.glob(f"{repoDir}/*.csv") or glob.glob(f"{repoDir}/*.ctbl")
         if not committed:
             return False
+        if len(committed) > 1:
+            # Compare against the same file prepareReleaseSnapshot writes (first match); warn so a
+            # stray extra color file can't silently make the comparison pick the wrong one.
+            logging.warning(f"Multiple committed color files {committed}; comparing against {committed[0]}")
         committedPath = committed[0]
         tmpDir = tempfile.mkdtemp()
         try:
@@ -3139,8 +3151,11 @@ class MorphoDepotWidget(ScriptedLoadableModuleWidget, VTKObservationMixin, Enabl
             f"Release creation failed:\n{error}\n\n"
             "Click OK to reset the local repository to its pre-release state.\n"
             "Click Cancel to leave the working tree as is so you can salvage screenshots or other work.\n\n"
-            "Note: a local reset cannot undo any push that may have already reached origin/main; "
-            "if the push succeeded you may need to fix things on GitHub manually."
+            "Note: a local reset cannot undo a push that may have already reached GitHub. For a personal "
+            "repo that is origin/main; for an org/archival repo the push went to a "
+            "'release-candidate-<version>' branch and main is untouched until approval. Either is safe "
+            "to leave — a retry force-pushes the candidate again — but you may delete a stray "
+            "release-candidate branch on GitHub if you prefer."
         )
         if (not self.testingMode) and slicer.util.confirmOkCancelDisplay(msg, windowTitle="Release failed"):
             try:
@@ -5204,9 +5219,11 @@ class MorphoDepotLogic(ScriptedLoadableModuleLogic):
         me = self.whoami()
         selfAuthored = (pr.get("author") or {}).get("login") == me
         if selfAuthored:
-            if message != "":
-                self.gh(["pr", "comment", str(pr['number']), "--repo", upstreamNameWithOwner,
-                         "--body", message])
+            # Always post a comment -- an empty message would otherwise set the PR back to draft
+            # (below) with zero feedback to the contributor.
+            body = message if message != "" else "Changes requested (no additional comment)."
+            self.gh(["pr", "comment", str(pr['number']), "--repo", upstreamNameWithOwner,
+                     "--body", body])
         else:
             commandList = f"""
                 pr review {pr['number']}

--- a/MorphoDepot/Testing/MorphoDepot_UI_Test_Plan.md
+++ b/MorphoDepot/Testing/MorphoDepot_UI_Test_Plan.md
@@ -1,0 +1,542 @@
+# MorphoDepot — UI-Driven Test Plan
+
+Status: **PLAN ONLY — do not execute until explicitly told "go".**
+Target under test: [`MorphoDepot/MorphoDepot.py`](../MorphoDepot.py) (~6,600 lines, single tabbed module).
+Author/driver model: Claude Code driving 3D Slicer through the **Slicer MCP server**.
+
+---
+
+## 0. Purpose & non-negotiable constraints
+
+The module has grown past the point where its decision trees can be tested by hand.
+This plan defines a repeatable, **black-box, UI-event-driven** test suite that a coding
+agent (or a human following the same steps) can run against a live Slicer instance.
+
+Hard rules agreed with the maintainer (do not relax without asking):
+
+1. **Drive Slicer through the MCP server only.** Tooling: `mcp__slicer__execute_python`,
+   `mcp__slicer__screenshot`, `mcp__slicer__list_nodes`, `mcp__slicer__get_node_properties`,
+   `mcp__slicer__load_sample_data`, `mcp__slicer__read_file`, `mcp__slicer__write_file`,
+   plus `gh`/`git` via Bash for out-of-band setup and verification.
+2. **Signal-level UI actuation is the *only* legal way to perform the action under test.**
+   Allowed: locate a real widget and fire its user-facing signal —
+   `button.click()`, `lineEdit.setText(...)` (+ `editingFinished`), `comboBox.setCurrentIndex(...)`,
+   `qMRMLNodeComboBox.setCurrentNode(...)`, `radio.click()`, `listWidget.itemDoubleClicked(item)`.
+   **Forbidden as a way to trigger behavior:** calling slot/handler methods directly
+   (`widget.onCreateRepository()`, `widget.onCommit()`, `widget.onMakeRelease()`, …) or calling
+   `MorphoDepotLogic` methods to *do* the thing (`logic.createAccessionRepo(...)`,
+   `logic.publishStagedRepo(...)`, `logic.loadIssue(...)`, …).
+3. **Three real, already-logged-in GitHub accounts**, switched under the hood:
+   - `muratmaga` — MorphoDepot **org owner** (also a member)
+   - `amm554` — MorphoDepot **org member** (not owner of arbitrary repos)
+   - `SlicerMorph` — **outsider** (not a MorphoDepot org member)
+4. **Full real environment.** Real org repos, real S3 uploads, real GitHub releases, real
+   Zenodo DOI minting, real contact-list email. Clean up afterward. See §4.2 — some effects
+   (minted DOIs) are **not reversible**; those scenarios require explicit per-run go-ahead.
+
+> **What this is NOT:** it is not the existing `MorphoDepotTest` self-test (class at
+> `MorphoDepot.py:6172`). That test calls handlers and logic methods directly and
+> monkeypatches the search layer — exactly the style this plan rejects. It remains a useful
+> **coverage reference** (it already walks create→issue→PR→review→release end-to-end), and the
+> scenario catalog below mirrors its coverage, but every action here is fired through the GUI.
+
+---
+
+## 1. Test architecture
+
+### 1.1 Roles — who does what
+
+| Actor | Mechanism | Responsibility |
+|---|---|---|
+| **Driver (agent)** | MCP `execute_python` / `screenshot` | Fires widget signals, reads widget state, captures screenshots |
+| **Verifier** | `gh`/`git` via Bash, MCP node reads | Confirms authoritative GitHub state + MRML scene state |
+| **Fixture/teardown** | `gh`/`git` via Bash | Seeds long-lived test repos, cleans up afterward |
+
+`gh`/`logic` calls are allowed for **setup and verification only** — never to perform the
+step that is itself under test. (E.g. it's fine to verify a PR exists with `gh pr list`; it is
+**not** fine to create that PR with `gh pr create` when the test is "segmenter commits via the
+Annotate tab".)
+
+### 1.2 The "legal action" rule, made concrete
+
+Every action in the catalog (§6) is expressed as a `(widget, signal)` pair. The driver
+resolves the widget off the live widget object and fires the signal. Reference map of
+addressable widgets (from `setup()` / `Connections`, `MorphoDepot.py:160–693`):
+
+```
+w = slicer.modules.MorphoDepotWidget
+# Configure
+w.configureUI.repoDirectory / .gitPath / .ghPath / .reloadButton ("Apply Changes")
+w.configureUI.userNameLineEdit / .userEmailLineEdit / .adminModeCheckBox
+# Create
+w.createUI.archivalRadio / .shortTermRadio
+w.createUI.inputSelector (qMRMLNodeComboBox) / .colorSelector / .segmentationSelector
+w.createUI.accessionForm.questions[<key>].optionButtons[<label>] / .answerText
+w.createUI.autoAssignCheckBox / .autoAssignHelpButton
+w.createUI.createRepository ("Create (stage privately)") / .saveEditsButton
+w.createUI.stagedReposList / .refreshStagedReposButton
+w.createUI.goLiveEmail / .destinationQuestion / .publishButton ("Make Public") / .discardButton
+w.createUI.takeScreenshotButton / .reviewScreenshotsButton / .openRepository / .clearForm
+# Annotate (segmenter)
+w.annotateUI.refreshButton / .issueList / .prList / .messageTitle / .commitButton / .reviewButton / .openPRPageButton
+# Review (owner)
+w.reviewUI.refreshButton / .prList / .hideDraftsCheckBox / .requestChangesButton / .approveButton
+# Release (owner)
+w.releaseUI.refreshButton / .repoList / .newBaselineSelector / .newColorSelector
+w.releaseUI.releaseCommentsEdit / .makeReleaseButton / .openReleasePageButton
+w.releaseUI.announcementDeadline / .announcementMessageEdit / .announceButton
+# Search
+w.searchUI.refreshButton / .searchForm / .resultsTable / .saveSearchResultsButton
+# Tabs
+w.tabWidget  (switch tabs with w.tabWidget.setCurrentIndex(i) — a user clicking the tab)
+```
+
+To "double-click an issue/PR/repo" like a user, select the row and emit the item signal:
+```python
+lw = w.annotateUI.issueList
+item = lw.item(row)
+lw.setCurrentItem(item)
+lw.itemDoubleClicked(item)     # fires the connected slot via the real signal
+```
+
+### 1.3 `testingMode` stays OFF — and Developer mode stays OFF by default
+
+`widget.testingMode` is **not a user-facing toggle**. It is initialized `False` in
+`__init__` (`MorphoDepot.py:143`) and is flipped to `True` in exactly one place — the
+`MorphoDepotTest` self-test (`:6190`, reset in `:6201`). This suite **never sets it True**, so
+it stays `False` throughout. That matters because `testingMode` does **two** things
+(`grep testingMode`):
+- auto-skips ~18 modal confirm dialogs, **and**
+- **changes real behavior**: `onCreateRepository` (`:1368`) reroutes creation into the throwaway
+  `morphoDepotTestingOrg` with a *release-asset* payload and **no App/S3**.
+
+So testingMode=True would both hide the dialogs we want to test *and* bypass the real archival →
+org → S3 → DOI path — defeating a full-real-environment run. We keep it `False` and answer the
+live modals like a user (§1.4).
+
+**Developer mode is OFF by default**, because that is the faithful end-user configuration. The
+testing affordances are *only* exposed under `Developer/DeveloperMode`: the Configure **Testing**
+collapsible with the Creator/Annotator fields (`:265`) and the **Fill Form for Testing** button
+(`:346`). With Developer mode OFF these are hidden, so the accession form is filled field-by-field
+through real widget signals — exactly what an end user does.
+
+> Developer mode may be turned **ON** only as a *convenience* to use the **Fill Form for Testing**
+> shortcut while iterating. Turning it on does **not** change `testingMode` (still `False`) and
+> does not alter any tested code path — but it is a deviation from the pristine end-user state, so
+> the canonical P0 pass of the create flow (B1) is run at least once with Developer mode **OFF**
+> and the form filled manually.
+
+### 1.4 Modal dialogs — the central hazard
+
+With `testingMode` off, these block on a modal `exec_()` and must be answered like a user.
+Inventory (line refs in `MorphoDepot.py`):
+
+| Where | Line | Dialog | Default test response |
+|---|---|---|---|
+| Missing terminology on color table | 1302 | OK/Cancel | OK (fill defaults) — or pre-fix the table (see §2) |
+| Create confirmation (accession summary) | 1383→1748/1804 | custom OK/Cancel | OK to proceed; **Cancel** path is its own scenario |
+| Duplicate volume checksum | 1635/1638 | OK/Cancel | scenario-specific |
+| Publish repository | 1646 | OK/Cancel | OK |
+| Discard staged repo | 1712/1720 | OK/Cancel | OK |
+| Load issue / PR / repo (scene clear) | 2041 / 2204 / 2267 | OK/Cancel | OK |
+| Make release | 2645 / 2667 | OK/Cancel | OK |
+| Release failed | 2854 | OK/Cancel | observe only |
+| Announce upcoming release | 2876 / 2970 | OK/Cancel | OK |
+| Preview repository | 2980 | OK/Cancel | OK |
+| `errorDisplay` / `messageBox` (e.g. archival-requires-membership 1373; commit-failed 2138) | several | single OK | OK + assert text |
+| **Native file dialog** (Save search CSV) | 2577 | OS save dialog | special case (§6 S7) |
+
+**Strategy — arm an in-Slicer dialog auto-responder, then fire the action.**
+This is faithful: it does nothing but wait for whatever top-level modal appears and press one
+of *its* buttons — exactly what a human does — without calling any module handler. It also
+solves the deadlock: `execute_python` returns immediately; the timer answers the modal from
+inside Slicer's (nested) event loop.
+
+```python
+# Installed once per session; armed before each dialog-bearing action.
+def _md_arm_dialog(button="ok", capture_path=None, timeout_ms=8000):
+    """Wait for the top modal widget, screenshot+record its text, then click OK/Cancel.
+    Pure UI: it presses the dialog's own button; it never calls a module slot."""
+    import qt, time
+    state = {"text": None, "clicked": None}
+    slicer.modules._mdDialogState = state
+    deadline = time.time() + timeout_ms/1000.0
+    def poll():
+        dlg = slicer.app.activeModalWidget() or qt.QApplication.activeModalWidget()
+        if dlg is None:
+            if time.time() < deadline:
+                qt.QTimer.singleShot(100, poll)
+            return
+        state["text"] = dlg.windowTitle + " | " + (getattr(dlg, "text", lambda: "")() if hasattr(dlg, "text") else dlg.findChild(qt.QLabel).text if dlg.findChild(qt.QLabel) else "")
+        if capture_path:
+            dlg.grab().save(capture_path)
+        # Find the right button by role.
+        bb = dlg.findChild(qt.QDialogButtonBox)
+        target = None
+        if bb:
+            role = qt.QDialogButtonBox.Ok if button == "ok" else qt.QDialogButtonBox.Cancel
+            target = bb.button(role) or (bb.button(qt.QDialogButtonBox.Yes) if button=="ok" else bb.button(qt.QDialogButtonBox.No))
+        if target is None:  # QMessageBox path
+            for b in dlg.findChildren(qt.QPushButton):
+                if (button=="ok" and b.text.lower() in ("ok","yes")) or (button=="cancel" and b.text.lower() in ("cancel","no")):
+                    target = b; break
+        if target: target.click()
+        state["clicked"] = button
+    qt.QTimer.singleShot(100, poll)
+```
+
+> **#1 risk to validate in the smoke test:** whether the Slicer MCP server can still service
+> `execute_python` *while a modal `exec_()` runs*. Nested Qt event loops normally keep
+> processing queued/timer/socket events, so the armed timer above should fire regardless —
+> but this MUST be proven on day one. Fallback if the server is starved during a modal: rely
+> entirely on the pre-armed timer (no second MCP round-trip needed while blocked), which is why
+> the responder is *armed before* the action rather than handled after.
+
+### 1.5 Persona / account switching protocol
+
+Identity is derived from the **active `gh` account**, and several reads are **cached per
+module-load** — `userIsOrgMember` caches `_orgMemberCache` (`:3828`, comment literally says
+"reload the module after switching gh accounts"); `whoami` reads `gh auth status --active`
+(`:4218`); git `user.name`/`user.email` are read from git config.
+
+**Switch routine (between personas):**
+1. `gh auth switch --user <login>` (Bash). *(This is allowed — it is environment setup, not the
+   action under test. Note: the existing self-test does the equivalent via `logic.gh([...])`.)*
+2. In the Configure tab, set `user.name` / `user.email` to match the persona if a commit will
+   happen (drive `userNameLineEdit.setText` / `userEmailLineEdit.setText`).
+3. **Click "Apply Changes"** (`configureUI.reloadButton` → `onReload`) to reload the module and
+   drop cached identity/membership. Re-resolve `w = slicer.modules.MorphoDepotWidget` afterward
+   (the widget object is rebuilt).
+4. Verify: read `w.logic.whoami()` and (for org-gated steps) confirm the control-plane `/me`
+   membership via the UI's behavior, not by calling the gated method to perform an action.
+
+**State isolation:** the local repo dir is a single setting, but a segmenter clones a *fork*
+and an owner clones *upstream*; mixing accounts in one dir invites collisions. Use a **distinct
+`repoDirectory` per persona** (set via the Configure `repoDirectory` widget on switch), e.g.
+`…/md-uitest/<login>/`.
+
+### 1.6 Verification channels (in priority order)
+
+1. **Authoritative GitHub state** via `gh` (Bash) under the *appropriate* account: repo exists,
+   visibility, topics (`morphodepot` added / `morphodepot-staging` removed), issues, PR state &
+   draft flag, reviews, merges, releases, release assets, tags.
+2. **MRML scene state** via `mcp__slicer__list_nodes` / `get_node_properties`: segmentation and
+   volume nodes loaded after a load action; new segment present after an edit.
+3. **Widget state** via `execute_python` *reads* (reading is always allowed): label text
+   (`stagingStatusLabel`, `announcementStateLabel`, repo-row text/tooltip), `enabled` flags
+   (`publishButton.enabled`, `commitButton.enabled`, `makeReleaseButton.enabled`), list contents.
+4. **Screenshots** (`mcp__slicer__screenshot`) at every assertion point and for every dialog —
+   the human-auditable trail.
+
+### 1.7 Naming & teardown
+
+- Repo names: `uitest-<persona>-<species>-<runid>` (runid from Bash timestamp passed in, since
+  scripts can't read the clock). Mirrors the self-test's `test-…` convention.
+- S3 keys are content-addressed by sha256 — re-running with the same volume is idempotent.
+- Teardown (Bash, end of run, in `finally` spirit): `gh repo delete <nwo> --yes` for every repo
+  created this run (needs `delete_repo` scope; if absent, print the Danger-Zone URL like
+  `_cleanupTestRepo` does, `:6203`). Close any leftover issues/PRs. **DOIs cannot be deleted** —
+  see §4.2.
+
+---
+
+## 2. Pre-flight checklist (run once, before any scenario)
+
+- [ ] **Target the correct Slicer: the build on the Desktop** (`~/Desktop/Slicer*.app`), **not**
+      the stable release in `/Applications`. Every scenario runs against the Desktop build.
+- [ ] **Developer mode OFF before the run — verify and, if needed, restart.** It is OFF by default
+      but is currently ON on this machine. So: check the setting, set it OFF, and **restart Slicer**.
+      The MCP server is launched from Slicer's startup script, so restarting Slicer automatically
+      relaunches MCP. After restart, confirm the `mcp__slicer__*` tools resolve in-session.
+- [ ] 3D Slicer (Desktop build) is running with the **MorphoDepot** module loaded and MCP attached.
+- [ ] **Developer mode OFF** (`Developer/DeveloperMode`) — this is the faithful end-user config;
+      `testingMode` stays `False`. Turn it ON *only* if a scenario explicitly opts into the
+      *Fill Form for Testing* convenience (it then reveals the Configure *Testing* collapsible and
+      the *Fill Form* button; it does **not** flip `testingMode`). B1 is run at least once with it OFF.
+- [ ] `gh auth status` shows all three accounts logged in; note which is active.
+- [ ] Dependencies green: `checkPythonDependencies`, `checkGitDependencies`, valid
+      `localRepositoryDirectory` (else `checkModuleEnabled` blocks with a modal, `:82–125`).
+- [ ] Control plane reachable (`https://join.morphodepot.org`) for membership + S3 signing.
+- [ ] A real **source volume** available (MRHead via `mcp__slicer__load_sample_data`) and a
+      **color table with complete terminology** (or plan to OK the terminology dialog — §1.4).
+- [ ] Per-persona repo directories created.
+- [ ] Install the harness helpers (§5) into the running Slicer once.
+
+---
+
+## 3. Persona × capability matrix (the heart of the 3-account test)
+
+| Capability | `muratmaga` (owner) | `amm554` (member) | `SlicerMorph` (outsider) |
+|---|---|---|---|
+| Create **archival** repo (org, S3, DOI) | ✅ | ✅ | ❌ → `errorDisplay` "Archival requires membership" (`:1372`) |
+| Create **short-term** repo (personal acct) | ✅ | ✅ | ✅ |
+| See **org** as publish destination | ✅ | ✅ | ❌ (personal only; `populateOwnerSelector`) |
+| Auto-assign workflow checkbox enabled | scope-gated (`hasWorkflowScope` `:4061`) | scope-gated | scope-gated |
+| Segment an assigned issue → commit → PR (Annotate) | ✅ | ✅ | ✅ via fork on public repo |
+| Approve + **merge** a PR (Review) | ✅ on owned/org repos | only where granted | ❌ |
+| Cut a **release** + mint DOI (Release) | ✅ on org repos | only where admin | ❌ |
+| Admin tab | ✅ (admin mode) | per role | per role |
+
+Each ✅/❌ above is an assertion target. The outsider's ❌ rows are first-class scenarios, not
+afterthoughts — they exercise the permission guards that are easy to break.
+
+---
+
+## 4. Known functional constraints that shape the tests
+
+### 4.1 Search-index lag — **the biggest practical constraint**
+
+Annotate/Review/Release/Search refresh buttons resolve repos/issues/PRs through GitHub's
+**topic search index** (`topic:MorphoDepot`) and `issue list --search`, which **lag by minutes**
+for freshly created repos/issues/PRs. The existing self-test only passes by **monkeypatching**
+`morphoRepos`, `issueList`, `prList`, and `closedIssuesSinceLastRelease` to hit direct REST
+(`:6353, :6415, :6497–6554`). **A UI-driven test cannot monkeypatch** — clicking *Refresh* runs
+the real, lagging path, so a just-created repo's issues/PRs may simply **not appear**.
+
+Mitigation (simple, confirmed by maintainer): **insert a fixed ~60 s settle delay** after any
+create / assign / commit / merge, before clicking the relevant *Refresh* and asserting. RepoClerk
+now updates fast — typically **20–40 s** — so a 60 s wait clears the lag in the large majority of
+cases. As a backstop, the module exposes `notifyRepoClerk` / `hasRepoClerkUpdatePending` /
+`_waitForRepoClerkUpdate` and hidden per-tab `repoClerkStatusLabel`s; if a list is still empty
+after 60 s, poll those once or twice more before failing.
+
+Long-lived pre-seeded fixture repos remain an **optional** optimization (avoids recreating
+archival/org repos every run), but with the 60 s settle delay, fresh-create flows are viable for
+every group.
+
+> Treat "list empty immediately after create" as *expected lag*, not a bug: always settle ~60 s
+> (or poll RepoClerk) before a list-dependent assertion.
+
+### 4.2 Irreversible / outward side effects
+
+- **Zenodo DOI minting** (Release, archival repos): the extension mints against **Zenodo
+  sandbox**, so these are **sandbox DOIs — not real, citable DOIs**. Safe to create freely; no
+  human checkpoint needed. (Sandbox records can be removed from the sandbox account if desired;
+  they never resolve as production DOIs.)
+- **S3 uploads** (`uploadSourceVolumeToObjectStore`, `:3702`): content-addressed, public-read.
+  Re-runs are idempotent; old test keys accumulate — periodic bucket sweep, not per-run.
+- **Contact-list email** at publish time: real submission. Use a maintainer-owned address.
+- **Org pollution**: archival creates land in the real MorphoDepot org. Teardown deletes repos,
+  but the org membership/transfer events are visible. Name everything `uitest-…`.
+
+---
+
+## 5. Harness helpers (install once per session, in-Slicer)
+
+These are *test scaffolding the driver injects via `execute_python`*, not edits to the module.
+They only **read** state and **actuate widgets/dialogs** — never call module slots/logic to
+perform an action.
+
+- `_md_arm_dialog(button, capture_path, timeout_ms)` — §1.4 (modal responder).
+- `_md_widget(path)` — resolve a dotted widget path off `slicer.modules.MorphoDepotWidget`.
+- `_md_fire(path, signal, *args)` — fire a named signal/click on a resolved widget.
+- `_md_list_rows(listpath)` / `_md_dblclick(listpath, predicate)` — read a QListWidget and
+  double-click the row matching a predicate (by text), via the real `itemDoubleClicked` signal.
+- `_md_state()` — dump a snapshot dict: `whoami`, active tab, key button `.enabled` flags, key
+  label texts, segmentation/volume node counts — for fast assertions + logging.
+- `_md_switch_persona(login, name, email, repodir)` — performs §1.5 steps 2–3 (the `gh auth
+  switch` itself is a Bash call by the driver), then clicks **Apply Changes** and returns.
+
+Each scenario step = (optionally arm dialog) → fire signal → `processEvents` → screenshot →
+read state → assert (incl. `gh` verification under the right account).
+
+---
+
+## 6. Scenario catalog (core-first)
+
+Legend: **P** = persona/account · **Pre** = preconditions · **Act** = UI actions (signal-level)
+· **Dlg** = dialogs to answer · **Exp** = expected outcome · **Vfy** = verification · **Td** = teardown.
+Priority **P0** = must pass first, **P1**/**P2** = later passes. (`testingMode` is `False` in every
+scenario — see §1.3.)
+
+### Group A — Configure & gating
+
+- **A1 (P0) Identity & gates per account.** P: each of the three.
+  Act: switch persona (§1.5); read Configure fields; toggle `adminModeCheckBox`.
+  Exp: `whoami()` matches; git name/email reflect inputs; Admin tab appears/disappears with the
+  checkbox; with a bad repoDir, `checkModuleEnabled` raises the directory modal (Dlg: OK).
+  Vfy: `_md_state`, screenshot.
+
+### Group B — Create / Publish (fresh repos)
+
+- **B1 (P0) Owner creates ARCHIVAL repo end-to-end.** P: `muratmaga`.
+  Pre: MRHead loaded; color table with terminology; **Developer mode OFF** (canonical run).
+  Act: Create tab → `archivalRadio.click()` → set `inputSelector`/`colorSelector` → fill
+  `accessionForm` field-by-field (radios via `optionButtons[...].click()`, text via
+  `answerText.text=`; the *Fill Form for Testing* shortcut is unavailable with Developer mode OFF
+  and is only an optional convenience in a separate `amm554` iteration) → `createRepository.click()`
+  (Dlg: terminology? → OK; create
+  confirmation → **OK**) → in Go-live zone set `goLiveEmail`, pick org destination →
+  `publishButton.click()` (Dlg: Publish → **OK**).
+  Exp: repo staged private then made public in the **MorphoDepot org**; topics flip
+  (`morphodepot` added, `morphodepot-staging` removed); source volume uploaded to **S3**.
+  Vfy (gh as muratmaga): `gh repo view`, `--json visibility,owner`, topic list, release/asset or
+  S3 checksum index; `stagingStatusLabel` text. Td: `gh repo delete`.
+
+- **B2 (P1) Member creates archival.** P: `amm554`. Same as B1; assert org membership lets it through.
+
+- **B3 Non-member tries to create an ARCHIVAL repo** — the "user didn't understand archival
+  (org-only) vs short-term (personal)" case. P: `SlicerMorph` (a confirmed non-member). Maintainer
+  acceptance criteria: **(1) it must not be possible to actually create one, and (2) the message
+  must make clear this is a membership *requirement*, not a software failure.** Split into three:
+
+  - **B3a (P0) Proactive prevention — Archival not selectable for a confirmed non-member.**
+    Pre: Create tab freshly entered as `SlicerMorph`.
+    Exp (TARGET behavior): on Create-tab entry a membership check runs (mirroring
+    `_refreshAutoAssignAvailability`, `:1063`); since `userIsOrgMember()` (`:3828`) is False, the
+    **`archivalRadio` is disabled**, `shortTermRadio` is preselected, and an inline note/tooltip
+    names the membership requirement + join link. Vfy: `archivalRadio.enabled is False`, tooltip
+    text, short-term checked.
+    > GAP: today nothing checks membership on tab entry, so the radio is enabled and this assertion
+    > **fails against current code** — it documents the prevention the maintainer wants. Until it
+    > lands, B3b is the only enforced guard.
+
+  - **B3b (P0) Backstop — submit-time block (current behavior, keep even after B3a).**
+    Act: select `archivalRadio.click()` → fill the **entire** accession form → `createRepository.click()`.
+    Exp: the membership guard (`:1371`) aborts creation; **no repo created** on the personal account
+    or in the org. Vfy: dialog captured by `_md_arm_dialog`; assert the text (a) names the
+    membership requirement, (b) gives the join path, (c) offers Short-term as the alternative;
+    `gh repo list SlicerMorph` and `gh repo list MorphoDepot` show nothing new.
+    > QUALITY assertions tied to requirement 2: flag that the dialog uses `errorDisplay` (error/✕
+    > styling) rather than a warning/info "Membership required"; that the join URL is plain text,
+    > not an actionable button (cf. the `QMessageBox`+"Open Documentation" pattern at `:99`); and
+    > that the copy does not re-explain archival vs short-term for a user who didn't grasp it.
+
+  - **B3c (P1) Verification failure must NOT masquerade as "not a member."**
+    Pre: make the control-plane `/me` check fail (point `MorphoDepot/controlPlaneBase` at an
+    unreachable host) so `userIsOrgMember()` returns False by *error*, not by *fact*.
+    Exp (TARGET behavior): the message distinguishes "couldn't verify membership right now
+    (temporary, not your account)" from "you are not a member," and still offers Short-term.
+    > GAP: `userIsOrgMember()` swallows the exception and returns False (`:3840-3843`), so a real
+    > member hitting a network blip is wrongly told to "go join the org" — a software/infra problem
+    > mislabeled as a membership problem, the exact failure mode requirement 2 forbids. Documents
+    > the correctness gap.
+
+- **B4 (P1) Short-term repo on personal account.** P: `SlicerMorph` (and/or `amm554`).
+  Act: `shortTermRadio.click()` → fill → create → publish to **personal** account.
+  Exp: repo on personal account, public; no org transfer; release-asset payload (no S3 org tier).
+
+- **B5 (P1) Staged-repo recovery / resume.** P: `muratmaga`.
+  Act: create+stage but **do not** publish → click **Apply Changes** (reload) → Create tab →
+  `refreshStagedReposButton.click()` → `stagedReposList` double-click the staged repo →
+  edit a field → `saveEditsButton.click()` ("Update Repository (staged)") → then `publishButton`
+  OR `discardButton` (Dlg: Discard → OK).
+  Exp: staged repo reloads into the form; edits persist; publish/discard behave correctly.
+  Vfy: list contents pre/post; repo private→public or deleted.
+
+- **B6 (P2) Edge branches:** duplicate-volume checksum confirm (`:1635` — seed a second repo with
+  the same volume; Dlg appears); missing-terminology dialog Cancel path; create-confirmation
+  **Cancel** path (Exp: aborted, no repo); auto-assign checkbox disabled when token lacks
+  `workflow` scope (`hasWorkflowScope` False).
+
+### Group C — Annotate (segmenter)  *(use fixture repos — §4.1)*
+
+- **C1 (P0) Segmenter completes an assigned issue.** P: `amm554` (member) and `SlicerMorph`
+  (outsider via fork).
+  Pre: fixture repo with an open issue **assigned to this persona** (pre-seeded & indexed).
+  Act: Annotate tab → `refreshButton.click()` (poll for issue to appear) → `issueList`
+  double-click the issue (Dlg: "Close scene and load issue?" → OK) → make a segmentation edit
+  (add a segment via the Segment Editor / `AddEmptySegment` on the loaded node — this is editing
+  test data, not driving the module) → set `messageTitle.text` → `commitButton.click()` →
+  `reviewButton.click()` (request review / mark PR ready).
+  Exp: branch `issue-<n>` pushed; **draft PR** created, then marked ready.
+  Vfy (gh): `gh pr list --json number,title,isDraft,author`; node counts via MCP. Note: the
+  segmenter's own PR list may lag — poll.
+
+- **C2 (P2) Annotate guards:** `commitButton`/`reviewButton` start disabled (`:521`); enable only
+  after an issue is loaded + message entered (`onCommitMessageChanged`). Commit-conflict path
+  surfaces the `messageBox` at `:2138`.
+
+### Group D — Review (owner)  *(fixture repos)*
+
+- **D1 (P0) Owner requests changes, then approves+merges.** P: `muratmaga`.
+  Pre: open ready PR from C1 on a fixture repo the owner controls.
+  Act: Review tab → `refreshButton.click()` (poll) → `prList` double-click (Dlg: load PR → OK) →
+  `requestChangesButton.click()` → (segmenter addresses, D-loop with C1) → `approveButton.click()`.
+  Exp: review submitted (CHANGES_REQUESTED then APPROVED); PR merged (squash) & issue closed.
+  Vfy (gh): `gh pr view --json reviews,state,merged`; `hideDraftsCheckBox` toggles draft rows.
+
+- **D2 (P0) Member/outsider CANNOT approve+merge others' PRs.** P: `amm554` or `SlicerMorph` on a
+  repo they don't own. Exp: approve/merge fails or is not offered; assert the guard.
+
+### Group E — Release (owner)  *(fixture repos; DOI checkpoint §4.2)*
+
+- **E1 (P1) Owner cuts a release.** P: `muratmaga`.
+  Pre: org repo with ≥1 merged PR (closed issue) and ≥1 still-open issue (for cleanup test).
+  Act: Release tab → `refreshButton.click()` (poll) → `repoList` double-click the repo (Dlg: load
+  → OK) → `newBaselineSelector.setCurrentNode(...)` + `newColorSelector.setCurrentNode(...)`
+  (enables `makeReleaseButton` via `updateMakeReleaseEnabled`) → verify auto change-log in
+  `releaseCommentsEdit` → `makeReleaseButton.click()` (Dlg: Make release vN → OK; cleanup confirm → OK).
+  Exp: tagged release `vN`; baseline asset; change-log lists closed issues; lingering open issue
+  closed by cleanup; **DOI minted** (sandbox unless cleared for prod).
+  Vfy (gh): `gh release list/view`, assets, tag; issue states; row text shows
+  `(N open issue, M open PRs)` + tooltip (`:6573`). Td: `gh release delete`, repo delete; DOI stays.
+
+- **E2 (P1) Pre-release announcement.** P: `muratmaga`.
+  Act: set `announcementDeadline`/`announcementMessageEdit` → `announceButton.click()` (Dlg: OK).
+  Exp: announcement comment lands on each open issue (assert marker via `gh issue view`);
+  `announcementStateLabel`/header reflect existing announcement.
+
+- **E3 (P2) Release guards:** `makeReleaseButton` disabled until baseline+color chosen (`:2289`);
+  non-owner cannot release; release-failure dialog path (`:2854`).
+
+### Group F — Search (all personas, mostly read-only)
+
+- **F1 (P1)** Search tab → `refreshButton.click()` ("Load Searchable Repository Data", poll for
+  RepoClerk) → adjust `searchForm` criteria → results table populates → `resultsTable` double-click
+  a row (Dlg: preview → OK) loads a preview scene → `saveSearchResultsButton.click()` opens the
+  **native** save dialog. **Special case:** native OS file dialogs aren't Qt-button-clickable from
+  `execute_python`; either (a) pre-set the path by overriding the static
+  `QFileDialog.getSaveFileName` for that one call, or (b) assert up to the dialog opening and
+  document the manual step. Vfy: row count, CSV contents (if path forced).
+
+### Group G — Admin
+
+- **G1 (P2)** Admin mode on (`muratmaga`) → Admin tab present; basic visibility/enablement checks
+  (tab is a placeholder scroll area today, `:200–204`).
+
+---
+
+## 7. Execution order & session flow
+
+1. **Pre-flight (§2)** — target the **Desktop** Slicer build, ensure **Developer mode OFF** and
+   **restart Slicer** (which relaunches MCP), confirm MCP tools resolve → install helpers (§5) →
+   smoke-validate the modal responder (§8).
+2. **Fixtures:** seed long-lived indexed test repos for Groups C/D/E/F (§4.1), with issues
+   assigned to `amm554`/`SlicerMorph`. Allow index to settle (minutes) before list-dependent runs.
+3. **P0 pass:** A1 → B1 → B3 → C1 → D1/D2 → (E1 if DOI cleared). Stop & report.
+4. **P1 pass:** B2, B4, B5, E1/E2, F1.
+5. **P2 pass:** B6, C2, D-edge, E3, G1.
+6. **Teardown (§1.7)** + DOI note.
+
+Between every persona-spanning step, run `_md_switch_persona` (§1.5) and re-resolve the widget.
+
+---
+
+## 8. Open risks / validate in the smoke test (before trusting any result)
+
+1. **Modal vs MCP (blocker).** Prove `execute_python` still runs while a `confirmOkCancelDisplay`
+   modal is open, OR prove the pre-armed timer (§1.4) dismisses it without a second round-trip.
+   Test with a trivial `confirmOkCancelDisplay` before B1.
+2. **Reload re-resolves the widget.** After "Apply Changes", confirm `slicer.modules.
+   MorphoDepotWidget` is the *new* instance and caches are cleared (membership re-checked).
+3. **Settle timing (§4.1).** A ~60 s delay should clear RepoClerk lag (now ~20–40 s); confirm on
+   the first create/assign and add a RepoClerk poll only if a list is still empty after 60 s.
+4. **`gh auth switch` visibility to the running module.** Confirm a switch made via Bash is seen
+   by the in-Slicer `gh` calls (same `gh` config/keyring) after reload — they share the host
+   `gh`, so it should, but verify `whoami()` flips.
+5. **DOI environment.** Confirmed **Zenodo sandbox** — DOIs are sandbox-only, not real; no checkpoint needed.
+6. **Native file dialog** handling for F1 (§6).
+7. **Cross-account local dir collisions** — verify per-persona `repoDirectory` prevents fork vs
+   upstream clone clashes.
+
+---
+
+## Appendix — coverage cross-reference to the existing self-test
+
+`MorphoDepotTest.test_MorphoDepot1` (`:6236`) already walks: create→publish (B1), issue
+create/assign (fixture seeding), annotate commit→ready PR (C1), review request-changes/approve/
+merge (D1), address-feedback loop (C1↔D1), release with change-log + cleanup (E1), pre-release
+announcement (E2). This plan reproduces that coverage **through the GUI** and adds the
+permission-matrix scenarios (B3, D2, archival/short-term split) that the handler-driven test
+does not exercise.


### PR DESCRIPTION
## What this is

Accumulated `org-development` extension work from the App-mediated publish/release governance build, plus UI and contributor-credit fixes found during hands-on Slicer testing. Opened against `org-development` for the automated review.

## Highlights to review

**Release — Option C (history-safe).** Org/archival releases push a `release-candidate-<tag>` branch and request App review; `main` is fast-forwarded only on approval, so an unapproved or resubmitted release can never rewrite `main`/history. See `prepareReleaseSnapshot`, `createRelease`.

**No-change guards (M6).**
- Baseline `_baselineMatchesCommittedFile` (+ `_committedSegmentCount`) compares segment count + compressed file size, dropping the unreliable `GetModifiedSinceRead` fast-path that reported added segments as "unchanged". The earlier version resampled every segment onto the full source-volume grid and froze the UI.
- Color `_colorTableMatchesCommitted` only warns when a *different* node is byte-identical; the loaded/unchanged color table no longer false-warns.

**Review robustness.** `requestChanges` posts a PR comment when the reviewer authored the PR (GitHub forbids requesting changes on your own PR), mirroring `approvePR`. `_openPRForBranch` does an authoritative PR-existence check to avoid a duplicate PR under RepoClerk journal lag.

**Contributor credit (F2).** `_enrichMembersViaApi` fills the stable numeric `github_id` for every contributor row (members and already-named rows).

**Create tab (F4).** Auto-suggested, metadata-derived repo name (`genus-species-modality-contents`), editable, with a debounced availability check (`_checkSuggestedRepoNameAvailability`) and a naming-guidelines link.

## Testing

App-side flows verified on the JS2 box (Option C candidate/approve, `github_id` resolve, dup-volume email rendering). Extension UI changes await a manual Slicer pass; see `MorphoDepot/Testing/MorphoDepot_UI_Test_Plan.md`.

## Notes for the reviewer

Several counterpart pieces (review email, DOI mint, duplicate-volume warning) live in the separate `morphodepot-intake` service and are not in this diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
