### PR TITLE
Part E: bad-input guards (empty baseline, non-terminology color table) + stress tests

### DIFF
--- a/MorphoDepot/MorphoDepot.py
+++ b/MorphoDepot/MorphoDepot.py
@@ -57,6 +57,7 @@ from MorphoDepotLib.widget_annotate import AnnotateTabMixin
 from MorphoDepotLib.widget_review import ReviewTabMixin
 from MorphoDepotLib.widget_release import ReleaseTabMixin
 from MorphoDepotLib.widget_search import SearchTabMixin
+from MorphoDepotLib.widget_validation import ValidationMixin
 
 
 class MorphoDepot(ScriptedLoadableModule):
@@ -149,7 +150,7 @@ class EnableModuleMixin:
         return True
 
 
-class MorphoDepotWidget(ScriptedLoadableModuleWidget, VTKObservationMixin, EnableModuleMixin, CreateTabMixin, ConfigureTabMixin, AnnotateTabMixin, ReviewTabMixin, ReleaseTabMixin, SearchTabMixin):
+class MorphoDepotWidget(ScriptedLoadableModuleWidget, VTKObservationMixin, EnableModuleMixin, ValidationMixin, CreateTabMixin, ConfigureTabMixin, AnnotateTabMixin, ReviewTabMixin, ReleaseTabMixin, SearchTabMixin):
     """Uses ScriptedLoadableModuleWidget base class, available at:
     https://github.com/Slicer/Slicer/blob/main/Base/Python/slicer/ScriptedLoadableModule.py
     """

--- a/MorphoDepot/MorphoDepotLib/widget_create.py
+++ b/MorphoDepot/MorphoDepotLib/widget_create.py
@@ -536,6 +536,14 @@ class CreateTabMixin:
                 "Use the 'All nodes' tab of the Data module to access the color table and right-click to rename.")
             return None
 
+        # Part E bad-input guard: a selected-but-empty baseline segmentation would stage an empty
+        # baseline. (Color-table terminology is validated below for archival / warned for short-term.)
+        if self._segmentationIsEmpty(sourceSegmentation):
+            if not slicer.util.confirmOkCancelDisplay(
+                    "The selected baseline segmentation has no segments. Stage it anyway (the "
+                    "repository would start with an empty baseline)?", windowTitle="Empty baseline"):
+                return None
+
         accessionData = self.createUI.accessionForm.accessionData()
         accessionData['scanDimensions'] = str(sourceVolume.GetImageData().GetDimensions())
         accessionData['scanSpacing'] = str(sourceVolume.GetSpacing())

--- a/MorphoDepot/MorphoDepotLib/widget_create.py
+++ b/MorphoDepot/MorphoDepotLib/widget_create.py
@@ -539,9 +539,9 @@ class CreateTabMixin:
         # Part E bad-input guard: a selected-but-empty baseline segmentation would stage an empty
         # baseline. (Color-table terminology is validated below for archival / warned for short-term.)
         if self._segmentationIsEmpty(sourceSegmentation):
-            if not slicer.util.confirmOkCancelDisplay(
+            if not (self.testingMode or slicer.util.confirmOkCancelDisplay(
                     "The selected baseline segmentation has no segments. Stage it anyway (the "
-                    "repository would start with an empty baseline)?", windowTitle="Empty baseline"):
+                    "repository would start with an empty baseline)?", windowTitle="Empty baseline")):
                 return None
 
         accessionData = self.createUI.accessionForm.accessionData()

--- a/MorphoDepot/MorphoDepotLib/widget_release.py
+++ b/MorphoDepot/MorphoDepotLib/widget_release.py
@@ -333,6 +333,22 @@ class ReleaseTabMixin:
 
     # Search
 
+    def _segmentationIsEmpty(self, node):
+        """True if the segmentation has no segments (nothing to release/credit)."""
+        try:
+            return node is not None and node.GetSegmentation().GetNumberOfSegments() == 0
+        except Exception:
+            return False
+
+    def _colorTableNotTerminology(self, node):
+        """True if the color node does not look like a discrete terminology color table -- e.g. a
+        built-in continuous colormap (Rainbow/Grey/...) or generic Labels.  A real MorphoDepot color
+        table is loaded from a file or built by the user (type 'File'/'User').  False on any error."""
+        try:
+            return node is not None and node.GetTypeAsString() not in ("File", "User")
+        except Exception:
+            return False
+
     def onMakeRelease(self):
         if not self.logic.localRepo:
             return
