### PR TITLE
fix: grant {login}-team Write at create so staged org repos appear in the unpublished list

### DIFF
--- a/MorphoDepot/MorphoDepotLib/logic_accession.py
+++ b/MorphoDepot/MorphoDepotLib/logic_accession.py
@@ -368,6 +368,21 @@ jobs:
         # Mark it staged with the member's own gh (members own their topics now; the App does not).
         self.gh(["repo", "edit", nameWithOwner, "--add-topic", self.stagingTopic])
 
+        # Grant the member's {login}-team Write, so the repo is reachable THROUGH the team.  The Create
+        # tab's unpublished list queries `affiliation=organization_member` (team-based); without this
+        # grant the member reaches the repo only as its direct-collaborator creator and it never shows.
+        # The member is repo-admin (creator) and the team's maintainer, so their OWN gh performs this --
+        # no App Administration is involved.  GitHub gates this on admin of THIS repo, so a member can
+        # only ever team-grant repos they created (verified: a read-only repo returns 403).  Best-effort:
+        # a failure here only delays the repo appearing in the list; staging itself still succeeds.
+        teamSlug = f"{curator}-team".lower()
+        try:
+            self.gh(["api", "--method", "PUT",
+                     f"/orgs/{self.morphoDepotOrg}/teams/{teamSlug}/repos/{nameWithOwner}",
+                     "--field", "permission=push"])
+        except Exception as e:
+            logging.warning(f"Could not grant {teamSlug} Write on {nameWithOwner}: {e}")
+
         # Push the locally built content to the empty in-org repo (member has Write via team).
         self.localRepo = repo
         try:


### PR DESCRIPTION
## The bug

The Administration-free member-driven create (#20) creates the in-org repo with the member's own `gh` (so the creator is repo admin), but it never grants the member's `{login}-team`. The Create tab's unpublished list queries:

```
/user/repos?affiliation=owner,organization_member
```

For an org repo, `organization_member` means **team-based** access. A repo the member reaches only as its direct-collaborator creator is **not** in that result, so every staged repo created after the cutover was invisible there. That is the "(none)" the user saw, even with the `morphodepot-staging` topic present and the member as admin.

## The fix

Right after `gh repo create` and the staging topic, the **member's own gh** grants `{login}-team` Write:

```
PUT /orgs/{org}/teams/{login}-team/repos/{org}/{name}   permission=push
```

## Why this needs no App Administration, and is safe

- The member is the repo **admin** (creator) and the **maintainer** of their handle-team, which is exactly what GitHub requires for this endpoint.
- GitHub gates it on **admin of the target repo**. Verified live: a member adding a repo they do **not** admin (a public repo with read access) returns **403 "You must have administrative rights on this repository."** So a member can only ever team-grant repos they created. No escalation, and no App involvement.
- Best-effort: a grant failure is logged and does not break staging.

Existing staged repos (`test-delete`, `mus-musculus-microct-partial`) were backfilled the same way.

First step of the Administration-removal plan (member-self-grant), so the App no longer needs `organization_administration` for team grants. `py_compile` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)