### PR TITLE
Accession form: fix scroll area, rework Section 3 taxon controls, add advisory GBIF check

### DIFF
--- a/MorphoDepot/MorphoDepotLib/accession_form.py
+++ b/MorphoDepot/MorphoDepotLib/accession_form.py
@@ -67,7 +67,7 @@ class MorphoDepotAccessionForm():
         "species" : (
             "What is your specimen's species?",
             "",
-            "Enter a valid genus and species for your specimen and use the 'Check species' button to confirm.  If unsure, use the GBIF web page to search"
+            "Enter a valid genus and species for your specimen.  If unsure, use the 'Search taxon in GBIF' button to look it up and pick the correct name."
         ),
         "biologicalSex" : (
             "What is your specimen's sex?",
@@ -141,6 +141,11 @@ class MorphoDepotAccessionForm():
             self.scrollArea = qt.QScrollArea()
             self.scrollArea.setWidget(self.form)
             self.scrollArea.setWidgetResizable(True)
+            # A QScrollArea reports a near-zero minimum height, so when this widget is itself
+            # nested inside Slicer's (already scrolling) module panel, the surrounding layout
+            # happily shrinks it to a sliver and the form never expands.  Force a usable
+            # minimum height so the box always shows several rows and scrolls internally.
+            self.scrollArea.setMinimumHeight(400)
             self.topWidget = self.scrollArea
         else:
             self.topWidget = self.form

--- a/MorphoDepot/MorphoDepotLib/forms.py
+++ b/MorphoDepot/MorphoDepotLib/forms.py
@@ -155,6 +155,10 @@ class FormSpeciesQuestion(FormTextQuestion):
             rank = (entry.get("rank") or "").lower()
             if rank:
                 flat[rank] = entry.get("name")  # kingdom, phylum, class, order, family, genus, species
+        # GBIF's classification normally includes the species entry, but if a response omits it,
+        # fall back to the matched usage name so the species row is never left blank.
+        if not flat.get("species") and (flat.get("rank") or "").upper() == "SPECIES":
+            flat["species"] = flat["canonicalName"]
         return flat
 
     def _setSpeciesInfoLabel(self, result):

--- a/MorphoDepot/MorphoDepotLib/forms.py
+++ b/MorphoDepot/MorphoDepotLib/forms.py
@@ -155,8 +155,9 @@ class FormSpeciesQuestion(FormTextQuestion):
             rank = (entry.get("rank") or "").lower()
             if rank:
                 flat[rank] = entry.get("name")  # kingdom, phylum, class, order, family, genus, species
-        # GBIF's classification normally includes the species entry, but if a response omits it,
-        # fall back to the matched usage name so the species row is never left blank.
+        # Whether GBIF's classification array carries the SPECIES entry varies across responses;
+        # if the loop above didn't fill the species row, fall back to the matched usage name so
+        # it is never left blank.
         if not flat.get("species") and (flat.get("rank") or "").upper() == "SPECIES":
             flat["species"] = flat["canonicalName"]
         return flat

--- a/MorphoDepot/MorphoDepotLib/forms.py
+++ b/MorphoDepot/MorphoDepotLib/forms.py
@@ -121,21 +121,47 @@ class FormComboBoxQuestion(FormBaseQuestion):
 class FormSpeciesQuestion(FormTextQuestion):
     def __init__(self, question, validator):
         super().__init__(question, validator)
-        self.checkSpeciesButton = qt.QPushButton("Check species")
-        self.checkSpeciesButton.connect("clicked()", self.onCheckSpecies)
-        self.questionLayout.addWidget(self.checkSpeciesButton)
-        self.searchButton = qt.QPushButton()
+        # Browse the GBIF backbone taxonomy and pick a name; clicking a result fills the field
+        # and shows its lineage in speciesInfo below.
+        self.searchButton = qt.QPushButton("Search taxon in GBIF")
         self.searchButton.setIcon(qt.QIcon(qt.QPixmap(":/Icons/Search.png")))
+        self.searchButton.setToolTip("Browse the GBIF backbone taxonomy and pick a species name to fill the field.")
         self.searchButton.connect("clicked()", self.onSearchSpecies)
         self.questionLayout.addWidget(self.searchButton)
         self.speciesInfo = qt.QLabel()
         self.questionLayout.addWidget(self.speciesInfo)
         self.searchDialog = None
 
+    @staticmethod
+    def _normalizeGbifResult(result):
+        """Flatten a GBIF name match into the flat keys this form displays.
+
+        The search dialog uses name_suggest(), which returns a *flat* dict with
+        matchType/rank/canonicalName/kingdom/... at the top level.  GBIF's newer *nested*
+        match format ({'usage': {...}, 'classification': [...], 'diagnostics': {...}}) is
+        also accepted so the lineage display is robust to pygbif version differences."""
+        if not isinstance(result, dict):
+            return {}
+        # The new nested format always carries one of these keys; the flat format never does.
+        isNested = any(key in result for key in ("diagnostics", "usage", "classification"))
+        if not isNested:
+            return result
+        flat = {}
+        flat["matchType"] = (result.get("diagnostics") or {}).get("matchType", "NONE")
+        usage = result.get("usage") or {}
+        flat["canonicalName"] = usage.get("canonicalName") or usage.get("name")
+        flat["rank"] = usage.get("rank")
+        for entry in result.get("classification") or []:
+            rank = (entry.get("rank") or "").lower()
+            if rank:
+                flat[rank] = entry.get("name")  # kingdom, phylum, class, order, family, genus, species
+        return flat
+
     def _setSpeciesInfoLabel(self, result):
+        result = self._normalizeGbifResult(result)
         requiredKeys = ['matchType', 'rank', 'canonicalName', 'kingdom', 'phylum', 'class', 'order', 'family', 'genus', 'species']
         for key in requiredKeys:
-            if key not in result:
+            if key not in result or result[key] is None:
                 result[key] = "missing"
         if result['matchType'] == "NONE":
             labelText = "No match"
@@ -184,11 +210,6 @@ class FormSpeciesQuestion(FormTextQuestion):
         result = item.data(qt.Qt.UserRole)
         self.answerText.text = result['canonicalName']
         self.searchDialog.hide()
-        self._setSpeciesInfoLabel(result)
-
-    def onCheckSpecies(self):
-        import pygbif
-        result = pygbif.species.name_backbone(self.answerText.text)
         self._setSpeciesInfoLabel(result)
 
     def answer(self):

--- a/MorphoDepot/MorphoDepotLib/widget_create.py
+++ b/MorphoDepot/MorphoDepotLib/widget_create.py
@@ -583,7 +583,9 @@ class CreateTabMixin:
             # only flags the discrepancy and lets the user proceed -- a reviewer follows up.  Skipped
             # in testing mode and silently passes if GBIF is unreachable (see _gbifTaxonStatus).
             if not self.testingMode and accessionData.get("subjectType", ["", ""])[1] == "Biological specimen":
+                slicer.util.showStatusMessage("Checking taxon name in GBIF...")
                 taxonIssue = self._gbifTaxonStatus(accessionData.get("species", ["", ""])[1])
+                slicer.util.showStatusMessage("")
                 if taxonIssue and not slicer.util.confirmOkCancelDisplay(
                         taxonIssue + "\n\n"
                         "This is not necessarily a problem: a recent name change, a newly described "

--- a/MorphoDepot/MorphoDepotLib/widget_create.py
+++ b/MorphoDepot/MorphoDepotLib/widget_create.py
@@ -577,6 +577,25 @@ class CreateTabMixin:
                 if colorTable.GetTerminologyAsString(colorIndex) == "~^^~^^~^^~~^^~^^~":
                     slicer.util.errorDisplay(f"Selected Color table is missing terminology for index {colorIndex}, {colorTable.GetColorName(colorIndex)}", windowTitle="Missing Terminology")
                     return None
+            # Advisory GBIF taxon check for archival biological specimens.  Unlike the color-table
+            # rules above this NEVER rejects: there are legitimate reasons a valid name is absent
+            # from GBIF (recent reclassification, a newly described species, indexing lag), so it
+            # only flags the discrepancy and lets the user proceed -- a reviewer follows up.  Skipped
+            # in testing mode and silently passes if GBIF is unreachable (see _gbifTaxonStatus).
+            if not self.testingMode and accessionData.get("subjectType", ["", ""])[1] == "Biological specimen":
+                taxonIssue = self._gbifTaxonStatus(accessionData.get("species", ["", ""])[1])
+                if taxonIssue and not slicer.util.confirmOkCancelDisplay(
+                        taxonIssue + "\n\n"
+                        "This is not necessarily a problem: a recent name change, a newly described "
+                        "species, or a name GBIF has not yet indexed can all cause it. It can also be "
+                        "a typo or an outdated name.\n\n"
+                        "Please double-check the name and, if it needs fixing, use the 'Search taxon "
+                        "in GBIF' button to look it up and insert the exact GBIF spelling.\n\n"
+                        "You can continue staging now regardless. Since this is an archival "
+                        "repository, a reviewer may follow up about this taxon during review.\n\n"
+                        "Click OK to continue staging, or Cancel to go back and edit the species.",
+                        windowTitle="Taxon not verified in GBIF"):
+                    return None
         else:
             validTerminology = True
             for colorIndex in range(1, colorTable.GetNumberOfColors()):

--- a/MorphoDepot/MorphoDepotLib/widget_validation.py
+++ b/MorphoDepot/MorphoDepotLib/widget_validation.py
@@ -4,6 +4,8 @@ Kept in a dedicated mixin (rather than living on one tab mixin and being called 
 so the dependency is explicit and either tab can use them without an implicit cross-tab coupling.
 """
 
+import logging
+
 
 class ValidationMixin:
     def _segmentationIsEmpty(self, node):
@@ -12,6 +14,45 @@ class ValidationMixin:
             return node is not None and node.GetSegmentation().GetNumberOfSegments() == 0
         except Exception:
             return False
+
+    def _gbifTaxonStatus(self, species):
+        """Advisory check of a species name against the GBIF backbone taxonomy.
+
+        Returns a short, human-readable sentence describing a discrepancy worth flagging
+        (not found / matched only above species rank / a GBIF synonym / no exact match), or
+        None when the name resolves cleanly to an accepted species -- OR when GBIF cannot be
+        reached or its response cannot be parsed.  Those failures return None on purpose: an
+        unverifiable name must never block or nag, because there are legitimate reasons a valid
+        name is absent from GBIF (a recent reclassification, a newly described species, indexing
+        lag).  Accepts both pygbif response shapes (flat pre-0.6, nested >= 0.6)."""
+        species = (species or "").strip()
+        if not species:
+            return None
+        try:
+            import pygbif
+            result = pygbif.species.name_backbone(species)
+        except Exception as e:
+            logging.warning(f"GBIF taxon check skipped for '{species}': {e}")
+            return None
+        if not isinstance(result, dict):
+            return None
+        diagnostics = result.get("diagnostics") or {}
+        usage = result.get("usage") or {}
+        accepted = result.get("acceptedUsage") or {}
+        matchType = diagnostics.get("matchType") or result.get("matchType") or "NONE"
+        canonical = usage.get("canonicalName") or usage.get("name") or result.get("canonicalName") or ""
+        rank = usage.get("rank") or result.get("rank") or ""
+        isSynonym = bool(result.get("synonym"))
+        acceptedName = accepted.get("canonicalName") or accepted.get("name") or canonical
+        if matchType == "NONE":
+            return f"'{species}' was not found in the GBIF backbone taxonomy."
+        if rank and rank != "SPECIES":
+            return f"GBIF could match '{species}' only to {rank.lower()} '{canonical}', not to a species."
+        if isSynonym and acceptedName:
+            return f"GBIF lists '{species}' as a synonym of the accepted name '{acceptedName}'."
+        if canonical and canonical.strip().lower() != species.lower():
+            return f"GBIF has no exact match for '{species}'. Its closest accepted name is '{canonical}'."
+        return None
 
     def _colorTableNotTerminology(self, node):
         """True if the color node does not look like a discrete terminology color table -- e.g. a

--- a/MorphoDepot/MorphoDepotLib/widget_validation.py
+++ b/MorphoDepot/MorphoDepotLib/widget_validation.py
@@ -30,7 +30,16 @@ class ValidationMixin:
             return None
         try:
             import pygbif
-            result = pygbif.species.name_backbone(species)
+            import socket
+            # name_backbone() runs synchronously on the Qt UI thread and pygbif uses requests,
+            # which has no default timeout -- so a slow/hung GBIF server would freeze Slicer.
+            # Cap the wait with a temporary socket timeout (restored in finally).
+            previousTimeout = socket.getdefaulttimeout()
+            socket.setdefaulttimeout(8)
+            try:
+                result = pygbif.species.name_backbone(species)
+            finally:
+                socket.setdefaulttimeout(previousTimeout)
         except Exception as e:
             logging.warning(f"GBIF taxon check skipped for '{species}': {e}")
             return None
@@ -43,12 +52,14 @@ class ValidationMixin:
         canonical = usage.get("canonicalName") or usage.get("name") or result.get("canonicalName") or ""
         rank = usage.get("rank") or result.get("rank") or ""
         isSynonym = bool(result.get("synonym"))
-        acceptedName = accepted.get("canonicalName") or accepted.get("name") or canonical
+        # Only the real accepted name (never the synonym itself) -- so we don't emit the
+        # self-referential "X is a synonym of X" when GBIF omits acceptedUsage.
+        acceptedName = accepted.get("canonicalName") or accepted.get("name") or ""
         if matchType == "NONE":
             return f"'{species}' was not found in the GBIF backbone taxonomy."
         if rank and rank != "SPECIES":
             return f"GBIF could match '{species}' only to {rank.lower()} '{canonical}', not to a species."
-        if isSynonym and acceptedName:
+        if isSynonym and acceptedName and acceptedName.strip().lower() != species.lower():
             return f"GBIF lists '{species}' as a synonym of the accepted name '{acceptedName}'."
         if canonical and canonical.strip().lower() != species.lower():
             return f"GBIF has no exact match for '{species}'. Its closest accepted name is '{canonical}'."


### PR DESCRIPTION
## Summary

Improvements to the Create tab's Accession Form, centered on the Section 3 taxon controls, plus an advisory GBIF taxon check for archival repositories (the client-side part of #176).

### Accession Form layout
- The form was wrapped in its own `QScrollArea` nested inside Slicer's already-scrolling module panel. A `QScrollArea` reports a near-zero minimum height, so the surrounding layout squeezed it to ~2 visible lines. Gave it a sensible minimum height so it always shows several rows and scrolls internally.

### Section 3 (species) controls
- Removed the **"Check species"** button. Its `pygbif.species.name_backbone()` lookup broke under `pygbif >= 0.6`, which switched to GBIF's new *nested* match response (`{usage, classification, diagnostics}`); the old flat-key parsing produced *"Not a species (missing is rank missing)"* for valid names.
- Kept a single, clearly labeled **"Search taxon in GBIF"** button (was an unlabeled magnifying-glass icon), moved above where Check used to be.
- Added `FormSpeciesQuestion._normalizeGbifResult()` so the lineage display works with both the flat (`name_suggest`) and nested (`name_backbone`) response shapes.

### Advisory GBIF taxon check (#176)
- `ValidationMixin._gbifTaxonStatus()` looks a species name up in the GBIF backbone and returns a short flag sentence for: not found / matched only above species rank / a GBIF synonym / no exact match — or `None` for a clean accepted-species match.
- For **archival biological specimens**, `_collectAccessionInputs` now shows a **non-blocking** OK/Cancel warning when the taxon does not cleanly resolve (OK continues staging, Cancel returns to the form to edit).
- It **never rejects** the submission (unlike the color-table rule), is **skipped in testing mode**, and **passes silently if GBIF is unreachable** — there are legitimate reasons a valid name is absent from GBIF (recent reclassification, a newly described species, indexing lag), so a reviewer follows up instead of the tool blocking. Short-term / classroom and non-biological subjects are exempt.

## Testing
- `python -m py_compile` on all four changed files.
- `_gbifTaxonStatus` message wording verified against the live GBIF API for: clean species (`Mus musculus`, `Testudo atlas`), synonym (`Vulpes fulva`), inexact/typo (`Homo sapeins`), genus-only (`Testudo atlass`), not found (`Asdf qwerty`), and case-only difference (`homo sapiens` → no flag).

Implements #176 (client-side). Any server-side / CI enforcement that issue also describes is out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