@@ -340,6 +356,22 @@ class ReleaseTabMixin:
         colorTableNode = self.releaseUI.newColorSelector.currentNode()
         if baselineNode is None or colorTableNode is None:
             return
+
+        # Part E bad-input guards: an empty baseline or a non-terminology (e.g. continuous) color
+        # table would publish a broken release.  Warn (consistent with the no-change warnings below).
+        if self._segmentationIsEmpty(baselineNode):
+            if not (self.testingMode or slicer.util.confirmOkCancelDisplay(
+                    "The selected baseline segmentation has no segments, so this release would "
+                    "publish an empty baseline.\n\nProceed anyway?", windowTitle="Empty baseline")):
+                return
+        if self._colorTableNotTerminology(colorTableNode):
+            if not (self.testingMode or slicer.util.confirmOkCancelDisplay(
+                    f"The selected color table '{colorTableNode.GetName()}' (type "
+                    f"'{colorTableNode.GetTypeAsString()}') does not look like a terminology color "
+                    "table loaded from a file -- it may be a built-in continuous colormap. MorphoDepot "
+                    "expects a discrete, terminology-based color table.\n\nUse it anyway?",
+                    windowTitle="Color table not terminology")):
+                return
 
         nameWithOwner = self.logic.nameWithOwner("origin")
         newTag = self.logic.nextReleaseTag()

--- a/MorphoDepot/MorphoDepotLib/widget_release.py
+++ b/MorphoDepot/MorphoDepotLib/widget_release.py
@@ -333,22 +333,6 @@ class ReleaseTabMixin:
 
     # Search
 
-    def _segmentationIsEmpty(self, node):
-        """True if the segmentation has no segments (nothing to release/credit)."""
-        try:
-            return node is not None and node.GetSegmentation().GetNumberOfSegments() == 0
-        except Exception:
-            return False
-
-    def _colorTableNotTerminology(self, node):
-        """True if the color node does not look like a discrete terminology color table -- e.g. a
-        built-in continuous colormap (Rainbow/Grey/...) or generic Labels.  A real MorphoDepot color
-        table is loaded from a file or built by the user (type 'File'/'User').  False on any error."""
-        try:
-            return node is not None and node.GetTypeAsString() not in ("File", "User")
-        except Exception:
-            return False
-
     def onMakeRelease(self):
         if not self.logic.localRepo:
             return

--- a/MorphoDepot/MorphoDepotLib/widget_validation.py
+++ b/MorphoDepot/MorphoDepotLib/widget_validation.py
@@ -1,0 +1,23 @@
+"""Shared input-validation helpers used by both the Create and Release tabs.
+
+Kept in a dedicated mixin (rather than living on one tab mixin and being called from another)
+so the dependency is explicit and either tab can use them without an implicit cross-tab coupling.
+"""
+
+
+class ValidationMixin:
+    def _segmentationIsEmpty(self, node):
+        """True if the segmentation has no segments (nothing to release/credit)."""
+        try:
+            return node is not None and node.GetSegmentation().GetNumberOfSegments() == 0
+        except Exception:
+            return False
+
+    def _colorTableNotTerminology(self, node):
+        """True if the color node does not look like a discrete terminology color table -- e.g. a
+        built-in continuous colormap (Rainbow/Grey/...) or generic Labels.  A real MorphoDepot color
+        table is loaded from a file or built by the user (type 'File'/'User').  False on any error."""
+        try:
+            return node is not None and node.GetTypeAsString() not in ("File", "User")
+        except Exception:
+            return False

--- a/MorphoDepot/Testing/Python/md_tests.py
+++ b/MorphoDepot/Testing/Python/md_tests.py
@@ -127,8 +127,9 @@ def _stress_continuous_colortable_guard():
     # Part E: a continuous/built-in colormap must be flagged; a File/User terminology table must not.
     assert H.w._colorTableNotTerminology(slicer.util.getNode("Rainbow")), "Rainbow (continuous) not flagged"
     assert H.w._colorTableNotTerminology(slicer.util.getNode("Grey")), "Grey (continuous) not flagged"
-    assert not H.w._colorTableNotTerminology(slicer.util.getNode("GenericAnatomyColors")), \
-        "File terminology table wrongly flagged"
+    terminologyNode = slicer.util.getNode("GenericAnatomyColors")
+    assert terminologyNode is not None, "GenericAnatomyColors not in scene (positive case can't run)"
+    assert not H.w._colorTableNotTerminology(terminologyNode), "File terminology table wrongly flagged"
 
 
 def _stress_invalid_repo_name():

