### PR TITLE
fix(security): S3/S4/S9/S10 — sanitize journal data, re-verify volume cache

### DIFF
--- a/MorphoDepot/MorphoDepotContributors.py
+++ b/MorphoDepot/MorphoDepotContributors.py
@@ -18,6 +18,7 @@ from __future__ import annotations
 
 import json
 import os
+import re
 import urllib.request
 
 SCHEMA = "morphodepot-contributors/1"
@@ -73,6 +74,11 @@ def save(path: str, data: dict) -> None:
 
 def orcid_name(orcid: str):
     """Authoritative ``(given, family)`` from the public ORCID record — best-effort (None, None)."""
+    # S10: orcid is interpolated into the request URL; require the canonical ORCID format so a
+    # malformed value can't alter the URL path or host.
+    orcid = (orcid or "").strip()
+    if not re.fullmatch(r"\d{4}-\d{4}-\d{4}-\d{3}[\dX]", orcid):
+        return (None, None)
     try:
         req = urllib.request.Request(f"{ORCID_PUBLIC_API}/{orcid}/person",
                                      headers={"Accept": "application/json"})

--- a/MorphoDepot/MorphoDepotLib/logic_objectstore.py
+++ b/MorphoDepot/MorphoDepotLib/logic_objectstore.py
@@ -36,6 +36,10 @@ class ObjectStoreMixin:
         "releases/download/v1/..." pointers are re-based onto the repo owner.
         """
         if volumeRef.startswith("http"):
+            # S10: a source_volume pointer comes from (potentially arbitrary) repo content; require
+            # https so a poisoned pointer can't downgrade to cleartext http or use a non-http scheme.
+            if not volumeRef.startswith("https://"):
+                raise ValueError(f"Refusing non-HTTPS source volume URL: {volumeRef!r}")
             return volumeRef  # full URL (object-store or legacy hardcoded) — use as-is
         return f"https://github.com/{repoNameWithOwner}/{volumeRef}"
 

--- a/MorphoDepot/MorphoDepotLib/logic_repo.py
+++ b/MorphoDepot/MorphoDepotLib/logic_repo.py
@@ -10,6 +10,7 @@ import math
 import locale
 import random
 import shutil
+import hashlib
 import logging
 import platform
 import datetime
@@ -228,6 +229,21 @@ class RepoMixin:
         self.loadFromLocalRepository(remoteName="origin", configuration="preview")
         return True
 
+    def _fileMatchesChecksum(self, filePath, checksum):
+        """True if filePath's digest matches `checksum` ('<algo>:<hex>', e.g. 'SHA256:ab...', or a
+        bare SHA-256 hex).  Used to re-verify the name-keyed volume cache on every load (review S4)."""
+        algo, sep, expected = checksum.partition(":")
+        if not sep:
+            algo, expected = "sha256", checksum  # bare hex -> assume SHA-256
+        try:
+            h = hashlib.new(algo.lower())
+            with open(filePath, "rb") as fp:
+                for block in iter(lambda: fp.read(1024 * 1024), b""):
+                    h.update(block)
+        except (ValueError, OSError):
+            return False  # unknown algorithm or unreadable file -> treat as mismatch
+        return h.hexdigest().lower() == expected.strip().lower()
+
     def loadFromLocalRepository(self, remoteName="upstream", configuration="segment"):
         localDirectory = self.localRepo.working_dir
         branchName = self.localRepo.active_branch.name
@@ -263,6 +279,18 @@ class RepoMixin:
         if os.path.exists(checksumFilePath):
             with open(checksumFilePath) as fp:
                 checksum = fp.read().strip()
+        else:
+            # S4: no committed checksum -- integrity can't be verified.  Warn rather than silently
+            # trusting whatever bytes are served/cached for legacy repos.
+            self.progressMethod("Warning: no source_volume_checksum committed; cannot verify volume integrity.")
+        if checksum and os.path.exists(nrrdPath) and not self._fileMatchesChecksum(nrrdPath, checksum):
+            # S4: the cache is keyed by repo name, not content, so a stale (new release) or tampered
+            # cached file would otherwise be reused unverified -- re-fetch instead of trusting it.
+            self.progressMethod("Cached source volume failed checksum; re-downloading.")
+            try:
+                os.remove(nrrdPath)
+            except OSError:
+                pass
         if not os.path.exists(nrrdPath):
             slicer.util.downloadFile(volumeURL, nrrdPath, checksum=checksum)
         volumeNode = slicer.util.loadVolume(nrrdPath)

--- a/MorphoDepot/MorphoDepotLib/logic_repo.py
+++ b/MorphoDepot/MorphoDepotLib/logic_repo.py
@@ -289,8 +289,12 @@ class RepoMixin:
             self.progressMethod("Cached source volume failed checksum; re-downloading.")
             try:
                 os.remove(nrrdPath)
-            except OSError:
-                pass
+            except OSError as e:
+                # S4: if we can't evict the bad file we must NOT fall through and load it (the
+                # `if not os.path.exists` below would otherwise skip re-download and loadVolume the
+                # known-bad cache file, defeating the integrity check).
+                raise RuntimeError(
+                    f"Cached source volume failed checksum and could not be removed for re-download: {e}")
         if not os.path.exists(nrrdPath):
             slicer.util.downloadFile(volumeURL, nrrdPath, checksum=checksum)
         volumeNode = slicer.util.loadVolume(nrrdPath)

--- a/MorphoDepot/MorphoDepotLib/widget_search.py
+++ b/MorphoDepot/MorphoDepotLib/widget_search.py
@@ -190,7 +190,9 @@ class SearchTabMixin:
                             logging.warning(f"Could not download screenshot {imageURL}: {e}")
 
                     if os.path.exists(localImagePath):
-                        tooltipParts.append(f'<img src="file:///{localImagePath}" width="128"> ')
+                        # S9: owner/repoName are also in this path -- escape so a crafted value
+                        # can't break out of the src="" attribute.
+                        tooltipParts.append(f'<img src="file:///{html.escape(localImagePath)}" width="128"> ')
 
             tooltipText = "".join(tooltipParts)
 

--- a/MorphoDepot/MorphoDepotLib/widget_search.py
+++ b/MorphoDepot/MorphoDepotLib/widget_search.py
@@ -1,6 +1,7 @@
 """MorphoDepotWidget SearchTabMixin (split from MorphoDepot.py)."""
 import os
 import re
+import html
 import sys
 import csv
 import glob
@@ -133,15 +134,18 @@ class SearchTabMixin:
             sizeItem.setData(repoDataKey, qt.Qt.UserRole + 1)
             rowItems = [sizeItem, repoItem, ownerItem, speciesItem, modalityItem, activeItem, spacingItem, dimensionsItem]
 
-            # Create a rich HTML tooltip
-            tooltipParts = [f"<b>{repoName}</b> by <b>{owner}</b><br><hr>"]
+            # Create a rich HTML tooltip.  S9: every interpolated field below is journal-derived
+            # (mirrored from arbitrary public repos), so escape it -- Qt rich text won't run JS but
+            # <img>/markup could load remote/file:// resources or corrupt layout.
+            esc = lambda v: html.escape(str(v))
+            tooltipParts = [f"<b>{esc(repoName)}</b> by <b>{esc(owner)}</b><br><hr>"]
             tooltipParts.append("<table>")
-            tooltipParts.append(f"<tr><td><b>Last Active:</b></td><td>{activeText}</td></tr>")
-            tooltipParts.append(f"<tr><td><b>Species:</b></td><td>{species}</td></tr>")
-            tooltipParts.append(f"<tr><td><b>Size (GB):</b></td><td>{sizeText}</td></tr>")
-            tooltipParts.append(f"<tr><td><b>Modality:</b></td><td>{modality}</td></tr>")
-            tooltipParts.append(f"<tr><td><b>Spacing:</b></td><td>{spacingText}</td></tr>")
-            tooltipParts.append(f"<tr><td><b>Dimensions:</b></td><td>{dimensionsText}</td></tr>")
+            tooltipParts.append(f"<tr><td><b>Last Active:</b></td><td>{esc(activeText)}</td></tr>")
+            tooltipParts.append(f"<tr><td><b>Species:</b></td><td>{esc(species)}</td></tr>")
+            tooltipParts.append(f"<tr><td><b>Size (GB):</b></td><td>{esc(sizeText)}</td></tr>")
+            tooltipParts.append(f"<tr><td><b>Modality:</b></td><td>{esc(modality)}</td></tr>")
+            tooltipParts.append(f"<tr><td><b>Spacing:</b></td><td>{esc(spacingText)}</td></tr>")
+            tooltipParts.append(f"<tr><td><b>Dimensions:</b></td><td>{esc(dimensionsText)}</td></tr>")
             tooltipParts.append("</table>")
             screenshotCount = repoData.get('screenshotCount', 0)
 
@@ -167,9 +171,16 @@ class SearchTabMixin:
                         tooltipParts.append(f"<i>...and {screenshotCount - 5} more.</i>")
                         break
 
+                    # S3: filename is a key from a RepoClerk journal (mirrored from arbitrary public
+                    # repos); accept only a bare screenshot basename so it can't traverse out of the
+                    # cache dir when downloadFile writes to it (path-traversal write primitive).
+                    safeName = os.path.basename(filename)
+                    if not re.fullmatch(r"screenshot-\d+\.png", safeName):
+                        logging.warning(f"Skipping screenshot with unexpected filename: {filename!r}")
+                        continue
                     urlPrefix = "https://raw.githubusercontent.com"
-                    imageURL = f"{urlPrefix}/{owner}/{repoName}/main/screenshots/{filename}"
-                    localImagePath = os.path.join(screenshotCacheDir, owner, repoName, filename)
+                    imageURL = f"{urlPrefix}/{owner}/{repoName}/main/screenshots/{safeName}"
+                    localImagePath = os.path.join(screenshotCacheDir, owner, repoName, safeName)
 
                     if not os.path.exists(localImagePath):
                         try:


### PR DESCRIPTION
Implements **S3 + S4 + S9 + S10** from the independent extension security review (`MorphoDepot-extension-review.md`) — the untrusted-data pool.

- **S3 (Med):** screenshot filename from a journal must match `screenshot-<n>.png` (basename) before it's used for a cache path / `downloadFile` target — closes the path-traversal write.
- **S4 (Med):** the repo-name-keyed volume cache is re-verified against the committed SHA-256 on every load (stale/tampered cache re-fetched); missing checksum now **warns** instead of silently skipping.
- **S9 (Low):** all journal-derived tooltip fields are `html.escape()`'d.
- **S10 (Low):** `resolveVolumeURL` refuses non-HTTPS pointers; `orcid_name` validates the ORCID format before URL interpolation.

No token-scope changes. `py_compile` clean; pure logic unit-tested (S3/S4/S10).

🤖 Generated with [Claude Code](https://claude.com/claude-code)