### PR TITLE
E2E: full archival lifecycle (create→publish→Option-C release) with DOI versioning

### DIFF
--- a/MorphoDepot/Testing/Python/md_e2e.py
+++ b/MorphoDepot/Testing/Python/md_e2e.py
@@ -17,8 +17,36 @@ def _rm(name):
         slicer.mrmlScene.RemoveNode(n)
 
 
-def setupCreateFixtures():
-    """A synthetic source volume + a User terminology color table, selected in the Create tab."""
+def makeBaseline(name, nsegs, vol=None):
+    """A segmentation in the source-volume geometry with `nsegs` disjoint labeled blocks (so it has
+    real segments + voxels). Used as the create baseline and, with a different nsegs + the loaded
+    repo's volume, as the changed release baseline (M6 keys on segment count)."""
+    import vtk
+    _rm(name)
+    if vol is None:
+        vol = slicer.mrmlScene.GetFirstNodeByName(E2E_VOL)
+    shape = slicer.util.arrayFromVolume(vol).shape
+    lm = np.zeros(shape, "uint8")
+    for i in range(nsegs):
+        s = 2 + i * 4
+        lm[s:s + 3, s:s + 3, s:s + 3] = i + 1
+    labelVol = slicer.mrmlScene.AddNewNodeByClass("vtkMRMLLabelMapVolumeNode", name + "-lm")
+    labelVol.SetSpacing(vol.GetSpacing())
+    labelVol.SetOrigin(vol.GetOrigin())
+    m = vtk.vtkMatrix4x4()
+    vol.GetIJKToRASDirectionMatrix(m)
+    labelVol.SetIJKToRASDirectionMatrix(m)
+    slicer.util.updateVolumeFromArray(labelVol, lm)
+    seg = slicer.mrmlScene.AddNewNodeByClass("vtkMRMLSegmentationNode", name)
+    seg.SetReferenceImageGeometryParameterFromVolumeNode(vol)
+    slicer.modules.segmentations.logic().ImportLabelmapToSegmentationNode(labelVol, seg)
+    slicer.mrmlScene.RemoveNode(labelVol)
+    return seg
+
+
+def setupCreateFixtures(baselineSegs=0):
+    """A synthetic source volume + a User terminology color table (+ optional baseline segmentation
+    with `baselineSegs` segments), selected in the Create tab. Returns (vol, color, baseline|None)."""
     _rm(E2E_VOL)
     _rm(E2E_COLOR)
     vol = slicer.mrmlScene.AddNewNodeByClass("vtkMRMLScalarVolumeNode", E2E_VOL)
@@ -35,19 +63,20 @@ def setupCreateFixtures():
     ct.SetColor(2, "StructureB", 0.0, 1.0, 0.0, 1.0)
     ct.SetTerminology(2, "SCT", "85756007", "Tissue", "SCT", "85756007", "Tissue")
 
+    seg = makeBaseline("mdteste2ebaseline", baselineSegs) if baselineSegs else None
     H.goTab("Create")
     H.w.createUI.inputSelector.setCurrentNode(vol)
     H.w.createUI.colorSelector.setCurrentNode(ct)
-    H.w.createUI.segmentationSelector.setCurrentNode(None)
+    H.w.createUI.segmentationSelector.setCurrentNode(seg)
     slicer.app.processEvents()
-    return vol, ct
+    return vol, ct, seg
 
 
-def e2eCreate(name, archival):
+def e2eCreate(name, archival, baselineSegs=0):
     """Drive Create to STAGE a real repo (short-term=personal, archival=org). Auto-accepts the
     custom confirmation modal and disables auto-assign (skips the workflow push). Returns the
     staged nameWithOwner (or an error)."""
-    vol, ct = setupCreateFixtures()
+    vol, ct, seg = setupCreateFixtures(baselineSegs)
     H.fillValidForm(name=name, shortTerm=not archival)
     H.w.createUI.inputSelector.setCurrentNode(vol)
     H.w.createUI.colorSelector.setCurrentNode(ct)
@@ -69,7 +98,8 @@ def e2eCreate(name, archival):
 
 
 def e2eDiscard():
-    """Drive Discard to delete the currently-staged repo (teardown). Confirm dialog auto-answered."""
+    """Drive Discard to delete the currently-staged repo (teardown). Confirm dialog auto-answered
+    by the harness; the member/archival path routes through the App (no UI confirm)."""
     H.dialogLog = []
     err = None
     try:
@@ -95,10 +125,61 @@ def e2ePublish():
             "texts": [d["text"][:200] for d in H.dialogLog], "error": err}
 
 
