### PR TITLE
Fix color-table type check (UserDefined), found by E2E probing + E2E groundwork

### DIFF
--- a/MorphoDepot/MorphoDepotLib/logic_accession.py
+++ b/MorphoDepot/MorphoDepotLib/logic_accession.py
@@ -201,7 +201,7 @@ jobs:
         repoFileNames.append(f"{colorTableName}.csv")
 
         # write accessionData file
-        accessionData['fileFormatVersion'] = MorphoDepotLogic.accessionFileFormatVersion
+        accessionData['fileFormatVersion'] = self.accessionFileFormatVersion
         fp = open(os.path.join(repoDir, "MorphoDepotAccession.json"), "w")
         fp.write(json.dumps(accessionData, indent=4))
         fp.close()
@@ -265,7 +265,7 @@ jobs:
             workflowDir = os.path.join(repoDir, ".github", "workflows")
             os.makedirs(workflowDir, exist_ok=True)
             with open(os.path.join(workflowDir, "auto-assign.yml"), "w") as fp:
-                fp.write(MorphoDepotLogic.autoAssignWorkflow)
+                fp.write(self.autoAssignWorkflow)
             repoFileNames.append(os.path.join(".github", "workflows", "auto-assign.yml"))
 
         repoFilePaths = [os.path.join(repoDir, fileName) for fileName in repoFileNames]
@@ -730,7 +730,7 @@ jobs:
         priorSpecies = self._speciesFromReadme(repoDir)
 
         # Regenerate the metadata-derived files from the edited data.
-        accessionData['fileFormatVersion'] = MorphoDepotLogic.accessionFileFormatVersion
+        accessionData['fileFormatVersion'] = self.accessionFileFormatVersion
         with open(os.path.join(repoDir, "MorphoDepotAccession.json"), "w") as fp:
             fp.write(json.dumps(accessionData, indent=4))
 

