### PR TITLE
build: package the MorphoDepotLib sub-package (Factory was shipping a broken module)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,7 +8,7 @@ set(EXTENSION_HOMEPAGE "https://www.slicer.org/wiki/Documentation/Nightly/Extens
 set(EXTENSION_CATEGORY "SlicerMorph")
 set(EXTENSION_CONTRIBUTORS "Steve Pieper (Isomics, Inc.)")
 set(EXTENSION_DESCRIPTION "Code to support collaborative segmentation projects using github.")
-set(EXTENSION_ICONURL "https://github.com/MorphoCloud/SlicerMorphoDepot/blob/main/MorphoDepot.png?raw=true")
+set(EXTENSION_ICONURL "https://github.com/SlicerMorph/SlicerMorphoDepot/blob/main/MorphoDepot.png?raw=true")
 set(EXTENSION_SCREENSHOTURLS "https://github.com/user-attachments/assets/2d81e4f3-8d8b-49e4-97f4-f906053d375f https://github.com/user-attachments/assets/9481ce0f-dc37-4900-9cdc-14bb0922df59")
 set(EXTENSION_DEPENDS "NA") # Specified as a list or "NA" if no dependencies
 

--- a/MorphoDepot/CMakeLists.txt
+++ b/MorphoDepot/CMakeLists.txt
@@ -5,6 +5,30 @@ set(MODULE_NAME MorphoDepot)
 set(MODULE_PYTHON_SCRIPTS
   ${MODULE_NAME}.py
   ${MODULE_NAME}Contributors.py
+  # MorphoDepotLib sub-package: MorphoDepot.py imports every one of these at load time, so they
+  # must be packaged/installed alongside the main script or the module fails to import.
+  ${MODULE_NAME}Lib/__init__.py
+  ${MODULE_NAME}Lib/accession_form.py
+  ${MODULE_NAME}Lib/forms.py
+  ${MODULE_NAME}Lib/logic_accession.py
+  ${MODULE_NAME}Lib/logic_contribute.py
+  ${MODULE_NAME}Lib/logic_controlplane.py
+  ${MODULE_NAME}Lib/logic_deps.py
+  ${MODULE_NAME}Lib/logic_github.py
+  ${MODULE_NAME}Lib/logic_objectstore.py
+  ${MODULE_NAME}Lib/logic_release.py
+  ${MODULE_NAME}Lib/logic_repo.py
+  ${MODULE_NAME}Lib/logic_repoclerk.py
+  ${MODULE_NAME}Lib/logic_search.py
+  ${MODULE_NAME}Lib/screenshot_dialog.py
+  ${MODULE_NAME}Lib/search_form.py
+  ${MODULE_NAME}Lib/widget_annotate.py
+  ${MODULE_NAME}Lib/widget_configure.py
+  ${MODULE_NAME}Lib/widget_create.py
+  ${MODULE_NAME}Lib/widget_release.py
+  ${MODULE_NAME}Lib/widget_review.py
+  ${MODULE_NAME}Lib/widget_search.py
+  ${MODULE_NAME}Lib/widget_validation.py
   )
 
 set(MODULE_PYTHON_RESOURCES


### PR DESCRIPTION
## Why this is build-critical

`MorphoDepot.py` was refactored into a thin shell that imports **22 mixins** from `MorphoDepotLib/` (`from MorphoDepotLib.forms import ...`, `logic_*`, `widget_*`, etc.). But the module `CMakeLists.txt` still listed only `MorphoDepot.py` + `MorphoDepotContributors.py`.

`slicerMacroBuildScriptedModule` copies/installs **only** the files in `MODULE_PYTHON_SCRIPTS`. So a Slicer **Factory build** (and any packaged/installed copy) shipped the module **without** `MorphoDepotLib/` — the module fails to import on load. This is invisible when running from the source clone (the package is sitting right there), which is why it slipped through.

## Fix

- Add all **22** `MorphoDepotLib/*.py` to `MODULE_PYTHON_SCRIPTS`, using the `${MODULE_NAME}Lib/<file>.py` pattern that core scripted modules (WebServer, ExtensionWizard) use for their `Lib` sub-packages.
- Verified mechanically: the listed set is an **exact match** with the files on disk (22/22) and covers **every** `from MorphoDepotLib.X import` in `MorphoDepot.py` — no missing, no extras.
- Secondary: de-stale `EXTENSION_ICONURL` (`MorphoCloud` → `SlicerMorph`; the repo was transferred and the old URL only resolved via GitHub's redirect).

## Not changed (verified OK)
- All 6 `Resources/UI/*.ui` already match the actual files.
- Test helpers under `Testing/Python/` (`md_e2e.py` etc.) are MCP-driven dev tools, not ctests, and correctly stay out of the installed package.

First half of the org-development → main cutover; once merged, the cutover carries this fix to main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)