### PR TITLE
feat(#20): member-driven create + publish (Administration-free extension side)

### DIFF
--- a/MorphoDepot/MorphoDepotLib/logic_accession.py
+++ b/MorphoDepot/MorphoDepotLib/logic_accession.py
@@ -348,10 +348,16 @@ jobs:
         sourceFileName = buildContext["sourceFileName"]
         checksum = buildContext["checksum"]
 
-        self.progressMethod(f"Creating {self.morphoDepotOrg}/{repoName} (private) via the App...")
-        info = self.controlPlaneRequest("repos/create", {"name": repoName})
-        nameWithOwner = info["full_name"]
-        cloneURL = info["clone_url"]
+        # Member-driven create (#20): the member creates the repo in-org with their OWN gh -- they have
+        # create-private rights and become its admin -- instead of asking the App. This is what lets the
+        # App drop its Administration permission. The member (admin) retains push regardless; the
+        # {login}-team grant for other collaborators can be added later without the App.
+        self.progressMethod(f"Creating {self.morphoDepotOrg}/{repoName} (private)...")
+        nameWithOwner = f"{self.morphoDepotOrg}/{repoName}"
+        self.gh(f"repo create {nameWithOwner} --private --disable-wiki")
+        cloneURL = f"https://github.com/{nameWithOwner}.git"
+        # Mark it staged with the member's own gh (members own their topics now; the App does not).
+        self.gh(f"repo edit {nameWithOwner} --add-topic {self.stagingTopic}")
 
         # Push the locally built content to the empty in-org repo (member has Write via team).
         self.localRepo = repo
@@ -503,24 +509,32 @@ jobs:
         return repoNameWithOwner
 
     def _publishStagedRepoInOrg(self, ctx):
-        """Member tier: ask the App to make the staged org repo public.  Going public is a governed
-        event (org-design 11.3): the App routes the request through the MD-reviewers review gate —
-        it emails a signed Approve link and does NOT flip the repo now.  Returns a pending-review
-        dict in that case (the repo stays private + staged until a reviewer approves, after which
-        the App makes it public on its own).  A non-gated immediate publish (backstop) returns the
-        nameWithOwner string, as before."""
+        """Member tier (#20): submit the staged org repo to the App's review gate.  The App validates
+        (#19): on a hard-check failure it AUTO-BOUNCES (returns changes_requested) — the repo stays
+        private + staged and we surface the failures; otherwise it requests review (pending_review).
+        Once a reviewer approves, the App mints the DOI but does NOT flip; the member's repeat publish
+        then gets {status: approved, flip: True}, and the MEMBER flips visibility + sets the discovery
+        topics here with their OWN gh (they are admin of their repo).  Returns a dict (changesRequested
+        / pending) or the public nameWithOwner string once flipped."""
         repoName = ctx["repoName"]
         species = ctx.get("speciesTopicString")
         topics = ["morphodepot"] + ([f"md-{species}"] if species else [])
         finalNameWithOwner = ctx["personalNameWithOwner"]
+        repoDir = ctx.get("repoDir")
         self.progressMethod(f"Submitting {finalNameWithOwner} for review...")
         resp = self.controlPlaneRequest("repos/publish", {"repo": repoName, "topics": topics}) or {}
-        repoDir = ctx.get("repoDir")
+        status = resp.get("status")
 
-        if resp.get("status") == "pending_review":
-            # Review requested.  The repo is still private and still carries morphodepot-staging,
-            # so it remains in the unpublished list; drop only the transient local clone (reopen
-            # re-clones).  Do NOT notify RepoClerk (nothing public to crawl) or add a contact.
+        if status == "changes_requested":
+            # #19 auto-bounce: automated validation found blocking issues.  The repo stays private +
+            # staged; surface the failures so the curator can fix and re-submit (the local clone is
+            # kept — reopen/edit is unchanged).
+            return {"changesRequested": True, "nameWithOwner": finalNameWithOwner,
+                    "validation": resp.get("validation"), "issueUrl": resp.get("issue_url")}
+
+        if status == "pending_review":
+            # Review requested.  The repo is still private and still carries morphodepot-staging, so it
+            # remains in the unpublished list; drop only the transient local clone (reopen re-clones).
             self.localRepo = None
             if repoDir and os.path.exists(repoDir):
                 shutil.rmtree(repoDir, ignore_errors=True)
@@ -528,14 +542,29 @@ jobs:
             return {"pending": True, "nameWithOwner": finalNameWithOwner,
                     "reviewSentTo": resp.get("review_sent_to")}
 
-        # Backstop: an immediate (non-gated) publish actually made it public — clean up as before.
+        if status == "approved" and resp.get("flip"):
+            # Member-driven go-live (#20): the reviewer approved and the App minted the DOI WITHOUT
+            # flipping.  The MEMBER now flips the repo public and swaps the staging topic for the
+            # discovery topics, both with their own gh — so the App never needs Administration.
+            self.progressMethod(f"Approved -- publishing {finalNameWithOwner}...")
+            self.setRepoVisibility(finalNameWithOwner, public=True)
+            self.addMorphoTopics(finalNameWithOwner, species)
+            self.ghTopicClearCache()
+            self.localRepo = None
+            if repoDir and os.path.exists(repoDir):
+                shutil.rmtree(repoDir, ignore_errors=True)
+            try:
+                self.notifyRepoClerk(finalNameWithOwner)
+            except Exception as e:
+                logging.warning(f"Could not notify RepoClerk of publish: {e}")
+            self.stagingContext = None
+            return finalNameWithOwner
+
+        # Backstop: a non-gated immediate publish (legacy App-flips mode) already made it public.
         self.ghTopicClearCache()
         self.localRepo = None
         if repoDir and os.path.exists(repoDir):
             shutil.rmtree(repoDir, ignore_errors=True)
-        # The repo is now public + topic:morphodepot, so RepoClerk will crawl it — nudge it to
-        # journal the new repo promptly instead of waiting for the next scheduled sweep.
-        # Best-effort: the publish already succeeded, so a notify failure must not surface here.
         try:
             self.notifyRepoClerk(finalNameWithOwner)
         except Exception as e:

--- a/MorphoDepot/MorphoDepotLib/widget_create.py
+++ b/MorphoDepot/MorphoDepotLib/widget_create.py
@@ -853,6 +853,16 @@ class CreateTabMixin:
         except Exception:
             return False
 
+    def _repoHasMintedDoi(self, nameWithOwner):
+        """True if the App already minted a DOI on this still-private repo (``.zenodo/state.json``) --
+        i.e. it was approved and is awaiting the member's flip (#20).  Used to SKIP the edit-resave on
+        a finish-flip, which would otherwise rewrite main and drop the App's DOI citation block."""
+        try:
+            info = self.logic.ghJSON(["api", f"/repos/{nameWithOwner}/contents/.zenodo/state.json"])
+            return isinstance(info, dict) and bool(info.get("sha"))
+        except Exception:
+            return False
+
     def _readRepoFileViaApi(self, nameWithOwner, path):
         """Return (text, sha) for a repo file via the GitHub API, or (None, None) if absent."""
         import base64
@@ -957,10 +967,15 @@ class CreateTabMixin:
                   + (" in the MorphoDepot organization." if isOrg else " on your account."))
         if not (self.testingMode or slicer.util.confirmOkCancelDisplay(prompt, windowTitle="Publish repository")):
             return
