### PR TITLE
fix(security): S1 gh() injection-safety + S2 rmtree data-loss guard

### DIFF
--- a/MorphoDepot/MorphoDepotLib/accession_form.py
+++ b/MorphoDepot/MorphoDepotLib/accession_form.py
@@ -421,7 +421,9 @@ class MorphoDepotAccessionForm():
         self._applySuggestedRepoName()   # F4: prefill a metadata-derived name (until the user edits it)
         valid = valid and self.questions["githubRepoName"].answer() != ""
         valid = valid and self.questions["repoType"].answer() != ""
-        repoNameRegex = r"^(?:([a-zA-Z\d]+(?:-[a-zA-Z\d]+)*)/)?([\w.-]+)$"
+        # Reject "." / ".." as the repo name (review S2): such a name flows into a local
+        # os.path.join + shutil.rmtree and would otherwise target the whole working dir / its parent.
+        repoNameRegex = r"^(?:([a-zA-Z\d]+(?:-[a-zA-Z\d]+)*)/)?((?!\.\.?$)[\w.-]+)$"
         valid = valid and (re.match(repoNameRegex, self.questions["githubRepoName"].answer()) != None)
         # The contact email is validated separately at Go-live (see _updatePublishEnabled), not here.
         self.validationCallback(valid)

--- a/MorphoDepot/MorphoDepotLib/logic_accession.py
+++ b/MorphoDepot/MorphoDepotLib/logic_accession.py
@@ -326,7 +326,13 @@ jobs:
 
         # Local clones are disposable working copies.  Clear any stale leftover (e.g. from a
         # previous interrupted attempt) so it never blocks a fresh build with the same name.
-        repoDir = os.path.join(self.localRepositoryDirectory(), repoName)
+        base = os.path.abspath(self.localRepositoryDirectory())
+        repoDir = os.path.abspath(os.path.join(base, repoName))
+        # Safety (review S2): a crafted name ('.', '..', or separators) could make repoDir resolve to
+        # the working directory itself or its parent -- rmtree would then wipe unrelated clones/caches.
+        # Refuse any repoDir that is not a *strict* child of the working directory.
+        if repoDir == base or os.path.commonpath([base, repoDir]) != base:
+            raise ValueError(f"Invalid repository name {repoName!r} -- must be a plain repository name.")
         if os.path.exists(repoDir):
             self.progressMethod(f"Removing stale local directory {repoDir}")
             shutil.rmtree(repoDir, ignore_errors=True)
@@ -354,10 +360,10 @@ jobs:
         # {login}-team grant for other collaborators can be added later without the App.
         self.progressMethod(f"Creating {self.morphoDepotOrg}/{repoName} (private)...")
         nameWithOwner = f"{self.morphoDepotOrg}/{repoName}"
-        self.gh(f"repo create {nameWithOwner} --private --disable-wiki")
+        self.gh(["repo", "create", nameWithOwner, "--private", "--disable-wiki"])
         cloneURL = f"https://github.com/{nameWithOwner}.git"
         # Mark it staged with the member's own gh (members own their topics now; the App does not).
-        self.gh(f"repo edit {nameWithOwner} --add-topic {self.stagingTopic}")
+        self.gh(["repo", "edit", nameWithOwner, "--add-topic", self.stagingTopic])
 
         # Push the locally built content to the empty in-org repo (member has Write via team).
         self.localRepo = repo
@@ -436,7 +442,8 @@ jobs:
 
         # Create PRIVATE: the staging state is invisible (private + no topic) until go-live.
         try:
-            self.gh(f"repo create {personalTarget} --disable-wiki --private --source {repoDir} --push")
+            self.gh(["repo", "create", personalTarget, "--disable-wiki", "--private",
+                     "--source", repoDir, "--push"])
         except RuntimeError as e:
             # gh repo create --push can race with GitHub provisioning the new repo for
             # git-over-HTTPS access; the create succeeds but the immediate push fails with
@@ -465,7 +472,7 @@ jobs:
 
         # Tag the repo as staged-but-unpublished.  This topic is the durable, queryable record
         # of staging state (no client-side marker); publish removes it.
-        self.gh(f"repo edit {repoNameWithOwner} --add-topic {self.stagingTopic}")
+        self.gh(["repo", "edit", repoNameWithOwner, "--add-topic", self.stagingTopic])
 
         # subscribe to all notifications for the new repository
         # gh repo watch was removed in newer gh CLI versions; use the API directly
@@ -478,7 +485,8 @@ jobs:
         commandList = ["release", "create", "--repo", repoNameWithOwner, "v1"]
         commandList += ["--notes", "Initial release"]
         self.gh(commandList)
