### PR TITLE
Use palette(highlight) for button hover (review follow-up)

### DIFF
--- a/MorphoDepot/MorphoDepot.py
+++ b/MorphoDepot/MorphoDepot.py
@@ -249,8 +249,8 @@ class MorphoDepotWidget(ScriptedLoadableModuleWidget, VTKObservationMixin, Enabl
                 padding: 4px 12px;
                 min-height: 18px;
             }
-            QPushButton:hover { background-color: palette(light); }
-            QPushButton:focus { border: 1px solid palette(highlight); outline: none; }
+            QPushButton:hover { background-color: palette(highlight); color: palette(highlighted-text); }
+            QPushButton:focus { border: 1px solid palette(highlight); }
             QPushButton:pressed { background-color: palette(button); }
             QPushButton:disabled {
                 background-color: palette(window);


### PR DESCRIPTION
Follow-up to the #161 review: `palette(light)` is near-white in Slicer's light theme, so the button hover state washed out against the window. Switch hover to the selection color (`palette(highlight)` + `palette(highlighted-text)` for contrast), which is distinct in both themes. Also drops the no-op `outline: none` (not recognized in Qt's CSS subset, per the #161 review).

Cosmetic only; `py_compile` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)