--- a/MorphoDepot/Testing/Python/md_tests.py
+++ b/MorphoDepot/Testing/Python/md_tests.py
@@ -112,7 +112,41 @@ def _annotate_tab_touch():
     assert H.w.annotateUI.commitButton is not None
 
 
+def _stress_empty_segmentation_guard():
+    # Part E: an empty baseline segmentation must be detected (would publish an empty baseline).
+    seg = slicer.mrmlScene.AddNewNodeByClass("vtkMRMLSegmentationNode", "stress-empty")
+    try:
+        assert H.w._segmentationIsEmpty(seg), "empty segmentation not detected"
+        seg.GetSegmentation().AddEmptySegment("a")
+        assert not H.w._segmentationIsEmpty(seg), "non-empty segmentation flagged as empty"
+    finally:
+        slicer.mrmlScene.RemoveNode(seg)
+
+
+def _stress_continuous_colortable_guard():
+    # Part E: a continuous/built-in colormap must be flagged; a File/User terminology table must not.
+    assert H.w._colorTableNotTerminology(slicer.util.getNode("Rainbow")), "Rainbow (continuous) not flagged"
+    assert H.w._colorTableNotTerminology(slicer.util.getNode("Grey")), "Grey (continuous) not flagged"
+    assert not H.w._colorTableNotTerminology(slicer.util.getNode("GenericAnatomyColors")), \
+        "File terminology table wrongly flagged"
+
+
+def _stress_invalid_repo_name():
+    # Part E: a malformed repo name must keep Create disabled (form regex guard).
+    H.goTab("Create")
+    H.fillValidForm(name="valid-name", shortTerm=True)
+    assert H.w.createUI.createRepository.enabled, "valid name should enable Create"
+    f = H.form()
+    f.userEditedRepoName = True
+    f.questions["githubRepoName"].answerText.text = "bad name!"   # space + '!' -> invalid
+    H.pump(60)
+    assert not H.w.createUI.createRepository.enabled, "invalid repo name should keep Create disabled"
+
+
 TESTS = [
+    ("stress_empty_segmentation_guard", _stress_empty_segmentation_guard),
+    ("stress_continuous_colortable_guard", _stress_continuous_colortable_guard),
+    ("stress_invalid_repo_name", _stress_invalid_repo_name),
     ("create_redistribution_gate", _create_redistribution_gate),
     ("create_f4_name_suggestion", _create_f4_name_suggestion),
     ("create_repotype_shortterm_personal", _create_repotype_shortterm_personal),


### PR DESCRIPTION
## What this is

Part E of the refactor/test plan: the **bad-input / stress** hardening pass on the now-modular code. Driven by stress-probing the real UI via the test harness, this adds guards for the malformed inputs the workflow didn't previously catch, and pins them with tests. Net is **15/15** (12 workflow + 3 stress).

## Gaps found + hardened

- **Empty baseline segmentation.** Neither the Release nor Create path checked that a selected segmentation actually has segments — an empty baseline could be released/staged. Added `_segmentationIsEmpty()` and a warn-to-proceed in `onMakeRelease` and `_collectAccessionInputs`.
- **Non-terminology color table at Release.** `onMakeRelease` had no color-table validation, so a built-in continuous colormap (Rainbow/Grey, `type` not `File`/`User`) could be selected. Added `_colorTableNotTerminology()` + a warn-to-proceed. (Create already validates terminology per-color: archival hard-blocks a missing entry, short-term warns + offers to fill — so that path was already covered.)

## Already-validated (verified, no change)

- **Repo name.** The accession-form regex already rejects malformed names (keeps Create disabled) — added a stress test that pins it.
- **Source volume / color-table node names** — already regex-checked in `_collectAccessionInputs`.

## Notes

- All guards are **warn-to-proceed** (`confirmOkCancelDisplay`), consistent with the existing no-change/announcement warnings — they make the bad input visible without hard-blocking an intentional edge case.
- "Non-binary segmentation" isn't separately guarded: the selectors already filter to `vtkMRMLSegmentationNode` (binary labelmaps by construction), so the actionable bad-input there is the empty case, now covered.
- App-unreachable / 5xx is handled by the existing tri-state membership design (not a UI-input guard).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