+        # Member-driven finish (#20): a resumed repo that is already approved (the App minted its DOI on
+        # the still-private repo, awaiting the member's flip) must NOT have its edits re-saved -- that
+        # rewrites main and drops the App's DOI citation block.  Just flip it.
+        nwoForFinish = ctx.get("personalNameWithOwner")
+        approvedFinish = bool(isOrg and nwoForFinish and self._repoHasMintedDoi(nwoForFinish))
         # Gather any pending edits up front so we can abort cleanly (without publishing) if the
         # loaded segmentation was edited in place.
         editsBundle = None
-        if self._resumedForEdit:
+        if self._resumedForEdit and not approvedFinish:
             editsBundle = self._gatherStagedEdits()
             if editsBundle is None:
                 return  # warned; abort publish

--- a/MorphoDepot/MorphoDepotLib/widget_create.py
+++ b/MorphoDepot/MorphoDepotLib/widget_create.py
@@ -1007,6 +1007,22 @@ class CreateTabMixin:
         slicer.util.showStatusMessage("")
         if not final:
             return
+        # Member-driven cutover (#20): automated validation (#19) bounced the submission — show the
+        # specific blocking failures and leave the repo staged so the curator can fix and re-submit.
+        if isinstance(final, dict) and final.get("changesRequested"):
+            v = final.get("validation") or {}
+            fails = v.get("failures") or []
+            lines = "\n".join(f"  • {f.get('title')}: {f.get('detail')}" for f in fails) or "  • (see the review report)"
+            self._stagedNameWithOwner = final.get("nameWithOwner")
+            self.refreshStagedReposList(force=True)
+            if not self.testingMode:
+                slicer.util.errorDisplay(
+                    "Automated checks must pass before this can be reviewed:\n\n"
+                    f"{lines}\n\n"
+                    "Fix these, then click Make Public again to re-submit."
+                    + (f"\n\nTracking issue: {final.get('issueUrl')}" if final.get("issueUrl") else ""),
+                    windowTitle="Changes required before publishing")
+            return
         # Org publish is routed through the MD-reviewers review gate (org-design 11.3): the App
         # emailed an Approve link and did NOT make the repo public yet.  Report that review was
         # requested and leave the repo staged; do NOT add a contact (the repo isn't public).
