### PR TITLE
fix(security): S5 HTTPS-pin token endpoints + S8 guard shared item maps

### DIFF
--- a/MorphoDepot/MorphoDepotLib/logic_controlplane.py
+++ b/MorphoDepot/MorphoDepotLib/logic_controlplane.py
@@ -29,8 +29,13 @@ from slicer.i18n import translate
 
 class ControlPlaneMixin:
     def controlPlaneBase(self):
-        return qt.QSettings().value(
+        base = qt.QSettings().value(
             "MorphoDepot/controlPlaneBase", "https://join.morphodepot.org").rstrip("/")
+        # S5: the user's gh token is sent here as a Bearer credential; refuse a non-HTTPS endpoint so
+        # a poisoned/typo'd QSettings value can't exfiltrate it in cleartext or to an http host.
+        if not str(base).startswith("https://"):
+            raise RuntimeError(f"Refusing non-HTTPS control plane endpoint: {base!r}")
+        return base
 
     def orgMembershipStatus(self, org=None):
         """Tri-state membership against the MorphoDepot org via the App control plane (`/me`):

--- a/MorphoDepot/MorphoDepotLib/logic_objectstore.py
+++ b/MorphoDepot/MorphoDepotLib/logic_objectstore.py
@@ -61,6 +61,10 @@ class ObjectStoreMixin:
         qsettings = qt.QSettings()
         signEndpoint = qsettings.value("MorphoDepot/uploadSignEndpoint",
                                        "https://join.morphodepot.org/uploads/sign")
+        # S5: the user's gh token authenticates these calls; refuse a non-HTTPS endpoint so a
+        # poisoned/typo'd QSettings value can't exfiltrate it in cleartext.
+        if not str(signEndpoint).startswith("https://"):
+            raise RuntimeError(f"Refusing non-HTTPS upload endpoint: {signEndpoint!r}")
         # Derive the multipart base: …/uploads/sign -> …/uploads/multipart
         base = signEndpoint.rsplit("/uploads/", 1)[0] + "/uploads/multipart"
         # Authenticate with the user's own gh token (member tier — "git + gh, nothing else").

--- a/MorphoDepot/MorphoDepotLib/widget_annotate.py
+++ b/MorphoDepot/MorphoDepotLib/widget_annotate.py
@@ -142,7 +142,11 @@ class AnnotateTabMixin:
     def onIssueDoubleClicked(self, item):
         slicer.util.showStatusMessage(f"Loading {item.text()}")
         repoDirectory = os.path.normpath(self.configureUI.repoDirectory.currentPath)
-        issue = self.issuesByItem[item]
+        # S8: issuesByItem is shared across tabs; a stale/foreign list item is not a key -- bail
+        # instead of raising KeyError outside any tryWithErrorDisplay.
+        issue = self.issuesByItem.get(item)
+        if issue is None:
+            return
         if self.testingMode or slicer.util.confirmOkCancelDisplay("Close scene and load issue?"):
             with slicer.util.tryWithErrorDisplay("Failed to load issue", waitCursor=True):
                 slicer.util.showStatusMessage(f"Loading {item.text()}")

--- a/MorphoDepot/MorphoDepotLib/widget_annotate.py
+++ b/MorphoDepot/MorphoDepotLib/widget_annotate.py
@@ -140,13 +140,13 @@ class AnnotateTabMixin:
             slicer.util.errorDisplay("No PR selected.")
 
     def onIssueDoubleClicked(self, item):
-        slicer.util.showStatusMessage(f"Loading {item.text()}")
-        repoDirectory = os.path.normpath(self.configureUI.repoDirectory.currentPath)
         # S8: issuesByItem is shared across tabs; a stale/foreign list item is not a key -- bail
-        # instead of raising KeyError outside any tryWithErrorDisplay.
+        # before showing any status, instead of raising KeyError outside any tryWithErrorDisplay.
         issue = self.issuesByItem.get(item)
         if issue is None:
             return
+        slicer.util.showStatusMessage(f"Loading {item.text()}")
+        repoDirectory = os.path.normpath(self.configureUI.repoDirectory.currentPath)
         if self.testingMode or slicer.util.confirmOkCancelDisplay("Close scene and load issue?"):
             with slicer.util.tryWithErrorDisplay("Failed to load issue", waitCursor=True):
                 slicer.util.showStatusMessage(f"Loading {item.text()}")

--- a/MorphoDepot/MorphoDepotLib/widget_release.py
+++ b/MorphoDepot/MorphoDepotLib/widget_release.py
@@ -195,7 +195,11 @@ class ReleaseTabMixin:
             slicer.util.showStatusMessage(f"Found {len(administratedRepos)} owned repositories.")
 
     def onReleaseRepoDoubleClicked(self, item):
-        repoData = self.reposByItem[item]
+        # S8: reposByItem is shared across tabs; a stale/foreign list item is not a key -- bail
+        # instead of raising KeyError outside any tryWithErrorDisplay.
+        repoData = self.reposByItem.get(item)
+        if repoData is None:
+            return
         slicer.util.showStatusMessage(f"Loading repository {repoData['nameWithOwner']}...")
         if self.testingMode or slicer.util.confirmOkCancelDisplay("Close scene and load repository?"):
             slicer.mrmlScene.Clear()


### PR DESCRIPTION
Implements **S5 + S8** from the independent extension security review (`MorphoDepot-extension-review.md`) — the final pool.

- **S5 (Med):** both token-carrying endpoints (`controlPlaneBase()` and the upload `signEndpoint`) now reject a non-`https://` value, so a poisoned/typo'd QSettings can't leak the user's gh token in cleartext. **No token-scope change** (per request — the scope / App-token redesign is tracked separately).
- **S8 (Med):** `onReleaseRepoDoubleClicked` / `onIssueDoubleClicked` use `.get(item)` + bail on `None` on the cross-tab `reposByItem` / `issuesByItem` maps (matching `widget_review.py`), instead of `KeyError`-ing a handler.

`py_compile` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)