--- a/MorphoDepot/MorphoDepotLib/widget_validation.py
+++ b/MorphoDepot/MorphoDepotLib/widget_validation.py
@@ -16,8 +16,11 @@ class ValidationMixin:
     def _colorTableNotTerminology(self, node):
         """True if the color node does not look like a discrete terminology color table -- e.g. a
         built-in continuous colormap (Rainbow/Grey/...) or generic Labels.  A real MorphoDepot color
-        table is loaded from a file or built by the user (type 'File'/'User').  False on any error."""
+        table is loaded from a file ('File') or built by the user ('UserDefined' -- note: NOT 'User',
+        which is what a User-type node's GetTypeAsString() actually returns).  False on any error.
+        (Terminology presence alone does not discriminate -- even File anatomy tables can report no
+        per-entry terminology -- so this keys on the source type.)"""
         try:
-            return node is not None and node.GetTypeAsString() not in ("File", "User")
+            return node is not None and node.GetTypeAsString() not in ("File", "UserDefined")
         except Exception:
             return False

--- a/MorphoDepot/Testing/Python/md_e2e.py
+++ b/MorphoDepot/Testing/Python/md_e2e.py
@@ -43,6 +43,58 @@ def setupCreateFixtures():
     return vol, ct
 
 
+def e2eCreate(name, archival):
+    """Drive Create to STAGE a real repo (short-term=personal, archival=org). Auto-accepts the
+    custom confirmation modal and disables auto-assign (skips the workflow push). Returns the
+    staged nameWithOwner (or an error)."""
+    vol, ct = setupCreateFixtures()
+    H.fillValidForm(name=name, shortTerm=not archival)
+    H.w.createUI.inputSelector.setCurrentNode(vol)
+    H.w.createUI.colorSelector.setCurrentNode(ct)
+    H.w.createUI.autoAssignCheckBox.checked = False
+    slicer.app.processEvents()
+    orig = H.w.showConfirmationDialog
+    H.w.showConfirmationDialog = lambda *a, **k: True   # auto-accept (it's a custom QDialog)
+    H.dialogLog = []
+    err = None
+    try:
+        H.w.onCreateRepository()
+    except Exception as e:
+        import traceback
+        err = {"err": str(e), "tb": traceback.format_exc().splitlines()[-5:]}
+    finally:
+        H.w.showConfirmationDialog = orig
+    H.pump(200)
+    return {"staged": getattr(H.w, "_stagedNameWithOwner", None), "dialogs": H.shown(), "error": err}
+
+
+def e2eDiscard():
+    """Drive Discard to delete the currently-staged repo (teardown). Confirm dialog auto-answered."""
+    H.dialogLog = []
+    err = None
+    try:
+        H.w.onDiscard()
+    except Exception as e:
+        err = str(e)
+    H.pump(200)
+    return {"staged": getattr(H.w, "_stagedNameWithOwner", None), "dialogs": H.shown(), "error": err}
+
+
+def e2ePublish():
+    """Drive Make Public (onPublish). For an archival repo this requests review (the gate); the
+    repo stays staged + pending. Returns staged name + dialog texts."""
+    H.dialogLog = []
+    err = None
+    try:
+        H.w.onPublish()
+    except Exception as e:
+        import traceback
+        err = {"err": str(e), "tb": traceback.format_exc().splitlines()[-5:]}
+    H.pump(200)
+    return {"staged": getattr(H.w, "_stagedNameWithOwner", None), "dialogs": H.shown(),
+            "texts": [d["text"][:200] for d in H.dialogLog], "error": err}
+
+
 def probeCreateValidation(archival=True, name="mdtest-e2e-probe"):
     """Set up fixtures + fill the form, then run _collectAccessionInputs WITHOUT creating a repo.
     Returns whether validation passed + what (if any) dialogs it raised + a peek at the color check."""

--- a/MorphoDepot/Testing/Python/md_e2e.py
+++ b/MorphoDepot/Testing/Python/md_e2e.py
@@ -10,10 +10,11 @@ E2E_COLOR = "mdteste2ecolors"
 
 
 def _rm(name):
-    n = slicer.mrmlScene.GetFirstNodeByName(name)
-    while n:
-        slicer.mrmlScene.RemoveNode(n)
+    for _ in range(100):          # bounded so a stuck node can't spin forever
         n = slicer.mrmlScene.GetFirstNodeByName(name)
+        if not n:
+            break
+        slicer.mrmlScene.RemoveNode(n)
 
 
 def setupCreateFixtures():
@@ -56,7 +57,7 @@ def probeCreateValidation(archival=True, name="mdtest-e2e-probe"):
         "collectOK": inp is not None,
         "dialogs": H.shown(),
         "colorType": ct.GetTypeAsString(),
-        "term1": ct.GetTerminologyAsString(1)[:40],
+        "term1": (ct.GetTerminologyAsString(1) or "")[:40],
         "notTerminology": H.w._colorTableNotTerminology(ct),
         "volDims": str(vol.GetImageData().GetDimensions()) if vol.GetImageData() else None,
     }

--- a/MorphoDepot/Testing/Python/md_e2e.py
+++ b/MorphoDepot/Testing/Python/md_e2e.py
@@ -1,0 +1,62 @@
+"""End-to-end fixtures + flows: drive REAL create / publish / release against live GitHub + the
+App (test-mode). Uses the global `H` (Harness). These are heavier and stateful, kept separate from
+the fast workflow net. A repo named with the mdtest- prefix routes through the App test-mode (no
+reviewer email; approve-id fetchable via /repos/_test/pending)."""
+import slicer
+import numpy as np
+
+E2E_VOL = "mdteste2evol"
+E2E_COLOR = "mdteste2ecolors"
+
+
+def _rm(name):
+    n = slicer.mrmlScene.GetFirstNodeByName(name)
+    while n:
+        slicer.mrmlScene.RemoveNode(n)
+        n = slicer.mrmlScene.GetFirstNodeByName(name)
+
+
+def setupCreateFixtures():
+    """A synthetic source volume + a User terminology color table, selected in the Create tab."""
+    _rm(E2E_VOL)
+    _rm(E2E_COLOR)
+    vol = slicer.mrmlScene.AddNewNodeByClass("vtkMRMLScalarVolumeNode", E2E_VOL)
+    arr = np.zeros((20, 20, 20), "int16")
+    arr[5:15, 5:15, 5:15] = 200
+    slicer.util.updateVolumeFromArray(vol, arr)
+
+    ct = slicer.mrmlScene.AddNewNodeByClass("vtkMRMLColorTableNode", E2E_COLOR)
+    ct.SetTypeToUser()
+    ct.SetNumberOfColors(3)
+    ct.SetColor(0, "Background", 0.0, 0.0, 0.0, 0.0)
+    ct.SetColor(1, "StructureA", 1.0, 0.0, 0.0, 1.0)
+    ct.SetTerminology(1, "SCT", "85756007", "Tissue", "SCT", "85756007", "Tissue")
+    ct.SetColor(2, "StructureB", 0.0, 1.0, 0.0, 1.0)
+    ct.SetTerminology(2, "SCT", "85756007", "Tissue", "SCT", "85756007", "Tissue")
+
+    H.goTab("Create")
+    H.w.createUI.inputSelector.setCurrentNode(vol)
+    H.w.createUI.colorSelector.setCurrentNode(ct)
+    H.w.createUI.segmentationSelector.setCurrentNode(None)
+    slicer.app.processEvents()
+    return vol, ct
+
+
+def probeCreateValidation(archival=True, name="mdtest-e2e-probe"):
+    """Set up fixtures + fill the form, then run _collectAccessionInputs WITHOUT creating a repo.
+    Returns whether validation passed + what (if any) dialogs it raised + a peek at the color check."""
+    vol, ct = setupCreateFixtures()
+    H.fillValidForm(name=name, shortTerm=not archival)
+    # fillValidForm doesn't touch the node selectors, re-assert them just in case
+    H.w.createUI.inputSelector.setCurrentNode(vol)
+    H.w.createUI.colorSelector.setCurrentNode(ct)
+    slicer.app.processEvents()
+    inp = H.w._collectAccessionInputs()
+    return {
+        "collectOK": inp is not None,
+        "dialogs": H.shown(),
+        "colorType": ct.GetTypeAsString(),
+        "term1": ct.GetTerminologyAsString(1)[:40],
+        "notTerminology": H.w._colorTableNotTerminology(ct),
+        "volDims": str(vol.GetImageData().GetDimensions()) if vol.GetImageData() else None,
+    }

--- a/MorphoDepot/Testing/Python/md_tests.py
+++ b/MorphoDepot/Testing/Python/md_tests.py
@@ -130,6 +130,14 @@ def _stress_continuous_colortable_guard():
     terminologyNode = slicer.util.getNode("GenericAnatomyColors")
     assert terminologyNode is not None, "GenericAnatomyColors not in scene (positive case can't run)"
     assert not H.w._colorTableNotTerminology(terminologyNode), "File terminology table wrongly flagged"
+    # a user-built table reports type 'UserDefined' (NOT 'User') and must not be flagged
+    ud = slicer.mrmlScene.AddNewNodeByClass("vtkMRMLColorTableNode", "stress-ud")
+    ud.SetTypeToUser(); ud.SetNumberOfColors(2); ud.SetColor(1, "A", 1.0, 0.0, 0.0, 1.0)
+    try:
+        assert ud.GetTypeAsString() == "UserDefined", f"unexpected user type {ud.GetTypeAsString()!r}"
+        assert not H.w._colorTableNotTerminology(ud), "UserDefined table wrongly flagged"
+    finally:
+        slicer.mrmlScene.RemoveNode(ud)
 
 
 def _stress_invalid_repo_name():

--- a/MorphoDepot/Testing/Python/md_tests.py
+++ b/MorphoDepot/Testing/Python/md_tests.py
@@ -132,7 +132,9 @@ def _stress_continuous_colortable_guard():
     assert not H.w._colorTableNotTerminology(terminologyNode), "File terminology table wrongly flagged"
     # a user-built table reports type 'UserDefined' (NOT 'User') and must not be flagged
     ud = slicer.mrmlScene.AddNewNodeByClass("vtkMRMLColorTableNode", "stress-ud")
-    ud.SetTypeToUser(); ud.SetNumberOfColors(2); ud.SetColor(1, "A", 1.0, 0.0, 0.0, 1.0)
+    ud.SetTypeToUser()
+    ud.SetNumberOfColors(2)
+    ud.SetColor(1, "A", 1.0, 0.0, 0.0, 1.0)
     try:
         assert ud.GetTypeAsString() == "UserDefined", f"unexpected user type {ud.GetTypeAsString()!r}"
         assert not H.w._colorTableNotTerminology(ud), "UserDefined table wrongly flagged"


### PR DESCRIPTION
## What this is

The start of the **in-depth / end-to-end** test layer — and it immediately paid off by finding a real bug in already-merged code.

## Bug found + fixed

The Part E guard `_colorTableNotTerminology` (PR #150) allowed `('File', 'User')`, but a user-built color table actually reports `GetTypeAsString()` == **`'UserDefined'`** (not `'User'`). So a legitimate user-built terminology table was wrongly flagged as "not a terminology table." The stress test missed it because it only exercised `File` + continuous types; the E2E fixture (a `UserDefined` table) caught it. Fixed the allowed set to `('File', 'UserDefined')` and added a `UserDefined` regression assertion. (Terminology presence alone can't discriminate — even `GenericAnatomyColors`, a legit `File` table, reports all-missing per-entry terminology — so the guard keys on source type.)

## E2E groundwork

Adds `MorphoDepot/Testing/Python/md_e2e.py`: a synthetic source volume + a `UserDefined` terminology color table, and a create-validation probe that drives the Create tab and runs `_collectAccessionInputs` **without** creating a repo — verified to pass for archival. The full create→publish→release flows (real GitHub via the App test-mode) build on this.

## Counterpart (separate repo)

The App **test-mode** that makes the gate drivable (skip review email for `mdtest-*` repos + a token-gated `GET /repos/_test/pending/{name}`) is already committed + deployed in `morphodepot-intake` (`fba3283`).

Net 15/15.

🤖 Generated with [Claude Code](https://claude.com/claude-code)