### PR TITLE
feat: show review state in the unpublished list + clearer submit message

### DIFF
--- a/MorphoDepot/MorphoDepotLib/logic_controlplane.py
+++ b/MorphoDepot/MorphoDepotLib/logic_controlplane.py
@@ -82,3 +82,15 @@ class ControlPlaneMixin:
                 detail = r.text
             raise RuntimeError(f"Control plane '{path}' failed ({r.status_code}): {detail}")
         return r.json()
+
+    def reviewStatus(self, repoNames):
+        """The caller's own per-repo review state {name: 'approved'|'pending'|'none'} from the control
+        plane, used to label the unpublished list.  Best-effort -> {} on any error so the list still
+        renders (e.g. a non-member, or the App being briefly unreachable)."""
+        if not repoNames:
+            return {}
+        try:
+            return self.controlPlaneRequest("repos/review-status", {"repos": list(repoNames)}) or {}
+        except Exception as e:
+            logging.warning(f"Could not fetch review status: {e}")
+            return {}

--- a/MorphoDepot/MorphoDepotLib/logic_controlplane.py
+++ b/MorphoDepot/MorphoDepotLib/logic_controlplane.py
@@ -90,7 +90,10 @@ class ControlPlaneMixin:
         if not repoNames:
             return {}
         try:
-            return self.controlPlaneRequest("repos/review-status", {"repos": list(repoNames)}) or {}
+            result = self.controlPlaneRequest("repos/review-status", {"repos": list(repoNames)})
+            # Defensive: only a dict is usable by the caller (statuses.get(...)).  Any other valid-but-
+            # unexpected JSON (list/bool/str) would otherwise crash the whole list render, not degrade.
+            return result if isinstance(result, dict) else {}
         except Exception as e:
             logging.warning(f"Could not fetch review status: {e}")
             return {}

--- a/MorphoDepot/MorphoDepotLib/widget_create.py
+++ b/MorphoDepot/MorphoDepotLib/widget_create.py
@@ -53,8 +53,21 @@ class CreateTabMixin:
             placeholder.setFlags(qt.Qt.NoItemFlags)
             listWidget.addItem(placeholder)
             return
+        # Label each org repo with its review state so the curator isn't clicking Make Public blind:
+        # 'approved' (their turn to finish the flip) vs 'pending review'.  Org repos only -- short-term
+        # personal repos publish directly with no review.  Best-effort (reviewStatus returns {} on error).
+        orgPrefix = self.logic.morphoDepotOrg + "/"
+        orgNames = [r.get("repoName") for r in repos
+                    if r.get("repoName") and (r.get("nameWithOwner") or "").startswith(orgPrefix)]
+        statuses = self.logic.reviewStatus(orgNames) if orgNames else {}
         for repo in repos:
-            item = qt.QListWidgetItem(repo.get("summary") or repo.get("nameWithOwner", ""))
+            label = repo.get("summary") or repo.get("nameWithOwner", "")
+            state = statuses.get(repo.get("repoName"))
+            if state == "approved":
+                label += "    ✓ approved — click Make Public to finish"
+            elif state == "pending":
+                label += "    ⏳ pending review"
+            item = qt.QListWidgetItem(label)
             listWidget.addItem(item)
             self._stagedReposByItem[item] = repo
 
@@ -1119,10 +1132,11 @@ class CreateTabMixin:
             self._completeStepReset(
                 "Review request is successfully completed",
                 f"'{where}' has been submitted for review.\n\n"
-                f"A request was emailed to {to}. Once a reviewer approves you'll get an email — then "
-                "reopen this repo from your unpublished list and click Make Public again to publish it. "
-                "Until then it stays private (reopening to make changes will require requesting review "
-                "again).")
+                f"Publishing is a two-step process. A request was emailed to {to}. Once a reviewer "
+                "approves, you'll get an email; then reopen this repo from your unpublished list (it "
+                "will be marked 'approved') and click Make Public again to do the final flip to public "
+                "— within 14 days of approval. Until then it stays private (reopening to make changes "
+                "will require requesting review again).")
             return
         # Now that the repo is actually public, add the creator to the contact list (best-effort,
         # background).  Done here — never at stage — so discarded/abandoned repos never leak a


### PR DESCRIPTION
Makes the two-step member-driven publish legible to the curator. (Pairs with intake `/repos/review-status`.)

The flow: you Make Public -> reviewer approves (App mints the DOI, repo stays private) -> you reopen and Make Public again to do the final flip. Easy to misread as "approval publishes it", which is exactly what happened in testing.

- **Unpublished list now shows state.** `refreshStagedReposList` labels each org staged repo from the App: `approved -- click Make Public to finish` or `pending review`. No more clicking Make Public blind. Org repos only (short-term personal publish directly); best-effort, so the list still renders if the App is unreachable.
- **`logic_controlplane.reviewStatus()`** POSTs the repo names and returns `{name: state}`; `{}` on any error.
- **Submit popup sharpened** to state the two-step flow, the approval email, the new "approved" label, and the 14-day finish window.

`py_compile` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)