-        self.gh(f"release upload --repo {repoNameWithOwner} v1 {sourceFilePath}#{sourceFileName}.nrrd")
+        self.gh(["release", "upload", "--repo", repoNameWithOwner, "v1",
+                 f"{sourceFilePath}#{sourceFileName}.nrrd"])
 
         # write source volume pointer: an owner-relative path resolved against the repo's current
         # owner at read time (resolveVolumeURL).
@@ -627,8 +635,8 @@ jobs:
             resp = self.controlPlaneRequest("repos/discard", {"repo": ctx["repoName"]}) or {}
             if resp.get("member_must_discard"):
                 try:
-                    self.gh(f"repo edit {personal} --add-topic morphodepot-discarded "
-                            f"--remove-topic {self.stagingTopic}")
+                    self.gh(["repo", "edit", personal, "--add-topic", "morphodepot-discarded",
+                             "--remove-topic", self.stagingTopic])
                 except Exception as e:
                     logging.warning(f"Could not mark {personal} discarded: {e}")
             self.localRepo = None
@@ -707,7 +715,7 @@ jobs:
         repoDir = os.path.join(self.localRepositoryDirectory(), repoName)
         if os.path.exists(repoDir):
             shutil.rmtree(repoDir, ignore_errors=True)
-        self.gh(f"repo clone {nameWithOwner} {repoDir}")
+        self.gh(["repo", "clone", nameWithOwner, repoDir])
         self.localRepo = git.Repo(repoDir)
 
         accession = {}

--- a/MorphoDepot/MorphoDepotLib/logic_accession.py
+++ b/MorphoDepot/MorphoDepotLib/logic_accession.py
@@ -330,7 +330,9 @@ jobs:
         repoDir = os.path.abspath(os.path.join(base, repoName))
         # Safety (review S2): a crafted name ('.', '..', or separators) could make repoDir resolve to
         # the working directory itself or its parent -- rmtree would then wipe unrelated clones/caches.
-        # Refuse any repoDir that is not a *strict* child of the working directory.
+        # Refuse any repoDir that is not a *strict* child of the working directory.  NOTE: the
+        # `repoDir == base` arm is load-bearing -- commonpath([base, base]) == base, so the '.' case
+        # would slip past the second check alone; do not "simplify" it away.
         if repoDir == base or os.path.commonpath([base, repoDir]) != base:
             raise ValueError(f"Invalid repository name {repoName!r} -- must be a plain repository name.")
         if os.path.exists(repoDir):
@@ -388,7 +390,8 @@ jobs:
 
         owner, name = nameWithOwner.split("/", 1)
         try:
-            self.gh(f"api --method PUT /repos/{owner}/{name}/subscription --field subscribed=true --field ignored=false")
+            self.gh(["api", "--method", "PUT", f"/repos/{owner}/{name}/subscription",
+                 "--field", "subscribed=true", "--field", "ignored=false"])
         except Exception as e:
             logging.warning(f"Could not subscribe to {nameWithOwner}: {e}")
 
@@ -468,7 +471,7 @@ jobs:
         self.localRepo = repo
         repoNameWithOwner = self.nameWithOwner("origin")
 
-        self.gh(f"repo edit {repoNameWithOwner} --enable-projects=false --enable-discussions=false")
+        self.gh(["repo", "edit", repoNameWithOwner, "--enable-projects=false", "--enable-discussions=false"])
 
         # Tag the repo as staged-but-unpublished.  This topic is the durable, queryable record
         # of staging state (no client-side marker); publish removes it.
@@ -477,7 +480,8 @@ jobs:
         # subscribe to all notifications for the new repository
         # gh repo watch was removed in newer gh CLI versions; use the API directly
         owner, name = repoNameWithOwner.split("/", 1)
-        self.gh(f"api --method PUT /repos/{owner}/{name}/subscription --field subscribed=true --field ignored=false")
+        self.gh(["api", "--method", "PUT", f"/repos/{owner}/{name}/subscription",
+                 "--field", "subscribed=true", "--field", "ignored=false"])
 
         # Non-member tier: create the v1 release and upload the source volume AS A RELEASE ASSET
         # (the volume lives on GitHub, capped at 2 GB). Members use S3 instead — see