+def e2eLoadForRelease(nwo):
+    """Drive the Release tab to load a published repo (refresh -> double-click). Returns whether it
+    loaded + the committed baseline's segment count."""
+    H.goTab("Release")
+    H.w.onRefreshReleaseTab()
+    H.pump(500)
+    item = None
+    for it, rd in (getattr(H.w, "reposByItem", {}) or {}).items():
+        if rd.get("nameWithOwner") == nwo:
+            item = it
+            break
+    if item is None:
+        return {"loaded": False, "repos": [rd.get("nameWithOwner")
+                for rd in (getattr(H.w, "reposByItem", {}) or {}).values()][:15]}
+    H.w.onReleaseRepoDoubleClicked(item)
+    H.pump(800)   # clone + load
+    bl = getattr(H.w.logic, "baselineSegmentationNode", None)
+    return {"loaded": H.w.logic.localRepo is not None,
+            "currentRepo": H.w.releaseUI.currentRepoLabel.text,
+            "committedBaselineSegs": bl.GetSegmentation().GetNumberOfSegments() if bl else None,
+            "colorSelected": H.w.releaseUI.newColorSelector.currentNode() is not None}
+
+
+def e2eChangedBaseline(nsegs):
+    """Build a new baseline (nsegs) in the LOADED repo's source-volume geometry + select it as the
+    release baseline. Returns whether Make Release is now enabled."""
+    vol = slicer.mrmlScene.GetFirstNodeByName(getattr(H.w.logic, "sourceVolumeName", "") or "")
+    if vol is None:
+        vols = slicer.util.getNodesByClass("vtkMRMLScalarVolumeNode")
+        vol = vols[0] if vols else None
+    seg = makeBaseline("mdteste2e-newbaseline", nsegs, vol=vol)
+    H.w.releaseUI.newBaselineSelector.setCurrentNode(seg)
+    slicer.app.processEvents()
+    return {"newBaselineSegs": seg.GetSegmentation().GetNumberOfSegments(),
+            "makeEnabled": H.w.releaseUI.makeReleaseButton.enabled}
+
+
+def e2eMakeRelease():
+    """Drive Make Release (onMakeRelease). For an archival repo this pushes a candidate + requests
+    review (gate). Returns dialog texts (so callers can see M6/announcement/credit prompts)."""
+    H.dialogLog = []
+    err = None
+    try:
+        H.w.onMakeRelease()
+    except Exception as e:
+        import traceback
+        err = {"err": str(e), "tb": traceback.format_exc().splitlines()[-6:]}
+    H.pump(400)
+    return {"dialogs": H.shown(), "texts": [d["text"][:160] for d in H.dialogLog], "error": err}
+
+
 def probeCreateValidation(archival=True, name="mdtest-e2e-probe"):
     """Set up fixtures + fill the form, then run _collectAccessionInputs WITHOUT creating a repo.
     Returns whether validation passed + what (if any) dialogs it raised + a peek at the color check."""
-    vol, ct = setupCreateFixtures()
+    vol, ct, seg = setupCreateFixtures()
     H.fillValidForm(name=name, shortTerm=not archival)
     # fillValidForm doesn't touch the node selectors, re-assert them just in case
     H.w.createUI.inputSelector.setCurrentNode(vol)

--- a/MorphoDepot/Testing/Python/md_e2e.py
+++ b/MorphoDepot/Testing/Python/md_e2e.py
@@ -26,6 +26,8 @@ def makeBaseline(name, nsegs, vol=None):
     if vol is None:
         vol = slicer.mrmlScene.GetFirstNodeByName(E2E_VOL)
     shape = slicer.util.arrayFromVolume(vol).shape
+    if nsegs and (2 + (nsegs - 1) * 4 + 3) > min(shape):
+        raise ValueError(f"nsegs={nsegs} too large for volume shape {shape} (blocks would clip)")
     lm = np.zeros(shape, "uint8")
     for i in range(nsegs):
         s = 2 + i * 4
@@ -153,8 +155,12 @@ def e2eChangedBaseline(nsegs):
     release baseline. Returns whether Make Release is now enabled."""
     vol = slicer.mrmlScene.GetFirstNodeByName(getattr(H.w.logic, "sourceVolumeName", "") or "")
     if vol is None:
-        vols = slicer.util.getNodesByClass("vtkMRMLScalarVolumeNode")
+        # fallback: a loaded scalar volume that is NOT the create-fixture volume (wrong geometry)
+        vols = [v for v in slicer.util.getNodesByClass("vtkMRMLScalarVolumeNode")
+                if v.GetName() != E2E_VOL]
         vol = vols[0] if vols else None
+    if vol is None:
+        return {"error": "no loaded source volume found for the release baseline"}
     seg = makeBaseline("mdteste2e-newbaseline", nsegs, vol=vol)
     H.w.releaseUI.newBaselineSelector.setCurrentNode(seg)
     slicer.app.processEvents()


### PR DESCRIPTION
Completes the in-depth/E2E layer with the **release flow**, verified end-to-end against live GitHub + the App test-mode.

## Verified lifecycle (one real org repo, then torn down)
create (2-seg baseline) → publish → approve → **PUBLIC + v1 DOI** `10.5072/zenodo.516254` → load for release → 3-seg baseline (M6 sees the change) → **Make Release (Option C)**: candidate branch `release-candidate-v2` → gate → approve → **`pre-release-v2` archive** + **main fast-forward** + **v2 tag/release** + **v2 DOI** `516255` (new version under concept `516253`) + **candidate deleted** → teardown (App admin delete).

## Drivers added to `md_e2e.py`
`makeBaseline` (volume-aware), `baselineSegs` in the create fixtures/driver, `e2eLoadForRelease`, `e2eChangedBaseline`, `e2eMakeRelease`.

## Result
The release / Option-C / DOI path was **clean — no bugs** (unlike create, which the E2E found broken). The whole archival lifecycle is now end-to-end verified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)