@@ -1024,10 +1040,10 @@ class CreateTabMixin:
             if not self.testingMode:
                 slicer.util.infoDisplay(
                     f"'{where}' has been submitted for review.\n\n"
-                    f"A request was emailed to {to}. Once a reviewer approves, the repository is "
-                    "made public automatically and you'll get an email. Until then it stays "
-                    "private and remains in your unpublished list (reopen it there to make "
-                    "changes, which will require requesting review again).",
+                    f"A request was emailed to {to}. Once a reviewer approves you'll get an email — "
+                    "then reopen this repo from your unpublished list and click Make Public again to "
+                    "publish it. Until then it stays private (reopening to make changes will require "
+                    "requesting review again).",
                     windowTitle="Submitted for review")
             slicer.mrmlScene.Clear()
             return


### PR DESCRIPTION
**CUTOVER — extension side** (morphodepot-intake#20). Pairs with morphodepot-intake#22 (deployed + verified on the box). Makes the extension do the Administration-requiring work with the **member's own gh** so the App can drop its `Administration` permission.

- **Create** (`_provisionStagedRepoInOrg`): member `gh repo create MorphoDepot/<name> --private` + staging topic, instead of `controlPlaneRequest('repos/create')`. The member is admin of their own repo.
- **Publish** (`_publishStagedRepoInOrg`): handles the App's `changes_requested` (#19 auto-bounce → surface failures), `pending_review` (unchanged), and `approved`+`flip` (member flips visibility + sets discovery topics via the existing `setRepoVisibility`/`addMorphoTopics`).
- **`onPublish`**: shows the #19 failure list on a bounce; rewords the submitted-for-review message (after approval the member re-clicks Make Public to finish).

⚠️ **NOT yet tested in Slicer** — the running Slicer (5.10, /Applications) loads the *old installed* monolithic extension, not this dev code, so I couldn't drive it via the MCP. `py_compile` clean. Needs a pass with the dev-code Slicer: create → Make Public (submit) → approve → reopen → Make Public (flip) → verify public + topics + DOI.

**Cutover:** merge this + #22, deploy both, set `MEMBER_DRIVEN_PUBLISH=true`, (optional) RepoAdminTeam, then drop `Administration` from the App.

🤖 Generated with [Claude Code](https://claude.com/claude-code)