@@ -712,7 +716,12 @@ jobs:
         asset, not a git-tracked file — and gives a working tree for saveStagedRepoEdits()."""
         nameWithOwner = stagedRepo.get("nameWithOwner")
         repoName = stagedRepo.get("repoName")
-        repoDir = os.path.join(self.localRepositoryDirectory(), repoName)
+        base = os.path.abspath(self.localRepositoryDirectory())
+        repoDir = os.path.abspath(os.path.join(base, repoName or ""))
+        # Same strict-child guard as stageRepo (review S2): repoName here comes from the GitHub repo
+        # listing (GitHub itself rejects ./..), but guard for consistency before the rmtree.
+        if repoDir == base or os.path.commonpath([base, repoDir]) != base:
+            raise ValueError(f"Invalid repository name {repoName!r} -- must be a plain repository name.")
         if os.path.exists(repoDir):
             shutil.rmtree(repoDir, ignore_errors=True)
         self.gh(["repo", "clone", nameWithOwner, repoDir])

--- a/MorphoDepot/MorphoDepotLib/logic_github.py
+++ b/MorphoDepot/MorphoDepotLib/logic_github.py
@@ -200,10 +200,11 @@ class GitHubMixin:
         and REMOVE the `morphodepot-staging` marker, so the repo becomes findable by RepoClerk
         and the extension and simultaneously leaves the unpublished list.  The species topic is
         skipped when unknown (e.g. recovered repos with no species)."""
-        command = f"repo edit {nameWithOwner} --add-topic morphodepot --remove-topic {self.stagingTopic}"
+        command = ["repo", "edit", nameWithOwner, "--add-topic", "morphodepot",
+                   "--remove-topic", self.stagingTopic]
         if speciesTopicString:
-            command = (f"repo edit {nameWithOwner} --add-topic morphodepot "
-                       f"--add-topic md-{speciesTopicString} --remove-topic {self.stagingTopic}")
+            command = ["repo", "edit", nameWithOwner, "--add-topic", "morphodepot",
+                       "--add-topic", f"md-{speciesTopicString}", "--remove-topic", self.stagingTopic]
         self.gh(command)
 
     def issueList(self):

--- a/MorphoDepot/MorphoDepotLib/logic_repo.py
+++ b/MorphoDepot/MorphoDepotLib/logic_repo.py
@@ -108,7 +108,7 @@ class RepoMixin:
         else:
             cloneTarget = self._userForkOf(sourceRepository)
             if not cloneTarget:
-                self.gh(f"repo fork {sourceRepository} --clone=false")
+                self.gh(["repo", "fork", sourceRepository, "--clone=false"])
                 cloneTarget = self._userForkOf(sourceRepository) or f"{me}/{repositoryName}"
             isFork = True
         self.gh(["repo", "clone", cloneTarget, localDirectory])
@@ -208,7 +208,7 @@ class RepoMixin:
         self.cacheOldVersion(localDirectory)
 
         # clone the main repo, not a fork
-        self.gh(f"repo clone {repoNameWithOwner} {localDirectory}")
+        self.gh(["repo", "clone", repoNameWithOwner, localDirectory])
 
         self.localRepo = git.Repo(localDirectory)
         self.localRepo.git.checkout("main")
@@ -221,7 +221,7 @@ class RepoMixin:
 
         self.cacheOldVersion(localDirectory)
 
-        self.gh(f"repo clone {repoNameWithOwner} {localDirectory}")
+        self.gh(["repo", "clone", repoNameWithOwner, localDirectory])
 
         self.localRepo = git.Repo(localDirectory)
         self.localRepo.git.checkout("main")

--- a/MorphoDepot/MorphoDepotLib/widget_create.py
+++ b/MorphoDepot/MorphoDepotLib/widget_create.py
@@ -155,8 +155,9 @@ class CreateTabMixin:
                         slicer.util.downloadFile(volumeURL, nrrdPath)
                     else:
                         # Legacy staged repo: volume is a private v1 release asset (needs gh auth).
-                        self.logic.gh(f"release download v1 --repo {nameWithOwner} "
-                                      f"--pattern {sourceVolumeName}.nrrd --dir {cacheDir} --clobber")
+                        self.logic.gh(["release", "download", "v1", "--repo", nameWithOwner,
+                                       "--pattern", f"{sourceVolumeName}.nrrd", "--dir", cacheDir,
+                                       "--clobber"])
                 volumeNode = slicer.util.loadVolume(nrrdPath)
                 self.createUI.inputSelector.setCurrentNode(volumeNode)
             except Exception as e:


### PR DESCRIPTION
Implements **S1 + S2** from the independent extension security review (`MorphoDepot-extension-review.md`) — the data-loss / injection pair.

- **S2 (High):** repo names `.`/`..` rejected at validation; the staged-clone `shutil.rmtree` now asserts `repoDir` is a strict child of the working dir (`os.path.commonpath`) — a one-char typo can't wipe the working directory or its parent.
- **S1 (High):** every path/value-interpolating `gh()` call is now list-form (no string-split) — paths with spaces work, values can't become injected `gh` args.

No token-scope changes. Unit-tested locally (regex + commonpath guard).

🤖 Generated with [Claude Code](https://claude.com/claude-code)