### PR TITLE
fix: reconcile #168 cutover-review findings

### DIFF
--- a/MorphoDepot/MorphoDepotLib/logic_accession.py
+++ b/MorphoDepot/MorphoDepotLib/logic_accession.py
@@ -64,6 +64,7 @@ class AccessionMixin:
         else:
             licenseURL = "https://creativecommons.org/licenses/by/4.0/legalcode.txt"
         response = requests.get(licenseURL, timeout=15)
+        response.raise_for_status()  # never commit a 4xx/5xx error page as the repo's LICENSE.txt
         with open(os.path.join(repoDir, "LICENSE.txt"), "w") as fp:
             fp.write(response.content.decode('ascii', errors="ignore"))
 

--- a/MorphoDepot/MorphoDepotLib/logic_github.py
+++ b/MorphoDepot/MorphoDepotLib/logic_github.py
@@ -357,6 +357,8 @@ class GitHubMixin:
         try:
             out = subprocess.run([self.ghExecutablePath, "auth", "token"],
                                  capture_output=True, text=True, timeout=15)
+            if out.returncode != 0:
+                return ""  # gh failed: never treat a stray stdout diagnostic as a Bearer token
             return (out.stdout or "").strip()
         except Exception as e:
             raise RuntimeError(f"Could not get a GitHub token from gh: {e}")

--- a/MorphoDepot/MorphoDepotLib/logic_release.py
+++ b/MorphoDepot/MorphoDepotLib/logic_release.py
@@ -33,7 +33,8 @@ class ReleaseMixin:
         if not self.localRepo:
             return None
         originNameWithOwner = self.nameWithOwner("origin")
-        return self.ghJSON(f"release list --repo {originNameWithOwner} --json name,tagName,publishedAt")
+        return self.ghJSON(["release", "list", "--repo", originNameWithOwner,
+                            "--json", "name,tagName,publishedAt"])
 
     def closedIssuesSinceLastRelease(self, nameWithOwner):
         """Return a list of {number,title} for issues closed since the last published release.
@@ -41,7 +42,8 @@ class ReleaseMixin:
         ANNOUNCEMENT issues are excluded: they carry the invisible release-announce marker and are
         not contributions -- retiring an announcement closes it, which would otherwise make it show
         up as a 'change in this release' in the next cycle (the bug this filters out)."""
-        releases = self.ghJSON(f"release list --repo {nameWithOwner} --json tagName,publishedAt") or []
+        releases = self.ghJSON(["release", "list", "--repo", nameWithOwner,
+                               "--json", "tagName,publishedAt"]) or []
         sinceDate = releases[0].get('publishedAt') if releases else None
         if sinceDate:
             cmd = ["issue", "list", "--repo", nameWithOwner,
@@ -350,8 +352,10 @@ class ReleaseMixin:
 
     def openIssuesAndPRs(self, nameWithOwner):
         """Return (issues, prs) lists of open items for the given repo, each with number and title."""
-        issues = self.ghJSON(f"issue list --repo {nameWithOwner} --state open --json number,title")
-        prs = self.ghJSON(f"pr list --repo {nameWithOwner} --state open --json number,title")
+        issues = self.ghJSON(["issue", "list", "--repo", nameWithOwner, "--state", "open",
+                             "--json", "number,title"])
+        prs = self.ghJSON(["pr", "list", "--repo", nameWithOwner, "--state", "open",
+                          "--json", "number,title"])
         return issues, prs
 
     def announceUpcomingRelease(self, nameWithOwner, deadlineISO, message):


### PR DESCRIPTION
Addresses the three findings from the #168 cutover review (HIGH/MEDIUM per the review-hygiene rule).

| # | File | Severity | Fix |
|---|------|----------|-----|
| 1 | `logic_accession.py` `_writeLicense` | correctness bug | add `response.raise_for_status()` — a 4xx/5xx from creativecommons.org was being written into `LICENSE.txt` and committed |
| 2 | `logic_release.py` (×4) | latent inconsistency / injection | convert `ghJSON(f"... --repo {nameWithOwner} ...")` to **list form** in `getReleases`, `closedIssuesSinceLastRelease`, `openIssuesAndPRs` — the call sites the S1 pass missed |
| 3 | `logic_github.py` `_ghToken` | robustness | return `""` on non-zero `gh auth token` exit so a stray stdout diagnostic can't become a Bearer token; callers' `if not token` guard then fires |

**Noted, not changed:** 7 `ghJSON(f"...")` sites in `test_MorphoDepot1` (the self-test) use the same string form, but interpolate **constrained test values** (test repo nwo / GitHub login / int) — test-only, not the user-controlled injection surface S1 targeted. Editing the delicate self-test for cosmetic consistency isn't worth the regression risk; flagging for a possible later sweep.

`py_compile` clean; verified no remaining `gh(JSON)?(f"` calls outside the self-test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)