### PR TITLE
Create/Release tab UI text accuracy pass + dead-code cleanup

### DIFF
--- a/MorphoDepot/MorphoDepot.py
+++ b/MorphoDepot/MorphoDepot.py
@@ -37,7 +37,7 @@ from slicer.parameterNodeWrapper import (
 #
 
 from MorphoDepotLib.forms import (FormBaseQuestion, FormRadioQuestion, FormCheckBoxesQuestion,
-    FormTextQuestion, FormComboBoxQuestion, FormSpeciesQuestion)
+    FormTextQuestion, FormSpeciesQuestion)
 from MorphoDepotLib.accession_form import MorphoDepotAccessionForm
 from MorphoDepotLib.search_form import MorphoDepotSearchForm
 from MorphoDepotLib.screenshot_dialog import ScreenshotReviewDialog
@@ -356,7 +356,7 @@ class MorphoDepotWidget(ScriptedLoadableModuleWidget, VTKObservationMixin, Enabl
         self.createUI.segmentationSelector.setMRMLScene(slicer.mrmlScene)
         self.createUI.segmentationSelector.noneEnabled = True
         self.createUI.segmentationSelector.noneDisplay = "Select a baseline segmentation (optional)"
-        self.createUI.segmentationSelector.toolTip = "Pick an baseline segmentation (optional)."
+        self.createUI.segmentationSelector.toolTip = "Pick a baseline segmentation (optional)."
 
         formLayout = self.createUI.inputsCollapsibleButton.layout()
         formLayout.addRow("Source volume:", self.createUI.inputSelector)
@@ -371,9 +371,6 @@ class MorphoDepotWidget(ScriptedLoadableModuleWidget, VTKObservationMixin, Enabl
         self.createUI.createRepository.text = "Create (stage privately)"
         self.createUI.accessionForm = MorphoDepotAccessionForm(validationCallback=self._onAccessionFormValidated)
         self.createUI.accessionLayout.addWidget(self.createUI.accessionForm.topWidget)
-        # The destination dropdown is filled lazily the first time the Create tab is shown
-        # (see populateOwnerSelector / onCurrentTabChanged).
-        self.ownerSelectorPopulated = False
         # Auto-assign workflow availability is also resolved lazily on first Create-tab entry.
         self._workflowScopeChecked = False
         self._hasWorkflowScope = False
@@ -421,7 +418,7 @@ class MorphoDepotWidget(ScriptedLoadableModuleWidget, VTKObservationMixin, Enabl
         # privately but not yet published — the recovery path after a crash / close / different
         # computer (no client state).  Double-click to load for editing; right-click for actions.
         self.createUI.stagedReposCollapsible = ctk.ctkCollapsibleButton()
-        self.createUI.stagedReposCollapsible.text = "Existing yet to be published (staged only) Repos"
+        self.createUI.stagedReposCollapsible.text = "Staged repositories — not yet published"
         self.createUI.stagedReposCollapsible.collapsed = False
         stagedReposLayout = qt.QVBoxLayout(self.createUI.stagedReposCollapsible)
         stagedReposLayout.setContentsMargins(4, 4, 4, 4)
@@ -459,10 +456,10 @@ class MorphoDepotWidget(ScriptedLoadableModuleWidget, VTKObservationMixin, Enabl
         # REGION 2 action: "Update Repository (staged)" sits beside the form's "Create (stage
         # privately)" button (shown only when editing a reopened repo).  Both are form actions
         # and belong with the form — NOT in the Go-live section.
-        self.createUI.saveEditsButton = qt.QPushButton("Update Repository (staged)")
+        self.createUI.saveEditsButton = qt.QPushButton("Save Changes")
         self.createUI.saveEditsButton.toolTip = (
-            "Save your edits to the staged repository without publishing it. You can keep "
-            "editing and updating, then Publish when ready.")
+            "Save your changes to the staged repository without publishing it. You can keep "
+            "editing and saving, then Publish when ready.")
         self.createUI.saveEditsButton.visible = False
         createButtonIndex = self.createUI.verticalLayout.indexOf(self.createUI.createRepository)
         self.createUI.verticalLayout.insertWidget(createButtonIndex + 1, self.createUI.saveEditsButton)
@@ -515,6 +512,12 @@ class MorphoDepotWidget(ScriptedLoadableModuleWidget, VTKObservationMixin, Enabl
             self.createUI.accessionForm.questions["repoType"].questionBox.hide()
         except Exception:
             pass
+        # Section 6 redistribution acknowledgement is archival-only; hide it until the repo type is
+        # set to Archival (the type selector toggles it via _onRepoTypeChanged).
+        try:
+            self.createUI.accessionForm.questions["redistributionAcknowledgement"].questionBox.hide()
+        except Exception:
+            pass
 
         # === REGION 3: Make Repository Public (shown only once a repo is staged) ===
         # Separated from the form above by a divider + bold centered header (the SAME treatment
@@ -524,7 +527,7 @@ class MorphoDepotWidget(ScriptedLoadableModuleWidget, VTKObservationMixin, Enabl
         self.createUI.goLiveDivider.setFrameShape(qt.QFrame.HLine)
         self.createUI.goLiveDivider.setFrameShadow(qt.QFrame.Sunken)
         self.createUI.goLiveDivider.setLineWidth(2)
-        self.createUI.goLiveHeader = qt.QLabel("Make Repository Public (Publish)")
+        self.createUI.goLiveHeader = qt.QLabel("Make Repository Public")
         goLiveHeaderFont = self.createUI.goLiveHeader.font
         goLiveHeaderFont.setBold(True)
         goLiveHeaderFont.setPointSize(goLiveHeaderFont.pointSize() + 3)
@@ -547,17 +550,8 @@ class MorphoDepotWidget(ScriptedLoadableModuleWidget, VTKObservationMixin, Enabl
         self.createUI.goLiveEmail = qt.QLineEdit()
         self.createUI.goLiveEmail.toolTip = emailTooltip
         goLiveLayout.addWidget(self.createUI.goLiveEmail)
-        # Publish destination (personal account or an organization); hidden unless the user is
-        # in at least one organization (populateOwnerSelector decides).
-        self.createUI.destinationQuestion = FormComboBoxQuestion("Publish destination:")
-        self.createUI.destinationQuestion.questionBox.toolTip = (
-            "When you click 'Make Public', the repository is made public under this owner. "
-            "Choose your personal account or an organization you belong to.")
-        self.createUI.destinationQuestion.questionBox.setVisible(False)
-        self.createUI.destinationPersonalLogin = ""
-        goLiveLayout.addWidget(self.createUI.destinationQuestion.questionBox)
         goLiveButtonsLayout = qt.QHBoxLayout()
-        self.createUI.publishButton = qt.QPushButton("Make Public")
+        self.createUI.publishButton = qt.QPushButton("Publish")
         self.createUI.publishButton.enabled = False
         self.createUI.discardButton = qt.QPushButton("Discard")
         self.createUI.discardButton.enabled = False
@@ -740,9 +734,8 @@ class MorphoDepotWidget(ScriptedLoadableModuleWidget, VTKObservationMixin, Enabl
         self.updateRefreshButtonLabels()
 
         # The currentChanged signal is connected after the tab index is restored above, so
-        # populate the destination dropdown here if the Create tab is the active one at launch.
+        # refresh the staged-repos list here if the Create tab is the active one at launch.
         if self.tabWidget.currentIndex == self.createTabIndex:
-            self.populateOwnerSelector()
             self.refreshStagedReposList()
 
     def cleanup(self) -> None:
@@ -775,8 +768,6 @@ class MorphoDepotWidget(ScriptedLoadableModuleWidget, VTKObservationMixin, Enabl
         qt.QSettings().setValue("MorphoDepot/tabIndex", index)
         self.updateRefreshButtonLabels()
         if index == self.createTabIndex:
-            if not self.ownerSelectorPopulated:
-                self.populateOwnerSelector()
             self._refreshAutoAssignAvailability()
             self._refreshArchivalAvailability()
             self.refreshStagedReposList()
@@ -945,7 +936,6 @@ class MorphoDepotTest(ScriptedLoadableModuleTest):
         form.questions["modality"].optionButtons["Micro CT (or synchrotron)"].click()
         form.questions["contrastEnhancement"].optionButtons["No"].click()
         form.questions["imageContents"].optionButtons["Whole specimen"].click()
-        form.questions["redistributionAcknowledgement"].optionButtons["I have the right to allow redistribution of this data."].click()
         form.questions["license"].optionButtons["CC BY 4.0 (requires attribution, allows commercial usage)"].click()
         form.questions["githubRepoName"].answerText.text = repoName
         repoNameWithOwner = f"{logic.morphoDepotTestingOrg}/{repoName}"

--- a/MorphoDepot/MorphoDepotLib/accession_form.py
+++ b/MorphoDepot/MorphoDepotLib/accession_form.py
@@ -259,9 +259,6 @@ class MorphoDepotAccessionForm():
 
         # section 7
         layout = self.sectionWidgets[7].layout()
-        # Note: the repository destination (personal account vs. organization) is chosen later,
-        # at the Go-live gate in the Create tab — not here. Every repo is first staged privately
-        # on the creator's personal account. See MorphoDepotWidget.populateOwnerSelector().
         q,a,t = form["githubRepoName"]
         self.questions["githubRepoName"] = FormTextQuestion(q, self.validateForm)
         self.questions["githubRepoName"].questionBox.toolTip = t
@@ -416,7 +413,10 @@ class MorphoDepotAccessionForm():
         if isBiological:
             valid = valid and self.questions["contrastEnhancement"].answer() != ""
             valid = valid and self.questions["imageContents"].answer() != ""
-        valid = valid and self.questions["redistributionAcknowledgement"].answer() != []
+        # Redistribution acknowledgement (Section 6) is required only for ARCHIVAL repos; short-term
+        # repos neither show nor require it (the box is hidden by the repo-type selector).
+        if self.questions["repoType"].answer().startswith("Archival"):
+            valid = valid and self.questions["redistributionAcknowledgement"].answer() != []
         valid = valid and self.questions["license"].answer() != ""
         self._applySuggestedRepoName()   # F4: prefill a metadata-derived name (until the user edits it)
         valid = valid and self.questions["githubRepoName"].answer() != ""

--- a/MorphoDepot/MorphoDepotLib/widget_configure.py
+++ b/MorphoDepot/MorphoDepotLib/widget_configure.py
@@ -91,8 +91,7 @@ class ConfigureTabMixin:
             self.configureUI.userEmailStatusLabel.visible = True
 
     def onAutoAssignHelp(self):
-        """Explain the auto-assign option in a popup.  Kept as a popup for now; the
-        'Open Documentation' button is where a proper docs page will be linked later."""
+        """Explain the auto-assign option in a popup.  The explanation is kept in-module."""
         msgBox = qt.QMessageBox()
         msgBox.setWindowTitle("Auto-assign new issues to their creators")
         msgBox.setIcon(qt.QMessageBox.Information)
@@ -105,12 +104,8 @@ class ConfigureTabMixin:
             "them — the person who reports or requests something is already the assignee.\n\n"
             "This requires your GitHub login to have the 'workflow' scope. The option is left "
             "disabled until that scope is present.")
-        openDocsButton = msgBox.addButton("Open Documentation", qt.QMessageBox.ActionRole)
         msgBox.addButton(qt.QMessageBox.Ok)
         msgBox.exec_()
-        if msgBox.clickedButton() == openDocsButton:
-            qt.QDesktopServices.openUrl(qt.QUrl(
-                "https://github.com/SlicerMorph/SlicerMorphoDepot?tab=readme-ov-file#morphodepot"))
 
     def onUserNameChanged(self, userName):
         if userName:

--- a/MorphoDepot/MorphoDepotLib/widget_create.py
+++ b/MorphoDepot/MorphoDepotLib/widget_create.py
@@ -1172,8 +1172,8 @@ class CreateTabMixin:
         # When creating under the org, make the destination unmistakable at the top.
         if useOrg:
             repoName = accessionData['githubRepoName'][1].split("/")[-1]
-            # TODO: confirm the published guidelines URL (archival vs. short-term).
-            archivalDocURL = "https://morphodepot.org/docs/repository-types"
+            archivalDocURL = ("https://github.com/MorphoDepot/docs/blob/main/"
+                              "MorphoDepot-archival-guidelines.md#two-kinds-of-dataset")
             headerLabel = qt.QLabel(
                 f"<b>This repository will be created in the MorphoDepot organization, as "
                 f"<code>{self.logic.morphoDepotOrg}/{repoName}</code>.</b><br>"

--- a/MorphoDepot/MorphoDepotLib/widget_create.py
+++ b/MorphoDepot/MorphoDepotLib/widget_create.py
@@ -53,7 +53,7 @@ class CreateTabMixin:
             placeholder.setFlags(qt.Qt.NoItemFlags)
             listWidget.addItem(placeholder)
             return
-        # Label each org repo with its review state so the curator isn't clicking Make Public blind:
+        # Label each org repo with its review state so the curator isn't clicking Publish blind:
         # 'approved' (their turn to finish the flip) vs 'pending review'.  Org repos only -- short-term
         # personal repos publish directly with no review.  Best-effort (reviewStatus returns {} on error).
         orgPrefix = self.logic.morphoDepotOrg + "/"
@@ -64,7 +64,7 @@ class CreateTabMixin:
             label = repo.get("summary") or repo.get("nameWithOwner", "")
             state = statuses.get(repo.get("repoName"))
             if state == "approved":
-                label += "    ✓ approved — click Make Public to finish"
+                label += "    ✓ approved — click Publish to finish"
             elif state == "pending":
                 label += "    ⏳ pending review"
             item = qt.QListWidgetItem(label)
@@ -323,6 +323,12 @@ class CreateTabMixin:
             self.createUI.accessionForm.questions["repoType"].optionButtons[label].click()
         except Exception:
             pass
+        # Section 6 redistribution acknowledgement is archival-only: show it for archival, hide it
+        # for short-term (validateForm requires it only when archival -- see accession_form).
+        try:
+            self.createUI.accessionForm.questions["redistributionAcknowledgement"].questionBox.setVisible(isArchival)
+        except Exception:
+            pass
 
     def _refreshAutoAssignAvailability(self):
         """Check whether the gh token has the `workflow` scope and enable the auto-assign checkbox
@@ -459,10 +465,18 @@ class CreateTabMixin:
 
     def _redistributionAcknowledged(self):
         """True if the Section-6 'I have the right to allow redistribution of this data' box is
-        ticked.  Required to stage (validateForm), and enforced again at Update and Publish so the
-        attestation cannot be revoked while still proceeding."""
+        ticked.  Archival-only: required to stage an archival repo (validateForm), and enforced
+        again at Update and Publish so the attestation cannot be revoked while still proceeding."""
         try:
             return self.createUI.accessionForm.questions["redistributionAcknowledgement"].answer() != []
+        except Exception:
+            return False
+
+    def _redistributionRequired(self):
+        """The redistribution acknowledgement is archival-only: required (and shown) only when the
+        repository type is Archival.  Short-term repos neither show nor require it."""
+        try:
+            return self.createUI.accessionForm.questions["repoType"].answer().startswith("Archival")
         except Exception:
             return False
 
@@ -488,43 +502,6 @@ class CreateTabMixin:
         emailRegex = r'^[^@\s]+@[^@\s]+\.[^@\s]+$'
         email = self.createUI.goLiveEmail.text.strip()
         self.createUI.publishButton.enabled = bool(re.match(emailRegex, email))
-
-    def populateOwnerSelector(self):
-        """Fill the Create-tab destination dropdown with the active user's account and orgs.
-
-        Detects the organizations the logged-in GitHub account belongs to; if there are any,
-        the destination selector offers a choice between the personal account and each
-        organization (consulted at Go-live).  Runs lazily the first time the Create tab is
-        opened; transient failures (e.g. gh not yet configured) leave the flag unset so it
-        retries next time."""
-        destination = getattr(self.createUI, "destinationQuestion", None)
-        if destination is None:
-            return
-        try:
-            personal = self.logic.whoami()
-        except Exception as e:
-            logging.warning(f"Could not determine active GitHub user: {e}")
-            personal = ""
-        organizations = self.logic.userOrganizations() if personal else []
-        options = []
-        if personal:
-            options.append((f"{personal} (your personal account)", personal))
-        for org in organizations:
-            options.append((f"{org} (organization)", org))
-        destination.setOptions(options)
-        destination.questionBox.setVisible(False)  # destination is chosen at create now, not publish
-        self.createUI.destinationPersonalLogin = personal
-        self.ownerSelectorPopulated = bool(personal)
-
-    def selectedDestination(self):
-        """Return the chosen Go-live destination owner login, or '' if none resolved yet."""
-        destination = getattr(self.createUI, "destinationQuestion", None)
-        return destination.answer() if destination is not None else ""
-
-    def selectedDestinationIsOrganization(self):
-        """True when the chosen Go-live destination is an organization, not the personal account."""
-        owner = self.selectedDestination()
-        return bool(owner) and owner != getattr(self.createUI, "destinationPersonalLogin", "")
 
     def _isDefaultSlicerColorTable(self, colorNode):
         """True if colorNode is a built-in/default Slicer color table rather than a real terminology
@@ -739,7 +716,6 @@ class CreateTabMixin:
     def _enterGoLiveState(self, stagedNameWithOwner):
         """Reveal the Go-live gate after a repo has been staged privately."""
         self._stagedNameWithOwner = stagedNameWithOwner
-        self.populateOwnerSelector()
         self.createUI.createRepository.enabled = False
         self._setGoLiveZoneVisible(True)
         # Org members are already on the contact list (verified email captured at ORCID
@@ -763,11 +739,11 @@ class CreateTabMixin:
         if self._resumedForEdit:
             self.createUI.stagingStatusLabel.text = (
                 f"Editing staged repo {stagedNameWithOwner} (private, not yet published).\n"
-                "Correct any fields, Save changes as many times as you need, then Publish.")
+                "Correct any fields, click Save Changes as many times as you need, then Publish.")
         else:
             self.createUI.stagingStatusLabel.text = (
                 f"Staged privately as {stagedNameWithOwner} — not yet public, not discoverable.\n"
-                "Review it on GitHub, then choose a destination and Publish, or Discard.")
+                "Review it on GitHub. When ready click Publish, or Discard to remove the staged repo.")
         # Passive duplicate-volume note (cached from staging — no network here): a shared SHA-256
         # means a byte-identical source volume already lives in another repo.
         stagingCtx = getattr(self.logic, "stagingContext", None) or {}
@@ -784,7 +760,7 @@ class CreateTabMixin:
         repeatedly before going live."""
         if not self._resumedForEdit:
             return
-        if not self._redistributionAcknowledged():
+        if self._redistributionRequired() and not self._redistributionAcknowledged():
             slicer.util.errorDisplay(
                 "Please confirm you have the right to allow redistribution of this data "
                 "(Section 6: Licensing) before updating the repository.",
@@ -808,9 +784,9 @@ class CreateTabMixin:
         self._rebaselineResumedNodes()
         repoName = self._stagedNameWithOwner
         if changed:
-            statusText = f"✓ Repository updated: {repoName} (still staged — not yet published)."
-            popupText = (f"'{repoName}' was updated.\n\nIt is still staged (private, not "
-                         "published). Keep editing and updating, or click Publish when ready.")
+            statusText = f"✓ Changes saved: {repoName} (still staged — not yet published)."
+            popupText = (f"'{repoName}' was saved.\n\nIt is still staged (private, not "
+                         "published). Keep editing and saving, or click Publish when ready.")
         else:
             statusText = "No changes to save — the repository already matches the form."
             popupText = "No changes to save — the repository already matches the form."
@@ -1000,7 +976,7 @@ class CreateTabMixin:
     def onPublish(self):
         """Take the staged repo live (make it public) where it already lives — the destination
         was fixed at create, so this no longer offers an org/personal choice or any transfer."""
-        if not self._redistributionAcknowledged():
+        if self._redistributionRequired() and not self._redistributionAcknowledged():
             slicer.util.errorDisplay(
                 "Please confirm you have the right to allow redistribution of this data "
                 "(Section 6: Licensing) before publishing.",
@@ -1111,7 +1087,7 @@ class CreateTabMixin:
                 slicer.util.errorDisplay(
                     "Automated checks must pass before this can be reviewed:\n\n"
                     f"{lines}\n\n"
-                    "Fix these, then click Make Public again to re-submit."
+                    "Fix these, then click Publish again to re-submit."
                     + (f"\n\nTracking issue: {final.get('issueUrl')}" if final.get("issueUrl") else ""),
                     windowTitle="Changes required before publishing")
             return
@@ -1127,14 +1103,14 @@ class CreateTabMixin:
             self.createUI.discardButton.enabled = False
             self.createUI.openRepository.enabled = False
             self.createUI.stagingStatusLabel.text = (
-                f"Submitted for review: {where} becomes public once approved.")
+                f"Submitted for review: {where} — once approved, you need to click Publish once more to make it public.")
             self.refreshStagedReposList(force=True)
             self._completeStepReset(
                 "Review request is successfully completed",
                 f"'{where}' has been submitted for review.\n\n"
                 f"Publishing is a two-step process. A request was emailed to {to}. Once a reviewer "
                 "approves, you'll get an email; then reopen this repo from your unpublished list (it "
-                "will be marked 'approved') and click Make Public again to do the final flip to public "
+                "will be marked 'approved') and click Publish again to do the final flip to public "
                 "— within 14 days of approval. Until then it stays private (reopening to make changes "
                 "will require requesting review again).")
             return
@@ -1155,7 +1131,7 @@ class CreateTabMixin:
             qt.QDesktopServices.openUrl(qt.QUrl(f"https://github.com/{final}"))
         self._completeStepReset(
             "Publishing is successfully completed",
-            f"{final} is now public and discoverable in the MorphoDepot organization.")
+            f"{final} is now public and discoverable.")
 
     def onDiscard(self):
         """Abandon the staged repo.  Deleting a repo needs the `delete_repo` token scope,
@@ -1196,10 +1172,14 @@ class CreateTabMixin:
         # When creating under the org, make the destination unmistakable at the top.
         if useOrg:
             repoName = accessionData['githubRepoName'][1].split("/")[-1]
+            # TODO: confirm the published guidelines URL (archival vs. short-term).
+            archivalDocURL = "https://morphodepot.org/docs/repository-types"
             headerLabel = qt.QLabel(
                 f"<b>This repository will be created in the MorphoDepot organization, as "
                 f"<code>{self.logic.morphoDepotOrg}/{repoName}</code>.</b><br>"
-                "Cancel if you'd rather create it under your own account.")
+                "Change the repository type to Short-term if you'd rather create it under "
+                f"your own account. <a href=\"{archivalDocURL}\">Archival vs. short-term &rarr;</a>")
+            headerLabel.setOpenExternalLinks(True)
             headerLabel.setWordWrap(True)
             headerLabel.setStyleSheet("color:#b35900;")
             layout.addWidget(headerLabel)
@@ -1251,8 +1231,8 @@ class CreateTabMixin:
             return f"{label}: <i>{value}</i><br>"
 
         summary += add_detail("GitHub Repository", accessionData['githubRepoName'][1])
-        summary += add_detail("Initial state", "Private staging repo on your personal account "
-                              "(made public — and transferred to an org if you choose — at Go-live)")
+        summary += add_detail("Initial state", "Created as a private repository; made public "
+                              "when you click Publish")
         summary += add_detail("Source Volume", sourceVolume.GetName())
         summary += add_detail("Color Table", colorTable.GetName())
         if sourceSegmentation:
@@ -1357,7 +1337,8 @@ class CreateTabMixin:
         form.questions["contrastEnhancement"].optionButtons["No"].click()
         form.questions["imageContents"].optionButtons["Whole specimen"].click()
         form.questions["githubRepoName"].answerText.text = repoName
-        form.questions["redistributionAcknowledgement"].optionButtons["I have the right to allow redistribution of this data."].click()
         self.createUI.shortTermRadio.checked = True  # top-level Q0 selector -> drives the hidden repoType question
+        # Short-term fill: the redistribution acknowledgement is archival-only and hidden here, so it
+        # is intentionally not ticked.
         # Contact email is no longer part of the accession form; it is entered in the widget's
         # Go-live section and submitted at publish.

--- a/MorphoDepot/MorphoDepotLib/widget_release.py
+++ b/MorphoDepot/MorphoDepotLib/widget_release.py
@@ -618,10 +618,11 @@ class ReleaseTabMixin:
         if plan['issueSegFiles']:
             lines.append(
                 f"• {len(plan['issueSegFiles'])} per-issue segmentation file(s) will be removed from "
-                f"the working tree (kept in git history and in the pre-release-{tag} archive): "
-                f"{', '.join(plan['issueSegFiles'])}."
+                f"the working tree (kept in git history): {', '.join(plan['issueSegFiles'])}."
             )
         lines.append("")
+        # Release tab only lists org/archival repos (administratedRepoList); the short-term test path
+        # skips this dialog via testingMode, so the release described here is always the reviewed one.
         lines.append("This is an archival repository, so the release is reviewed before it goes public:")
         lines.append(f"  1. The release commit is pushed to a release-candidate-{tag} branch — main is left untouched.")
         lines.append("  2. A review request is emailed to the MorphoDepot reviewers.")

--- a/MorphoDepot/MorphoDepotLib/widget_release.py
+++ b/MorphoDepot/MorphoDepotLib/widget_release.py
@@ -412,7 +412,7 @@ class ReleaseTabMixin:
             if not self._curateContributorsForRelease(nameWithOwner):
                 return
 
-        prompt = self.buildReleaseConfirmation(plan, baselineNode, colorTableNode)
+        prompt = self.buildReleaseConfirmation(plan, baselineNode, colorTableNode, nameWithOwner)
         if not (self.testingMode or slicer.util.confirmOkCancelDisplay(prompt, windowTitle=f"Make release {newTag}")):
             return
 
@@ -588,30 +588,26 @@ class ReleaseTabMixin:
             MDC.ensure_person(data, github=login, github_id=author.get("id"), source="non-member")
             MDC.add_contribution(data, issue=int(match.group(1)), by=login, release=stampRelease)
 
-    def buildReleaseConfirmation(self, plan, baselineNode, colorTableNode):
-        """Compose the OK/Cancel summary describing every action that will run during release."""
+    def buildReleaseConfirmation(self, plan, baselineNode, colorTableNode, nameWithOwner):
+        """Compose the OK/Cancel summary describing every action that will run during release.
+
+        Releases are archival/org-only (the Release tab lists only org repos), so this always
+        describes the reviewed flow: the release commit goes to a release-candidate branch and
+        the tag + DOI are cut by the App on approval -- main is untouched until then."""
+        tag = plan['newTag']
         lines = []
-        lines.append(f"Make release {plan['newTag']} for the loaded repository.")
+        lines.append(f"Make release {tag} for {nameWithOwner}.")
         lines.append("")
-        lines.append("If you click OK, the following will happen on main:")
-        lines.append(
-            f"• A pre-release-{plan['newTag']} archive branch will be created and pushed to GitHub, "
-            f"capturing the pre-release state of main (including all per-issue segmentations) "
-            f"so it stays browsable on the remote."
-        )
-        lines.append(f"• The selected segmentation '{baselineNode.GetName()}' will be saved as baseline.seg.nrrd (replacing any existing one).")
-        lines.append(f"• The selected color table '{colorTableNode.GetName()}' will be saved (replacing any existing one).")
+        lines.append("This release will package:")
+        lines.append(f"• Baseline segmentation '{baselineNode.GetName()}' → saved as baseline.seg.nrrd (replaces the current one).")
+        lines.append(f"• Color table '{colorTableNode.GetName()}' → replaces the current one.")
+        lines.append(f"• README.md → regenerated for {tag}.")
         if plan['archivedReadme']:
             lines.append(
-                f"• README.md will be moved to {plan['archivedReadme']} and a new README.md will be generated for {plan['newTag']}."
+                f"  ⚠ The new README.md is rebuilt from MorphoDepotAccession.json. Your current "
+                f"README.md is preserved as {plan['archivedReadme']}, but manual edits in it are NOT "
+                f"carried into the new one — copy anything you want to keep after the release."
             )
-            lines.append(
-                f"  ⚠ The new README.md is regenerated from MorphoDepotAccession.json — any manual edits in the current README.md "
-                f"will be preserved in {plan['archivedReadme']} but NOT carried into the new README.md. "
-                f"After the release, copy any sections you want to keep into the new README.md by hand."
-            )
-        else:
-            lines.append(f"• A new README.md will be generated for {plan['newTag']}.")
         if plan['newScreenshotNames']:
             lines.append(
                 f"• {len(plan['newScreenshotNames'])} new screenshot(s) will be added: "
@@ -621,16 +617,22 @@ class ReleaseTabMixin:
             lines.append("• No new screenshots will be added.")
         if plan['issueSegFiles']:
             lines.append(
-                f"• {len(plan['issueSegFiles'])} per-issue segmentation file(s) will be removed from the working tree "
-                f"(preserved in the pre-release-{plan['newTag']} branch and in git history): {', '.join(plan['issueSegFiles'])}."
+                f"• {len(plan['issueSegFiles'])} per-issue segmentation file(s) will be removed from "
+                f"the working tree (kept in git history and in the pre-release-{tag} archive): "
+                f"{', '.join(plan['issueSegFiles'])}."
             )
+        lines.append("")
+        lines.append("This is an archival repository, so the release is reviewed before it goes public:")
+        lines.append(f"  1. The release commit is pushed to a release-candidate-{tag} branch — main is left untouched.")
+        lines.append("  2. A review request is emailed to the MorphoDepot reviewers.")
         lines.append(
-            f"• These changes will be committed and pushed to origin/main, then the {plan['newTag']} "
-            f"release tag will be created at the same commit."
+            f"  3. On approval the release is cut automatically: main is archived as pre-release-{tag}, "
+            f"updated to the candidate, the {tag} tag is created, and a DOI is minted for the release."
         )
+        lines.append("  4. If changes are requested, you'll get an email; nothing is published until you re-submit and it's approved.")
         lines.append("")
         lines.append("No data is lost: prior versions of every changed file remain in git history, and clicking Cancel makes no changes at all.")
-        lines.append("If anything fails partway, you will be offered the chance to reset the local repo to its pre-release state or to keep the partial changes for manual inspection.")
+        lines.append("If anything fails partway, you will be offered the chance to reset the local repository to its pre-release state or to keep the partial changes for inspection.")
         return "\n".join(lines)
 
     def handleReleaseFailure(self, error):


### PR DESCRIPTION
## What

An accuracy pass over every user-facing string in the **Create** and **Release** tabs, checked against how the create/publish/release workflow actually behaves today, plus a small amount of dead-code cleanup the review surfaced.

## Why

Several messages had drifted from the current workflow (e.g. the create-time destination model replaced the old "stage-on-personal, transfer-at-go-live" model, and archival vs. short-term repos behave differently), and Publish terminology was inconsistent ("Make Public" vs "Publish", "Update Repository" vs "Save Changes").

## Changes

**Accuracy fixes**
- Publish success message no longer claims "in the MorphoDepot organization" — that path is reached only for short-term/personal repos.
- Dropped stale "transferred to an org if you choose at Go-live" / "choose a destination" language (no destination choice or transfer exists anymore).
- Submitted-for-review status now states approval needs a second **Publish** click (the member-driven flip).

**Terminology (standardized)**
- Buttons use the verb **Publish**; descriptive text keeps **Make Repository Public**.
- `Update Repository (staged)` → **Save Changes** (+ consistent surrounding prose).
- Grammar: "Pick **a** baseline…".

**Behavioral**
- **Redistribution acknowledgement (Section 6) is now archival-only**: hidden and not required for short-term repos; the repo-type selector toggles its visibility, and it's gated at staging (`validateForm`), Save Changes, and Publish only when archival. License stays required for all types.
- **Release confirmation rewritten** to be org-only (review gate + DOI minting), since the Release tab already lists only archival/org repos (`administratedRepoList`). Clearer "what's packaged / what happens / reassurance" structure, and it no longer mis-describes the org path as a direct push to `origin/main`.

**Cleanup**
- Removed the **dormant "Publish destination" subsystem** (never shown; `setVisible(True)` never called; helper methods never invoked; it ran a pointless `userOrganizations()` call on every Create-tab entry and go-live) plus the now-unused `FormComboBoxQuestion` import.
- Removed the placeholder **"Open Documentation"** button from the auto-assign help popup; the explanation stays in-module.

## Notes for review

- ⚠️ **One TODO**: the archival-vs-short-term guidelines link added to the org-confirm dialog uses a placeholder URL (`https://morphodepot.org/docs/repository-types`) marked with a `# TODO` — needs the real published path before merge.
- The personal/short-term **release code path is intentionally kept** (used by the short-term test repos); only the *confirmation text* is org-only, and that dialog is skipped in `testingMode`, so the two don't conflict.
- **Testing**: all five edited files pass `python -m py_compile`; verified no dangling references to the removed symbols and no remaining "Make Public" strings. The full Slicer UI/e2e suite was **not** run in this environment — worth a sanity run of the Create/Release flows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
