### PR TITLE
docs: post-cutover cosmetic cleanups (stale URL, refactor line-count, branch ref)

### DIFF
--- a/MorphoDepot/MorphoDepot.py
+++ b/MorphoDepot/MorphoDepot.py
@@ -132,7 +132,7 @@ class EnableModuleMixin:
             msgBox.addButton(qt.QMessageBox.Ok)
             msgBox.exec_()
             if msgBox.clickedButton() == openDocsButton:
-                qt.QDesktopServices.openUrl(qt.QUrl("https://github.com/MorphoCloud/SlicerMorphoDepot?tab=readme-ov-file#prerequisites-for-morphodepot"))
+                qt.QDesktopServices.openUrl(qt.QUrl("https://github.com/SlicerMorph/SlicerMorphoDepot?tab=readme-ov-file#prerequisites-for-morphodepot"))
             return False
 
         # check local directory

--- a/MorphoDepot/MorphoDepotLib/widget_configure.py
+++ b/MorphoDepot/MorphoDepotLib/widget_configure.py
@@ -110,7 +110,7 @@ class ConfigureTabMixin:
         msgBox.exec_()
         if msgBox.clickedButton() == openDocsButton:
             qt.QDesktopServices.openUrl(qt.QUrl(
-                "https://github.com/MorphoCloud/SlicerMorphoDepot?tab=readme-ov-file#morphodepot"))
+                "https://github.com/SlicerMorph/SlicerMorphoDepot?tab=readme-ov-file#morphodepot"))
 
     def onUserNameChanged(self, userName):
         if userName:

--- a/MorphoDepot/Testing/MorphoDepot_UI_Test_Plan.md
+++ b/MorphoDepot/Testing/MorphoDepot_UI_Test_Plan.md
@@ -1,8 +1,14 @@
 # MorphoDepot — UI-Driven Test Plan
 
 Status: **PLAN ONLY — do not execute until explicitly told "go".**
-Target under test: [`MorphoDepot/MorphoDepot.py`](../MorphoDepot.py) (~6,600 lines, single tabbed module).
+Target under test: [`MorphoDepot/MorphoDepot.py`](../MorphoDepot.py) (now a ~1,300-line shell:
+`MorphoDepotWidget` + `MorphoDepotLogic` mix in the tab/logic behavior from `MorphoDepotLib/{widget,logic}_*.py`).
 Author/driver model: Claude Code driving 3D Slicer through the **Slicer MCP server**.
+
+> **Note on line references:** this plan predates the `MorphoDepotLib/` refactor, so the inline
+> `MorphoDepot.py:NNNN` anchors below are pre-refactor approximations — the handlers/logic they
+> point at now live in the `MorphoDepotLib/*.py` mixins. The signal-level UI-driving approach is
+> unchanged (widget addressing via `slicer.modules.MorphoDepotWidget.<tab>UI.*` still holds).
 
 ---
 

--- a/docs/refactor-and-test-plan.md
+++ b/docs/refactor-and-test-plan.md
@@ -168,8 +168,8 @@ validation** — that becomes the post-refactor hardening backlog (add guard →
 
 ## Status — delivered
 
-All phases shipped to `org-development`: the workflow net, the refactor (R0–R4), Part E hardening,
-and the in-depth E2E layer.
+All phases shipped (originally to `org-development`, since merged into `main` — the current
+development line): the workflow net, the refactor (R0–R4), Part E hardening, and the in-depth E2E layer.
 
 - **Refactor** — `MorphoDepot.py` 7,194 → 1,266 lines. The four Slicer-required classes stay thin in
   the main file and inherit per-domain mixins from `MorphoDepotLib/` (the Python-built UI classes,


### PR DESCRIPTION
Three small post-cutover doc/comment cleanups (bucket #4 from the doc audit):

1. **`MorphoDepot.py:135`** — the dependency-check *Open Documentation* button opened `github.com/`**`MorphoCloud`**`/SlicerMorphoDepot`. Repo was transferred; now `SlicerMorph/SlicerMorphoDepot`. (Worked via GitHub's redirect, just de-staled.)
2. **`MorphoDepot_UI_Test_Plan.md`** — header said "~6,600 lines, single tabbed module"; the module is now a ~1,300-line shell with behavior in `MorphoDepotLib/{widget,logic}_*.py`. Updated the header + added one note that the inline `MorphoDepot.py:NNNN` anchors are pre-refactor approximations (handlers moved into mixins). I deliberately did **not** rewrite the ~10 individual line numbers — for a planning doc, the note is more honest than re-anchoring numbers that will drift again.
3. **`refactor-and-test-plan.md`** — "shipped to `org-development`" → shipped (since merged into `main`).

`py_compile` clean; no `MorphoCloud/SlicerMorphoDepot` paths remain in module code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)