### PR TITLE
Collections tab: create curated "repo of repos" collections

### DIFF
--- a/MorphoDepot/CMakeLists.txt
+++ b/MorphoDepot/CMakeLists.txt
@@ -13,6 +13,7 @@ set(MODULE_PYTHON_SCRIPTS
   ${MODULE_NAME}Lib/contributors.py
   ${MODULE_NAME}Lib/forms.py
   ${MODULE_NAME}Lib/logic_accession.py
+  ${MODULE_NAME}Lib/logic_collections.py
   ${MODULE_NAME}Lib/logic_contribute.py
   ${MODULE_NAME}Lib/logic_controlplane.py
   ${MODULE_NAME}Lib/logic_deps.py
@@ -25,6 +26,7 @@ set(MODULE_PYTHON_SCRIPTS
   ${MODULE_NAME}Lib/screenshot_dialog.py
   ${MODULE_NAME}Lib/search_form.py
   ${MODULE_NAME}Lib/widget_annotate.py
+  ${MODULE_NAME}Lib/widget_collections.py
   ${MODULE_NAME}Lib/widget_configure.py
   ${MODULE_NAME}Lib/widget_create.py
   ${MODULE_NAME}Lib/widget_release.py
@@ -36,6 +38,7 @@ set(MODULE_PYTHON_SCRIPTS
 set(MODULE_PYTHON_RESOURCES
   Resources/Icons/${MODULE_NAME}.png
   Resources/UI/${MODULE_NAME}Annotate.ui
+  Resources/UI/${MODULE_NAME}Collections.ui
   Resources/UI/${MODULE_NAME}Create.ui
   Resources/UI/${MODULE_NAME}Configure.ui
   Resources/UI/${MODULE_NAME}Release.ui

--- a/MorphoDepot/MorphoDepot.py
+++ b/MorphoDepot/MorphoDepot.py
@@ -777,19 +777,32 @@ class MorphoDepotWidget(ScriptedLoadableModuleWidget, VTKObservationMixin, Enabl
 
     def _applyOrgMemberGating(self, moduleEnabled):
         """Gray out the org-member-only surfaces (the whole Release tab and the Collections
-        'Create a Collection' section) for a CONFIRMED non-member.  Fails OPEN on 'unknown' (App
-        unreachable) so a transient outage never locks out a real member; only relevant once the
-        module is enabled (otherwise everything is already grayed).  Re-applied on every enter()
-        because the loop above re-enables tabs; membership is cached, so this is cheap after the
-        first check.  Normal users are signed in to gh before use and don't switch accounts, so a
-        change (e.g. joining the org) takes effect on the next Slicer restart."""
+        'Create a Collection' section) for a CONFIRMED non-member.
+
+        The membership check hits the control-plane App, which can be slow or unreachable, so it
+        MUST NOT run on the UI thread (doing so froze the module in enter()).  It is computed ONCE
+        in a background thread and cached in ``self._orgIsNonMember``; this method only ever READS
+        that cached value to update the widgets, so it never blocks.  Until the result is in we
+        fail OPEN (surfaces enabled) — a real member is never locked out and the UI never hangs.
+        Membership is fixed for the session (normal users don't switch gh accounts / reload), so a
+        change such as joining the org takes effect on the next Slicer restart."""
         if not moduleEnabled:
             return
-        nonMember = False
-        try:
-            nonMember = (self.logic.orgMembershipStatus() == "non_member")
-        except Exception as e:
-            logging.warning(f"Org membership check failed; leaving member-only surfaces enabled: {e}")
+        # Kick off the one-time membership determination OFF the UI thread, then re-apply when done.
+        if not getattr(self, "_orgMemberCheckStarted", False):
+            self._orgMemberCheckStarted = True
+            self._orgIsNonMember = None
+            import threading
+            def worker():
+                try:
+                    self._orgIsNonMember = (self.logic.orgMembershipStatus() == "non_member")
+                except Exception as e:
+                    logging.warning(f"Org membership check failed; member-only surfaces left enabled: {e}")
+                    self._orgIsNonMember = False
+            threading.Thread(target=worker, daemon=True).start()
+            # Re-apply on the main thread once the result is likely in (non-blocking).
+            qt.QTimer.singleShot(2500, lambda: self._applyOrgMemberGating(self.checkModuleEnabled()))
+        nonMember = bool(getattr(self, "_orgIsNonMember", None))  # None (not yet known) -> fail open
         joinHint = ("Available to MorphoDepot organization members. "
                     "Join at https://join.morphodepot.org, then restart Slicer.")
         if self.releaseTabIndex is not None:

--- a/MorphoDepot/MorphoDepot.py
+++ b/MorphoDepot/MorphoDepot.py
@@ -220,8 +220,9 @@ class MorphoDepotWidget(ScriptedLoadableModuleWidget, VTKObservationMixin, Enabl
 
         uiWidget = slicer.util.loadUI(os.path.normpath(self.resourcePath("UI/MorphoDepotRelease.ui")))
         uiWidget.setMRMLScene(slicer.mrmlScene)
+        self.releaseTabIndex = None
         if self.includeReleaseUI:
-            self.tabWidget.addTab(uiWidget, "Release")
+            self.releaseTabIndex = self.tabWidget.addTab(uiWidget, "Release")
         self.releaseUI = slicer.util.childWidgetVariables(uiWidget)
 
         self.adminTab = qt.QScrollArea()
@@ -772,6 +773,31 @@ class MorphoDepotWidget(ScriptedLoadableModuleWidget, VTKObservationMixin, Enabl
                 self.tabWidget.setTabEnabled(tabIndex, moduleEnabled)
             else:
                 self.tabWidget.setTabEnabled(tabIndex, True)
+        self._applyOrgMemberGating(moduleEnabled)
+
+    def _applyOrgMemberGating(self, moduleEnabled):
+        """Gray out the org-member-only surfaces (the whole Release tab and the Collections
+        'Create a Collection' section) for a CONFIRMED non-member.  Fails OPEN on 'unknown' (App
+        unreachable) so a transient outage never locks out a real member; only relevant once the
+        module is enabled (otherwise everything is already grayed).  Re-applied on every enter()
+        because the loop above re-enables tabs; membership is cached, so this is cheap after the
+        first check.  Normal users are signed in to gh before use and don't switch accounts, so a
+        change (e.g. joining the org) takes effect on the next Slicer restart."""
+        if not moduleEnabled:
+            return
+        nonMember = False
+        try:
+            nonMember = (self.logic.orgMembershipStatus() == "non_member")
+        except Exception as e:
+            logging.warning(f"Org membership check failed; leaving member-only surfaces enabled: {e}")
+        joinHint = ("Available to MorphoDepot organization members. "
+                    "Join at https://join.morphodepot.org, then restart Slicer.")
+        if self.releaseTabIndex is not None:
+            self.tabWidget.setTabEnabled(self.releaseTabIndex, not nonMember)
+            self.tabWidget.setTabToolTip(self.releaseTabIndex, joinHint if nonMember else "")
+        # Collections: keep the "Existing Collections" list browsable; gray only the create section.
+        self.collectionsUI.createCollapsibleButton.enabled = not nonMember
+        self.collectionsUI.createCollapsibleButton.setToolTip(joinHint if nonMember else "")
 
     def onCurrentTabChanged(self,index):
         qt.QSettings().setValue("MorphoDepot/tabIndex", index)

--- a/MorphoDepot/MorphoDepot.py
+++ b/MorphoDepot/MorphoDepot.py
@@ -51,12 +51,14 @@ from MorphoDepotLib.logic_contribute import ContributeMixin
 from MorphoDepotLib.logic_release import ReleaseMixin
 from MorphoDepotLib.logic_accession import AccessionMixin
 from MorphoDepotLib.logic_search import SearchMixin
+from MorphoDepotLib.logic_collections import CollectionsMixin
 from MorphoDepotLib.widget_create import CreateTabMixin
 from MorphoDepotLib.widget_configure import ConfigureTabMixin
 from MorphoDepotLib.widget_annotate import AnnotateTabMixin
 from MorphoDepotLib.widget_review import ReviewTabMixin
 from MorphoDepotLib.widget_release import ReleaseTabMixin
 from MorphoDepotLib.widget_search import SearchTabMixin
+from MorphoDepotLib.widget_collections import CollectionsTabMixin
 from MorphoDepotLib.widget_validation import ValidationMixin
 
 
@@ -150,7 +152,7 @@ class EnableModuleMixin:
         return True
 
 
-class MorphoDepotWidget(ScriptedLoadableModuleWidget, VTKObservationMixin, EnableModuleMixin, ValidationMixin, CreateTabMixin, ConfigureTabMixin, AnnotateTabMixin, ReviewTabMixin, ReleaseTabMixin, SearchTabMixin):
+class MorphoDepotWidget(ScriptedLoadableModuleWidget, VTKObservationMixin, EnableModuleMixin, ValidationMixin, CreateTabMixin, ConfigureTabMixin, AnnotateTabMixin, ReviewTabMixin, ReleaseTabMixin, SearchTabMixin, CollectionsTabMixin):
     """Uses ScriptedLoadableModuleWidget base class, available at:
     https://github.com/Slicer/Slicer/blob/main/Base/Python/slicer/ScriptedLoadableModule.py
     """
@@ -215,6 +217,12 @@ class MorphoDepotWidget(ScriptedLoadableModuleWidget, VTKObservationMixin, Enabl
         uiWidget.setMRMLScene(slicer.mrmlScene)
         self.createTabIndex = self.tabWidget.addTab(uiWidget, "Create")
         self.createUI = slicer.util.childWidgetVariables(uiWidget)
+
+        uiWidget = slicer.util.loadUI(os.path.normpath(self.resourcePath("UI/MorphoDepotCollections.ui")))
+        uiWidget.setMRMLScene(slicer.mrmlScene)
+        self.tabWidget.addTab(uiWidget, "Collections")
+        self.collectionsUI = slicer.util.childWidgetVariables(uiWidget)
+        self.setupCollectionsTab()
 
         uiWidget = slicer.util.loadUI(os.path.normpath(self.resourcePath("UI/MorphoDepotRelease.ui")))
         uiWidget.setMRMLScene(slicer.mrmlScene)
@@ -772,7 +780,7 @@ class MorphoDepotWidget(ScriptedLoadableModuleWidget, VTKObservationMixin, Enabl
             self._refreshArchivalAvailability()
             self.refreshStagedReposList()
 
-class MorphoDepotLogic(ScriptedLoadableModuleLogic, DepsMixin, GitHubMixin, ControlPlaneMixin, ObjectStoreMixin, RepoClerkMixin, RepoMixin, ContributeMixin, ReleaseMixin, AccessionMixin, SearchMixin):
+class MorphoDepotLogic(ScriptedLoadableModuleLogic, DepsMixin, GitHubMixin, ControlPlaneMixin, ObjectStoreMixin, RepoClerkMixin, RepoMixin, ContributeMixin, ReleaseMixin, AccessionMixin, SearchMixin, CollectionsMixin):
     """This class should implement all the actual
     computation done by your module.  The interface
     should be such that other python code can import

--- a/MorphoDepot/MorphoDepot.py
+++ b/MorphoDepot/MorphoDepot.py
@@ -220,9 +220,8 @@ class MorphoDepotWidget(ScriptedLoadableModuleWidget, VTKObservationMixin, Enabl
 
         uiWidget = slicer.util.loadUI(os.path.normpath(self.resourcePath("UI/MorphoDepotRelease.ui")))
         uiWidget.setMRMLScene(slicer.mrmlScene)
-        self.releaseTabIndex = None
         if self.includeReleaseUI:
-            self.releaseTabIndex = self.tabWidget.addTab(uiWidget, "Release")
+            self.tabWidget.addTab(uiWidget, "Release")
         self.releaseUI = slicer.util.childWidgetVariables(uiWidget)
 
         self.adminTab = qt.QScrollArea()
@@ -773,44 +772,6 @@ class MorphoDepotWidget(ScriptedLoadableModuleWidget, VTKObservationMixin, Enabl
                 self.tabWidget.setTabEnabled(tabIndex, moduleEnabled)
             else:
                 self.tabWidget.setTabEnabled(tabIndex, True)
-        self._applyOrgMemberGating(moduleEnabled)
-
-    def _applyOrgMemberGating(self, moduleEnabled):
-        """Gray out the org-member-only surfaces (the whole Release tab and the Collections
-        'Create a Collection' section) for a CONFIRMED non-member.
-
-        The membership check hits the control-plane App, which can be slow or unreachable, so it
-        MUST NOT run on the UI thread (doing so froze the module in enter()).  It is computed ONCE
-        in a background thread and cached in ``self._orgIsNonMember``; this method only ever READS
-        that cached value to update the widgets, so it never blocks.  Until the result is in we
-        fail OPEN (surfaces enabled) — a real member is never locked out and the UI never hangs.
-        Membership is fixed for the session (normal users don't switch gh accounts / reload), so a
-        change such as joining the org takes effect on the next Slicer restart."""
-        if not moduleEnabled:
-            return
-        # Kick off the one-time membership determination OFF the UI thread, then re-apply when done.
-        if not getattr(self, "_orgMemberCheckStarted", False):
-            self._orgMemberCheckStarted = True
-            self._orgIsNonMember = None
-            import threading
-            def worker():
-                try:
-                    self._orgIsNonMember = (self.logic.orgMembershipStatus() == "non_member")
-                except Exception as e:
-                    logging.warning(f"Org membership check failed; member-only surfaces left enabled: {e}")
-                    self._orgIsNonMember = False
-            threading.Thread(target=worker, daemon=True).start()
-            # Re-apply on the main thread once the result is likely in (non-blocking).
-            qt.QTimer.singleShot(2500, lambda: self._applyOrgMemberGating(self.checkModuleEnabled()))
-        nonMember = bool(getattr(self, "_orgIsNonMember", None))  # None (not yet known) -> fail open
-        joinHint = ("Available to MorphoDepot organization members. "
-                    "Join at https://join.morphodepot.org, then restart Slicer.")
-        if self.releaseTabIndex is not None:
-            self.tabWidget.setTabEnabled(self.releaseTabIndex, not nonMember)
-            self.tabWidget.setTabToolTip(self.releaseTabIndex, joinHint if nonMember else "")
-        # Collections: keep the "Existing Collections" list browsable; gray only the create section.
-        self.collectionsUI.createCollapsibleButton.enabled = not nonMember
-        self.collectionsUI.createCollapsibleButton.setToolTip(joinHint if nonMember else "")
 
     def onCurrentTabChanged(self,index):
         qt.QSettings().setValue("MorphoDepot/tabIndex", index)

--- a/MorphoDepot/MorphoDepot.py
+++ b/MorphoDepot/MorphoDepot.py
@@ -218,12 +218,6 @@ class MorphoDepotWidget(ScriptedLoadableModuleWidget, VTKObservationMixin, Enabl
         self.createTabIndex = self.tabWidget.addTab(uiWidget, "Create")
         self.createUI = slicer.util.childWidgetVariables(uiWidget)
 
-        uiWidget = slicer.util.loadUI(os.path.normpath(self.resourcePath("UI/MorphoDepotCollections.ui")))
-        uiWidget.setMRMLScene(slicer.mrmlScene)
-        self.tabWidget.addTab(uiWidget, "Collections")
-        self.collectionsUI = slicer.util.childWidgetVariables(uiWidget)
-        self.setupCollectionsTab()
-
         uiWidget = slicer.util.loadUI(os.path.normpath(self.resourcePath("UI/MorphoDepotRelease.ui")))
         uiWidget.setMRMLScene(slicer.mrmlScene)
         if self.includeReleaseUI:
@@ -235,6 +229,13 @@ class MorphoDepotWidget(ScriptedLoadableModuleWidget, VTKObservationMixin, Enabl
             self.tabWidget.addTab(self.adminTab, "Admin")
         self.adminTabIndex = self.tabWidget.indexOf(self.adminTab)
         self.adminUI = {} # for future use
+
+        # Collections tab — added last so it sits at the right-most position.
+        uiWidget = slicer.util.loadUI(os.path.normpath(self.resourcePath("UI/MorphoDepotCollections.ui")))
+        uiWidget.setMRMLScene(slicer.mrmlScene)
+        self.tabWidget.addTab(uiWidget, "Collections")
+        self.collectionsUI = slicer.util.childWidgetVariables(uiWidget)
+        self.setupCollectionsTab()
 
         # restore last tab index
         tabIndex = slicer.util.settingsValue("MorphoDepot/tabIndex", 0, converter=int)

--- a/MorphoDepot/MorphoDepotLib/logic_collections.py
+++ b/MorphoDepot/MorphoDepotLib/logic_collections.py
@@ -11,6 +11,7 @@ posture.  Governance is deliberately simple: one ``CURATOR`` (the creator) for a
 else contributes via a standard fork-and-PR.
 """
 import base64
+import difflib
 import json
 import logging
 import re
@@ -19,6 +20,37 @@ import unicodedata
 COLLECTION_TOPIC = "md-collection"
 DISCOVERY_TOPIC = "morphodepot"
 SLUG_MAX_LEN = 40
+
+# Filler words ignored when fuzzily comparing collection titles for near-duplicates.
+_TITLE_STOPWORDS = {"the", "of", "a", "an", "and", "or", "for", "in", "on", "to", "with",
+                    "repo", "repos", "repository", "repositories"}
+
+
+def _normalize_title_tokens(title):
+    """Lowercase, strip punctuation/diacritics/stopwords and crudely de-pluralize a title into a
+    set of significant word tokens, so word order and trivial variations don't matter."""
+    text = unicodedata.normalize("NFKD", title or "").encode("ascii", "ignore").decode("ascii").lower()
+    tokens = set()
+    for w in re.findall(r"[a-z0-9]+", text):
+        if w in _TITLE_STOPWORDS:
+            continue
+        if len(w) > 3 and w.endswith("es"):
+            w = w[:-2]
+        elif len(w) > 3 and w.endswith("s"):
+            w = w[:-1]
+        tokens.add(w)
+    return tokens
+
+
+def _title_similarity(a, b):
+    """0..1 similarity between two titles — the max of token-set (Jaccard) and sequence-ratio
+    similarity over the normalized tokens, so reordered words and small edits both score high."""
+    ta, tb = _normalize_title_tokens(a), _normalize_title_tokens(b)
+    if not ta or not tb:
+        return 0.0
+    jaccard = len(ta & tb) / len(ta | tb)
+    seq = difflib.SequenceMatcher(None, " ".join(sorted(ta)), " ".join(sorted(tb))).ratio()
+    return max(jaccard, seq)
 
 
 class CollectionsMixin:
@@ -47,6 +79,31 @@ class CollectionsMixin:
                     "memberRefs": block.get("memberRefs", []),
                 })
         out.sort(key=lambda c: (c["title"] or "").lower())
+        return out
+
+    def existingCollectionTitles(self):
+        """All collection repos in the org, live via gh, as [{nameWithOwner, title}].  Uses the
+        repo description (set to the title at creation) so the duplicate check is NOT subject to
+        RepoClerk journal lag — a just-created collection is seen immediately."""
+        repos = self.ghJSON(["repo", "list", self.morphoDepotOrg, "--topic", COLLECTION_TOPIC,
+                            "--limit", "500", "--json", "nameWithOwner,description"]) or []
+        out = []
+        for r in repos:
+            if isinstance(r, dict) and r.get("nameWithOwner"):
+                title = (r.get("description") or "").strip() or r["nameWithOwner"].split("/")[-1]
+                out.append({"nameWithOwner": r["nameWithOwner"], "title": title})
+        return out
+
+    def similarCollections(self, title, threshold=0.6):
+        """Existing collections whose title is fuzzily similar to ``title`` (token-set + sequence
+        similarity, order-independent, plurals/filler-words folded), most-similar first.  Catches
+        e.g. 'Random Collection' vs 'random collections' vs 'random repo collection'."""
+        out = []
+        for c in self.existingCollectionTitles():
+            sim = _title_similarity(title, c["title"])
+            if sim >= threshold:
+                out.append({**c, "similarity": round(sim, 2)})
+        out.sort(key=lambda c: c["similarity"], reverse=True)
         return out
 
     def datasetRepoCorpus(self):

--- a/MorphoDepot/MorphoDepotLib/logic_collections.py
+++ b/MorphoDepot/MorphoDepotLib/logic_collections.py
@@ -236,22 +236,35 @@ class CollectionsMixin:
         self.gh(["repo", "create", nameWithOwner, "--public", "--disable-wiki",
                  "--add-readme", "--description", title])
 
-        # Grant the creator's {login}-team Write (mirrors dataset creation; best-effort).
-        teamSlug = f"{me}-team".lower()
+        # Everything after repo creation must succeed for the repo to be a usable, discoverable
+        # collection.  If any critical step fails, roll back the orphaned public repo so we don't
+        # leave behind an undiscoverable repo (no md-collection topic) with an opaque name the user
+        # can't find.  (README/CURATOR/topics are critical; the team grant is best-effort.)
         try:
-            self.gh(["api", "--method", "PUT",
-                     f"/orgs/{self.morphoDepotOrg}/teams/{teamSlug}/repos/{nameWithOwner}",
-                     "--field", "permission=push"])
-        except Exception as e:
-            logging.warning(f"Could not grant {teamSlug} Write on {nameWithOwner}: {e}")
+            teamSlug = f"{me}-team".lower()
+            try:
+                self.gh(["api", "--method", "PUT",
+                         f"/orgs/{self.morphoDepotOrg}/teams/{teamSlug}/repos/{nameWithOwner}",
+                         "--field", "permission=push"])
+            except Exception as e:
+                logging.warning(f"Could not grant {teamSlug} Write on {nameWithOwner}: {e}")
 
-        self._putRepoFile(nameWithOwner, "README.md",
-                          self._renderCollectionReadme(title, description, members),
-                          "Add collection README")
-        self._putRepoFile(nameWithOwner, "CURATOR", me + "\n", "Add CURATOR file")
+            self._putRepoFile(nameWithOwner, "README.md",
+                              self._renderCollectionReadme(title, description, members),
+                              "Add collection README")
+            self._putRepoFile(nameWithOwner, "CURATOR", me + "\n", "Add CURATOR file")
 
-        self.gh(["repo", "edit", nameWithOwner,
-                 "--add-topic", DISCOVERY_TOPIC, "--add-topic", COLLECTION_TOPIC])
+            self.gh(["repo", "edit", nameWithOwner,
+                     "--add-topic", DISCOVERY_TOPIC, "--add-topic", COLLECTION_TOPIC])
+        except Exception:
+            self.progressMethod(f"Rolling back incomplete collection {nameWithOwner}...")
+            try:
+                # Best-effort; needs the gh 'delete_repo' scope.
+                self.gh(["repo", "delete", nameWithOwner, "--yes"], quietErrors=True)
+            except Exception as delErr:
+                logging.warning(f"Could not roll back {nameWithOwner} after a failed create "
+                                f"(delete it manually; the gh token may lack delete_repo scope): {delErr}")
+            raise
 
         try:
             self.notifyRepoClerk(nameWithOwner)

--- a/MorphoDepot/MorphoDepotLib/logic_collections.py
+++ b/MorphoDepot/MorphoDepotLib/logic_collections.py
@@ -136,13 +136,15 @@ class CollectionsMixin:
             pass  # file does not exist yet -> plain create
         self.gh(args)
 
-    def createCollection(self, title, description, memberRefs, makePublic=False):
-        """Create an in-org collection repo: empty private repo + canonical README + CURATOR +
-        the ``morphodepot``/``md-collection`` topics, then notify RepoClerk.  ``memberRefs`` are
-        URLs or owner/repo strings; at least two must resolve.  Returns the nameWithOwner.
+    def createCollection(self, title, description, memberRefs):
+        """Create an in-org collection repo: public repo + canonical README + CURATOR + the
+        ``morphodepot``/``md-collection`` topics, then notify RepoClerk.  ``memberRefs`` are URLs
+        or owner/repo strings; at least two must resolve.  Returns the nameWithOwner.
 
-        Created **private**.  ``makePublic`` attempts to flip it public — which succeeds only for
-        an org owner; a regular member's collection stays private for an owner to publish.
+        Created **public** so it is immediately visible to everyone (and to RepoClerk).  The org
+        permits members to create public repositories, so this works for ANY member, not just
+        owners — no owner publish step.  An org owner can still delete or unpublish a collection
+        after the fact.
         """
         title = (title or "").strip()
         if not title:
@@ -160,10 +162,10 @@ class CollectionsMixin:
         slug = self.uniqueCollectionSlug(title)
         nameWithOwner = f"{self.morphoDepotOrg}/{slug}"
 
-        self.progressMethod(f"Creating collection {nameWithOwner} (private)...")
+        self.progressMethod(f"Creating collection {nameWithOwner} (public)...")
         # --add-readme initializes a default branch, so the contents API below can write to it
         # (a brand-new empty repo has no branch and the PUT would 404 "branch not found").
-        self.gh(["repo", "create", nameWithOwner, "--private", "--disable-wiki",
+        self.gh(["repo", "create", nameWithOwner, "--public", "--disable-wiki",
                  "--add-readme", "--description", title])
 
         # Grant the creator's {login}-team Write (mirrors dataset creation; best-effort).
@@ -182,13 +184,6 @@ class CollectionsMixin:
 
         self.gh(["repo", "edit", nameWithOwner,
                  "--add-topic", DISCOVERY_TOPIC, "--add-topic", COLLECTION_TOPIC])
-
-        if makePublic:
-            try:
-                self.setRepoVisibility(nameWithOwner, public=True)
-            except Exception as e:
-                logging.warning(
-                    f"Could not make {nameWithOwner} public (an org owner must publish it): {e}")
 
         try:
             self.notifyRepoClerk(nameWithOwner)

--- a/MorphoDepot/MorphoDepotLib/logic_collections.py
+++ b/MorphoDepot/MorphoDepotLib/logic_collections.py
@@ -11,6 +11,7 @@ posture.  Governance is deliberately simple: one ``CURATOR`` (the creator) for a
 else contributes via a standard fork-and-PR.
 """
 import base64
+import json
 import logging
 import re
 import unicodedata
@@ -102,6 +103,23 @@ class CollectionsMixin:
         if name.endswith(".git"):
             name = name[:-4]
         return f"{owner}/{name.rstrip('.,);:')}"
+
+    def isMorphoDepotRepo(self, nameWithOwner):
+        """True only if ``nameWithOwner`` is a MorphoDepot DATASET repo — it exists and carries the
+        ``morphodepot`` topic but NOT the ``md-collection`` topic (a collection is not itself a
+        valid member).  Checked live via gh (the repo's topics); False on any error or missing
+        topic, so a non-MorphoDepot URL or a typo is rejected."""
+        try:
+            out = self.gh(["api", f"repos/{nameWithOwner}/topics", "--jq", ".names"],
+                          quietErrors=True)
+        except RuntimeError:
+            return False
+        try:
+            names = json.loads(out) if out else []
+        except Exception:
+            names = []
+        names = names or []
+        return DISCOVERY_TOPIC in names and COLLECTION_TOPIC not in names
 
     # --- Creation ---
 

--- a/MorphoDepot/MorphoDepotLib/logic_collections.py
+++ b/MorphoDepot/MorphoDepotLib/logic_collections.py
@@ -137,13 +137,14 @@ class CollectionsMixin:
         self.gh(args)
 
     def createCollection(self, title, description, memberRefs):
-        """Create an in-org collection repo as a **private draft**: private repo + canonical
-        README + CURATOR + the ``morphodepot``/``md-collection`` topics.  ``memberRefs`` are URLs
+        """Create an in-org collection repo: public repo + canonical README + CURATOR + the
+        ``morphodepot``/``md-collection`` topics, then notify RepoClerk.  ``memberRefs`` are URLs
         or owner/repo strings; at least two must resolve.  Returns the nameWithOwner.
 
-        Mirrors the dataset staging model: the member assembles the collection privately, then
-        publishes it themselves via :meth:`publishCollection` (the org allows a member with
-        repo-admin to change visibility).  RepoClerk only renders it once it is published.
+        Created **public** so it is immediately visible to everyone (and to RepoClerk).  The org
+        permits members to create public repositories, so this works for ANY member, not just
+        owners — no owner publish step.  An org owner can still delete or unpublish a collection
+        after the fact.
         """
         title = (title or "").strip()
         if not title:
@@ -161,10 +162,10 @@ class CollectionsMixin:
         slug = self.uniqueCollectionSlug(title)
         nameWithOwner = f"{self.morphoDepotOrg}/{slug}"
 
-        self.progressMethod(f"Creating collection {nameWithOwner} (private draft)...")
+        self.progressMethod(f"Creating collection {nameWithOwner} (public)...")
         # --add-readme initializes a default branch, so the contents API below can write to it
         # (a brand-new empty repo has no branch and the PUT would 404 "branch not found").
-        self.gh(["repo", "create", nameWithOwner, "--private", "--disable-wiki",
+        self.gh(["repo", "create", nameWithOwner, "--public", "--disable-wiki",
                  "--add-readme", "--description", title])
 
         # Grant the creator's {login}-team Write (mirrors dataset creation; best-effort).
@@ -184,23 +185,9 @@ class CollectionsMixin:
         self.gh(["repo", "edit", nameWithOwner,
                  "--add-topic", DISCOVERY_TOPIC, "--add-topic", COLLECTION_TOPIC])
 
-        return nameWithOwner
-
-    def myDraftCollections(self):
-        """Unpublished (private) collection repos in the org that the user can see — i.e. their
-        own drafts (a regular member only sees the private repos they admin).  Returns a list of
-        {nameWithOwner, name}."""
-        repos = self.ghJSON(["repo", "list", self.morphoDepotOrg,
-                             "--topic", COLLECTION_TOPIC, "--visibility", "private",
-                             "--limit", "200", "--json", "nameWithOwner,name"]) or []
-        return [{"nameWithOwner": r["nameWithOwner"], "name": r.get("name", "")}
-                for r in repos if isinstance(r, dict) and r.get("nameWithOwner")]
-
-    def publishCollection(self, nameWithOwner):
-        """Publish a draft collection: flip it to public (a member with repo-admin may change
-        visibility — the org enables this for staging/review), then notify RepoClerk to render it."""
-        self.setRepoVisibility(nameWithOwner, public=True)
         try:
             self.notifyRepoClerk(nameWithOwner)
         except Exception as e:
             logging.warning(f"Could not notify RepoClerk for {nameWithOwner}: {e}")
+
+        return nameWithOwner

--- a/MorphoDepot/MorphoDepotLib/logic_collections.py
+++ b/MorphoDepot/MorphoDepotLib/logic_collections.py
@@ -1,9 +1,12 @@
 """MorphoDepotLogic CollectionsMixin — create and list curated "repo of repos" collections.
 
-A *collection* is a MorphoDepot org repository tagged ``md-collection`` whose README's first
-line is the collection title and whose body lists member dataset repositories.  RepoClerk parses
-that README and renders the collection as a gallery + screenshot slide deck.  See
-SlicerMorph/SlicerMorphoDepot#180 (this tab) and MorphoDepot/RepoClerk#411 (rendering).
+A *collection* is a MorphoDepot org repository tagged ``md-collection`` whose **description** holds
+the title (PR-proof repo metadata — only repo-admins can change it) and whose README lists the
+member dataset repositories.  RepoClerk reads the description for the title and parses the README
+for members, rendering a gallery + screenshot slide deck.  The repo name itself is an opaque
+``collection-<hash>`` — it carries no meaning, so it never needs to be a (lossy, collision-prone)
+truncation of a human title.  See SlicerMorph/SlicerMorphoDepot#180 (this tab) and
+MorphoDepot/RepoClerk#411 (rendering).
 
 The whole flow runs with the member's OWN ``gh`` (they create private in-org repos and are repo
 admin of their own creation) — no App/Administration privilege, consistent with the admin-free
@@ -15,11 +18,11 @@ import difflib
 import json
 import logging
 import re
+import secrets
 import unicodedata
 
 COLLECTION_TOPIC = "md-collection"
 DISCOVERY_TOPIC = "morphodepot"
-SLUG_MAX_LEN = 40
 
 # Filler words ignored when fuzzily comparing collection titles for near-duplicates.
 _TITLE_STOPWORDS = {"the", "of", "a", "an", "and", "or", "for", "in", "on", "to", "with",
@@ -123,28 +126,17 @@ class CollectionsMixin:
             corpus[nwo] = {"nameWithOwner": nwo, "species": species}
         return corpus
 
-    # --- Slug / reference normalization ---
+    # --- Repo name / reference normalization ---
 
-    @staticmethod
-    def slugifyTitle(title):
-        """Derive a short, URL-safe repo slug from a free-text collection title (diacritics
-        stripped, lowercased, non-alphanumerics collapsed to hyphens, length-capped on a word
-        boundary)."""
-        text = unicodedata.normalize("NFKD", title or "").encode("ascii", "ignore").decode("ascii")
-        text = re.sub(r"[^a-z0-9]+", "-", text.lower()).strip("-")
-        if len(text) > SLUG_MAX_LEN:
-            text = text[:SLUG_MAX_LEN].rsplit("-", 1)[0] or text[:SLUG_MAX_LEN]
-        return text or "collection"
-
-    def uniqueCollectionSlug(self, title):
-        """A slug for ``title`` that does not collide with an existing repo in the org."""
-        base = self.slugifyTitle(title)
-        slug, n = base, 2
-        while self.repoExists(f"{self.morphoDepotOrg}/{slug}"):
-            suffix = f"-{n}"
-            slug = (base[:SLUG_MAX_LEN - len(suffix)].rstrip("-") or base) + suffix
-            n += 1
-        return slug
+    def newCollectionSlug(self):
+        """A fresh, unique, opaque repo name for a collection: ``collection-`` + 8 random hex
+        chars.  Deliberately meaningless — the title lives authoritatively (and PR-proof) in the
+        repo *description* — so the name only needs to be unique and recognizable as a collection,
+        never a (lossy, collision-prone) truncation of a human-readable title."""
+        while True:
+            slug = "collection-" + secrets.token_hex(4)
+            if not self.repoExists(f"{self.morphoDepotOrg}/{slug}"):
+                return slug
 
     @staticmethod
     def normalizeRepoRef(ref):
@@ -190,8 +182,9 @@ class CollectionsMixin:
         lines += ["## Member repositories", ""]
         lines += [f"- https://github.com/{nwo}" for nwo in memberNwos]
         lines += ["",
-                  "<!-- Created with the MorphoDepot extension. Add or remove member repositories "
-                  "in the list above (one per line); RepoClerk re-renders the gallery on update. -->",
+                  "<!-- Created with the MorphoDepot extension. The collection TITLE is the repo "
+                  "description (edit it in repo settings; a pull request cannot change it). Add or "
+                  "remove member repositories in the list above; RepoClerk re-renders on update. -->",
                   ""]
         return "\n".join(lines)
 
@@ -234,7 +227,7 @@ class CollectionsMixin:
             raise ValueError("A collection needs at least two member repositories.")
 
         me = self.whoami()
-        slug = self.uniqueCollectionSlug(title)
+        slug = self.newCollectionSlug()
         nameWithOwner = f"{self.morphoDepotOrg}/{slug}"
 
         self.progressMethod(f"Creating collection {nameWithOwner} (public)...")

--- a/MorphoDepot/MorphoDepotLib/logic_collections.py
+++ b/MorphoDepot/MorphoDepotLib/logic_collections.py
@@ -137,14 +137,13 @@ class CollectionsMixin:
         self.gh(args)
 
     def createCollection(self, title, description, memberRefs):
-        """Create an in-org collection repo: public repo + canonical README + CURATOR + the
-        ``morphodepot``/``md-collection`` topics, then notify RepoClerk.  ``memberRefs`` are URLs
+        """Create an in-org collection repo as a **private draft**: private repo + canonical
+        README + CURATOR + the ``morphodepot``/``md-collection`` topics.  ``memberRefs`` are URLs
         or owner/repo strings; at least two must resolve.  Returns the nameWithOwner.
 
-        Created **public** so it is immediately visible to everyone (and to RepoClerk).  The org
-        permits members to create public repositories, so this works for ANY member, not just
-        owners — no owner publish step.  An org owner can still delete or unpublish a collection
-        after the fact.
+        Mirrors the dataset staging model: the member assembles the collection privately, then
+        publishes it themselves via :meth:`publishCollection` (the org allows a member with
+        repo-admin to change visibility).  RepoClerk only renders it once it is published.
         """
         title = (title or "").strip()
         if not title:
@@ -162,10 +161,10 @@ class CollectionsMixin:
         slug = self.uniqueCollectionSlug(title)
         nameWithOwner = f"{self.morphoDepotOrg}/{slug}"
 
-        self.progressMethod(f"Creating collection {nameWithOwner} (public)...")
+        self.progressMethod(f"Creating collection {nameWithOwner} (private draft)...")
         # --add-readme initializes a default branch, so the contents API below can write to it
         # (a brand-new empty repo has no branch and the PUT would 404 "branch not found").
-        self.gh(["repo", "create", nameWithOwner, "--public", "--disable-wiki",
+        self.gh(["repo", "create", nameWithOwner, "--private", "--disable-wiki",
                  "--add-readme", "--description", title])
 
         # Grant the creator's {login}-team Write (mirrors dataset creation; best-effort).
@@ -185,9 +184,23 @@ class CollectionsMixin:
         self.gh(["repo", "edit", nameWithOwner,
                  "--add-topic", DISCOVERY_TOPIC, "--add-topic", COLLECTION_TOPIC])
 
+        return nameWithOwner
+
+    def myDraftCollections(self):
+        """Unpublished (private) collection repos in the org that the user can see — i.e. their
+        own drafts (a regular member only sees the private repos they admin).  Returns a list of
+        {nameWithOwner, name}."""
+        repos = self.ghJSON(["repo", "list", self.morphoDepotOrg,
+                             "--topic", COLLECTION_TOPIC, "--visibility", "private",
+                             "--limit", "200", "--json", "nameWithOwner,name"]) or []
+        return [{"nameWithOwner": r["nameWithOwner"], "name": r.get("name", "")}
+                for r in repos if isinstance(r, dict) and r.get("nameWithOwner")]
+
+    def publishCollection(self, nameWithOwner):
+        """Publish a draft collection: flip it to public (a member with repo-admin may change
+        visibility — the org enables this for staging/review), then notify RepoClerk to render it."""
+        self.setRepoVisibility(nameWithOwner, public=True)
         try:
             self.notifyRepoClerk(nameWithOwner)
         except Exception as e:
             logging.warning(f"Could not notify RepoClerk for {nameWithOwner}: {e}")
-
-        return nameWithOwner

--- a/MorphoDepot/MorphoDepotLib/logic_collections.py
+++ b/MorphoDepot/MorphoDepotLib/logic_collections.py
@@ -1,0 +1,198 @@
+"""MorphoDepotLogic CollectionsMixin — create and list curated "repo of repos" collections.
+
+A *collection* is a MorphoDepot org repository tagged ``md-collection`` whose README's first
+line is the collection title and whose body lists member dataset repositories.  RepoClerk parses
+that README and renders the collection as a gallery + screenshot slide deck.  See
+SlicerMorph/SlicerMorphoDepot#180 (this tab) and MorphoDepot/RepoClerk#411 (rendering).
+
+The whole flow runs with the member's OWN ``gh`` (they create private in-org repos and are repo
+admin of their own creation) — no App/Administration privilege, consistent with the admin-free
+posture.  Governance is deliberately simple: one ``CURATOR`` (the creator) for attribution; anyone
+else contributes via a standard fork-and-PR.
+"""
+import base64
+import logging
+import re
+import unicodedata
+
+COLLECTION_TOPIC = "md-collection"
+DISCOVERY_TOPIC = "morphodepot"
+SLUG_MAX_LEN = 40
+
+
+class CollectionsMixin:
+    # --- Reading existing collections / the dataset corpus from the RepoClerk journals ---
+
+    def _allJournals(self):
+        """All RepoClerk journals from the shallow clone (empty list if unavailable)."""
+        clonePath = self.refreshRepoClerk()
+        if not clonePath:
+            return []
+        return self.repoClerkJournals(clonePath)
+
+    def collectionRepos(self):
+        """Existing collections (journals carrying a ``collection`` block), title-sorted.
+        Each entry: {nameWithOwner, title, description, curator, memberRefs}."""
+        out = []
+        for j in self._allJournals():
+            block = j.get("collection")
+            if isinstance(block, dict):
+                nwo = j.get("nameWithOwner", "")
+                out.append({
+                    "nameWithOwner": nwo,
+                    "title": block.get("title") or nwo.split("/")[-1],
+                    "description": block.get("description", ""),
+                    "curator": j.get("curator"),
+                    "memberRefs": block.get("memberRefs", []),
+                })
+        out.sort(key=lambda c: (c["title"] or "").lower())
+        return out
+
+    def datasetRepoCorpus(self):
+        """Known dataset repos (journals WITHOUT a collection block), for the member picker.
+        Returns a dict {nameWithOwner: {nameWithOwner, species}}."""
+        corpus = {}
+        for j in self._allJournals():
+            if isinstance(j.get("collection"), dict):
+                continue
+            nwo = j.get("nameWithOwner")
+            if not nwo:
+                continue
+            species = ""
+            sp = (j.get("accession") or {}).get("species")
+            if isinstance(sp, list) and len(sp) >= 2:
+                species = sp[1] or ""
+            corpus[nwo] = {"nameWithOwner": nwo, "species": species}
+        return corpus
+
+    # --- Slug / reference normalization ---
+
+    @staticmethod
+    def slugifyTitle(title):
+        """Derive a short, URL-safe repo slug from a free-text collection title (diacritics
+        stripped, lowercased, non-alphanumerics collapsed to hyphens, length-capped on a word
+        boundary)."""
+        text = unicodedata.normalize("NFKD", title or "").encode("ascii", "ignore").decode("ascii")
+        text = re.sub(r"[^a-z0-9]+", "-", text.lower()).strip("-")
+        if len(text) > SLUG_MAX_LEN:
+            text = text[:SLUG_MAX_LEN].rsplit("-", 1)[0] or text[:SLUG_MAX_LEN]
+        return text or "collection"
+
+    def uniqueCollectionSlug(self, title):
+        """A slug for ``title`` that does not collide with an existing repo in the org."""
+        base = self.slugifyTitle(title)
+        slug, n = base, 2
+        while self.repoExists(f"{self.morphoDepotOrg}/{slug}"):
+            suffix = f"-{n}"
+            slug = (base[:SLUG_MAX_LEN - len(suffix)].rstrip("-") or base) + suffix
+            n += 1
+        return slug
+
+    @staticmethod
+    def normalizeRepoRef(ref):
+        """Normalize a pasted GitHub URL or ``owner/repo`` string to ``owner/repo`` (''  if not
+        parseable)."""
+        ref = (ref or "").strip()
+        m = re.search(r"github\.com/([A-Za-z0-9][A-Za-z0-9-]*)/([A-Za-z0-9_.-]+)", ref)
+        if not m:
+            m = re.fullmatch(r"([A-Za-z0-9][A-Za-z0-9-]*)/([A-Za-z0-9_.-]+)", ref)
+        if not m:
+            return ""
+        owner, name = m.group(1), m.group(2)
+        if name.endswith(".git"):
+            name = name[:-4]
+        return f"{owner}/{name.rstrip('.,);:')}"
+
+    # --- Creation ---
+
+    def _renderCollectionReadme(self, title, description, memberNwos):
+        """Canonical collection README: title on line 1, optional description, then the member
+        repos as GitHub URLs.  Still a plain README, so it can be hand-edited later; RepoClerk's
+        tolerant parser harvests the member links regardless."""
+        lines = [f"# {title}", ""]
+        if description:
+            lines += [description, ""]
+        lines += ["## Member repositories", ""]
+        lines += [f"- https://github.com/{nwo}" for nwo in memberNwos]
+        lines += ["",
+                  "<!-- Created with the MorphoDepot extension. Add or remove member repositories "
+                  "in the list above (one per line); RepoClerk re-renders the gallery on update. -->",
+                  ""]
+        return "\n".join(lines)
+
+    def _putRepoFile(self, nameWithOwner, path, content, message):
+        """Create or update a file via the contents API.  If the path already exists (e.g. the
+        README auto-created at repo creation), its blob sha is included so the PUT updates rather
+        than 422-failing."""
+        b64 = base64.b64encode(content.encode("utf-8")).decode("ascii")
+        args = ["api", "--method", "PUT", f"/repos/{nameWithOwner}/contents/{path}",
+                "-f", f"message={message}", "-f", f"content={b64}"]
+        try:
+            sha = (self.gh(["api", f"/repos/{nameWithOwner}/contents/{path}", "--jq", ".sha"],
+                           quietErrors=True) or "").strip()
+            if sha:
+                args += ["-f", f"sha={sha}"]
+        except Exception:
+            pass  # file does not exist yet -> plain create
+        self.gh(args)
+
+    def createCollection(self, title, description, memberRefs, makePublic=False):
+        """Create an in-org collection repo: empty private repo + canonical README + CURATOR +
+        the ``morphodepot``/``md-collection`` topics, then notify RepoClerk.  ``memberRefs`` are
+        URLs or owner/repo strings; at least two must resolve.  Returns the nameWithOwner.
+
+        Created **private**.  ``makePublic`` attempts to flip it public — which succeeds only for
+        an org owner; a regular member's collection stays private for an owner to publish.
+        """
+        title = (title or "").strip()
+        if not title:
+            raise ValueError("A collection title is required.")
+
+        members = []
+        for ref in memberRefs:
+            nwo = self.normalizeRepoRef(ref)
+            if nwo and nwo not in members:
+                members.append(nwo)
+        if len(members) < 2:
+            raise ValueError("A collection needs at least two member repositories.")
+
+        me = self.whoami()
+        slug = self.uniqueCollectionSlug(title)
+        nameWithOwner = f"{self.morphoDepotOrg}/{slug}"
+
+        self.progressMethod(f"Creating collection {nameWithOwner} (private)...")
+        # --add-readme initializes a default branch, so the contents API below can write to it
+        # (a brand-new empty repo has no branch and the PUT would 404 "branch not found").
+        self.gh(["repo", "create", nameWithOwner, "--private", "--disable-wiki",
+                 "--add-readme", "--description", title])
+
+        # Grant the creator's {login}-team Write (mirrors dataset creation; best-effort).
+        teamSlug = f"{me}-team".lower()
+        try:
+            self.gh(["api", "--method", "PUT",
+                     f"/orgs/{self.morphoDepotOrg}/teams/{teamSlug}/repos/{nameWithOwner}",
+                     "--field", "permission=push"])
+        except Exception as e:
+            logging.warning(f"Could not grant {teamSlug} Write on {nameWithOwner}: {e}")
+
+        self._putRepoFile(nameWithOwner, "README.md",
+                          self._renderCollectionReadme(title, description, members),
+                          "Add collection README")
+        self._putRepoFile(nameWithOwner, "CURATOR", me + "\n", "Add CURATOR file")
+
+        self.gh(["repo", "edit", nameWithOwner,
+                 "--add-topic", DISCOVERY_TOPIC, "--add-topic", COLLECTION_TOPIC])
+
+        if makePublic:
+            try:
+                self.setRepoVisibility(nameWithOwner, public=True)
+            except Exception as e:
+                logging.warning(
+                    f"Could not make {nameWithOwner} public (an org owner must publish it): {e}")
+
+        try:
+            self.notifyRepoClerk(nameWithOwner)
+        except Exception as e:
+            logging.warning(f"Could not notify RepoClerk for {nameWithOwner}: {e}")
+
+        return nameWithOwner

--- a/MorphoDepot/MorphoDepotLib/widget_collections.py
+++ b/MorphoDepot/MorphoDepotLib/widget_collections.py
@@ -67,17 +67,8 @@ class CollectionsTabMixin:
         # --- Existing Collections ---
         existingLayout = ui.existingCollapsibleButton.layout()
         ui.existingList = qt.QListWidget()
-        ui.existingList.setToolTip("Published collections. Double-click to open. Click Refresh to load.")
+        ui.existingList.setToolTip("Existing collections (read-only). Click Refresh to load.")
         existingLayout.addWidget(ui.existingList)
-
-        ui.draftsLabel = qt.QLabel("Your unpublished drafts:")
-        existingLayout.addWidget(ui.draftsLabel)
-        ui.draftsList = qt.QListWidget()
-        ui.draftsList.setToolTip("Private collections you created but have not published yet. "
-                                 "Double-click to open on GitHub; select one and Publish to make it public.")
-        existingLayout.addWidget(ui.draftsList)
-        ui.publishButton = qt.QPushButton("Publish selected draft")
-        existingLayout.addWidget(ui.publishButton)
 
         # Display-text -> nameWithOwner map for the corpus combo.
         self._collectionCorpus = {}
@@ -89,9 +80,6 @@ class CollectionsTabMixin:
         ui.createButton.connect("clicked()", self.onCreateCollection)
         ui.existingList.connect("itemDoubleClicked(QListWidgetItem*)",
                                 self.onExistingCollectionDoubleClicked)
-        ui.draftsList.connect("itemDoubleClicked(QListWidgetItem*)",
-                              self.onExistingCollectionDoubleClicked)
-        ui.publishButton.connect("clicked()", self.onPublishDraft)
 
     # --- Handlers ---
 
@@ -128,24 +116,7 @@ class CollectionsTabMixin:
         if not collections:
             ui.existingList.addItem("No collections yet.")
 
-        # The member's own unpublished (private) drafts, listed via gh (RepoClerk only sees public).
-        try:
-            drafts = self.logic.myDraftCollections()
-        except Exception as e:
-            drafts = []
-            logging.warning(f"Could not list draft collections: {e}")
-        ui.draftsList.clear()
-        for d in drafts:
-            item = qt.QListWidgetItem(f"{d['name']}  [{d['nameWithOwner']}]")
-            item.setData(qt.Qt.UserRole, d["nameWithOwner"])
-            item.setToolTip(f"Double-click to open https://github.com/{d['nameWithOwner']}")
-            ui.draftsList.addItem(item)
-        if not drafts:
-            ui.draftsList.addItem("No unpublished drafts.")
-        ui.publishButton.enabled = bool(drafts)
-
-        ui.createStatus.text = (
-            f"Loaded {len(corpus)} repositories, {len(collections)} published, {len(drafts)} draft(s).")
+        ui.createStatus.text = f"Loaded {len(corpus)} repositories, {len(collections)} collections."
 
     def _resolveComboToNwo(self, text):
         text = (text or "").strip()
@@ -173,30 +144,6 @@ class CollectionsTabMixin:
         if nwo:
             qt.QDesktopServices.openUrl(qt.QUrl(f"https://github.com/{nwo}"))
 
-    def onPublishDraft(self):
-        """Publish the selected draft collection (flip it to public)."""
-        ui = self.collectionsUI
-        items = ui.draftsList.selectedItems()
-        nwo = items[0].data(qt.Qt.UserRole) if items else None
-        if not nwo:
-            ui.createStatus.text = "Select one of your drafts to publish."
-            return
-        ui.publishButton.enabled = False
-        ui.createStatus.text = f"Publishing {nwo}..."
-        qt.QApplication.setOverrideCursor(qt.Qt.WaitCursor)
-        slicer.app.processEvents()
-        try:
-            self.logic.publishCollection(nwo)
-        except Exception as e:
-            ui.createStatus.text = f"Failed to publish {nwo}: {e}"
-            logging.error(f"publishCollection failed: {e}")
-            ui.publishButton.enabled = True
-            return
-        finally:
-            qt.QApplication.restoreOverrideCursor()
-        ui.createStatus.text = f"Published {nwo}. It will appear on the dashboard shortly."
-        self.onCollectionsRefresh()
-
     def onCollectionRemoveMember(self):
         ui = self.collectionsUI
         for item in ui.membersList.selectedItems():
@@ -223,8 +170,7 @@ class CollectionsTabMixin:
             qt.QApplication.restoreOverrideCursor()
 
         ui.createStatus.text = (
-            f"Created {nwo} as a private draft. Review it, then use 'Publish selected draft' "
-            "above to make it public.")
+            f"Created {nwo} (public). It will appear on the RepoClerk dashboard shortly.")
         ui.titleEdit.text = ""
         ui.descEdit.text = ""
         ui.membersList.clear()

--- a/MorphoDepot/MorphoDepotLib/widget_collections.py
+++ b/MorphoDepot/MorphoDepotLib/widget_collections.py
@@ -142,7 +142,12 @@ class CollectionsTabMixin:
         if nwo not in self._collectionCorpus.values():
             ui.createStatus.text = f"Checking {nwo}…"
             slicer.app.processEvents()
-            if not self.logic.isMorphoDepotRepo(nwo):
+            qt.QApplication.setOverrideCursor(qt.Qt.WaitCursor)
+            try:
+                isMorphoDepot = self.logic.isMorphoDepotRepo(nwo)
+            finally:
+                qt.QApplication.restoreOverrideCursor()
+            if not isMorphoDepot:
                 ui.createStatus.text = (
                     f"{nwo} is not a MorphoDepot repository (it must carry the 'morphodepot' "
                     "topic). Only MorphoDepot dataset repositories can be added.")

--- a/MorphoDepot/MorphoDepotLib/widget_collections.py
+++ b/MorphoDepot/MorphoDepotLib/widget_collections.py
@@ -67,8 +67,17 @@ class CollectionsTabMixin:
         # --- Existing Collections ---
         existingLayout = ui.existingCollapsibleButton.layout()
         ui.existingList = qt.QListWidget()
-        ui.existingList.setToolTip("Existing collections (read-only). Click Refresh to load.")
+        ui.existingList.setToolTip("Published collections. Double-click to open. Click Refresh to load.")
         existingLayout.addWidget(ui.existingList)
+
+        ui.draftsLabel = qt.QLabel("Your unpublished drafts:")
+        existingLayout.addWidget(ui.draftsLabel)
+        ui.draftsList = qt.QListWidget()
+        ui.draftsList.setToolTip("Private collections you created but have not published yet. "
+                                 "Double-click to open on GitHub; select one and Publish to make it public.")
+        existingLayout.addWidget(ui.draftsList)
+        ui.publishButton = qt.QPushButton("Publish selected draft")
+        existingLayout.addWidget(ui.publishButton)
 
         # Display-text -> nameWithOwner map for the corpus combo.
         self._collectionCorpus = {}
@@ -80,6 +89,9 @@ class CollectionsTabMixin:
         ui.createButton.connect("clicked()", self.onCreateCollection)
         ui.existingList.connect("itemDoubleClicked(QListWidgetItem*)",
                                 self.onExistingCollectionDoubleClicked)
+        ui.draftsList.connect("itemDoubleClicked(QListWidgetItem*)",
+                              self.onExistingCollectionDoubleClicked)
+        ui.publishButton.connect("clicked()", self.onPublishDraft)
 
     # --- Handlers ---
 
@@ -116,7 +128,24 @@ class CollectionsTabMixin:
         if not collections:
             ui.existingList.addItem("No collections yet.")
 
-        ui.createStatus.text = f"Loaded {len(corpus)} repositories, {len(collections)} collections."
+        # The member's own unpublished (private) drafts, listed via gh (RepoClerk only sees public).
+        try:
+            drafts = self.logic.myDraftCollections()
+        except Exception as e:
+            drafts = []
+            logging.warning(f"Could not list draft collections: {e}")
+        ui.draftsList.clear()
+        for d in drafts:
+            item = qt.QListWidgetItem(f"{d['name']}  [{d['nameWithOwner']}]")
+            item.setData(qt.Qt.UserRole, d["nameWithOwner"])
+            item.setToolTip(f"Double-click to open https://github.com/{d['nameWithOwner']}")
+            ui.draftsList.addItem(item)
+        if not drafts:
+            ui.draftsList.addItem("No unpublished drafts.")
+        ui.publishButton.enabled = bool(drafts)
+
+        ui.createStatus.text = (
+            f"Loaded {len(corpus)} repositories, {len(collections)} published, {len(drafts)} draft(s).")
 
     def _resolveComboToNwo(self, text):
         text = (text or "").strip()
@@ -144,6 +173,30 @@ class CollectionsTabMixin:
         if nwo:
             qt.QDesktopServices.openUrl(qt.QUrl(f"https://github.com/{nwo}"))
 
+    def onPublishDraft(self):
+        """Publish the selected draft collection (flip it to public)."""
+        ui = self.collectionsUI
+        items = ui.draftsList.selectedItems()
+        nwo = items[0].data(qt.Qt.UserRole) if items else None
+        if not nwo:
+            ui.createStatus.text = "Select one of your drafts to publish."
+            return
+        ui.publishButton.enabled = False
+        ui.createStatus.text = f"Publishing {nwo}..."
+        qt.QApplication.setOverrideCursor(qt.Qt.WaitCursor)
+        slicer.app.processEvents()
+        try:
+            self.logic.publishCollection(nwo)
+        except Exception as e:
+            ui.createStatus.text = f"Failed to publish {nwo}: {e}"
+            logging.error(f"publishCollection failed: {e}")
+            ui.publishButton.enabled = True
+            return
+        finally:
+            qt.QApplication.restoreOverrideCursor()
+        ui.createStatus.text = f"Published {nwo}. It will appear on the dashboard shortly."
+        self.onCollectionsRefresh()
+
     def onCollectionRemoveMember(self):
         ui = self.collectionsUI
         for item in ui.membersList.selectedItems():
@@ -170,7 +223,8 @@ class CollectionsTabMixin:
             qt.QApplication.restoreOverrideCursor()
 
         ui.createStatus.text = (
-            f"Created {nwo} (public). It will appear on the RepoClerk dashboard shortly.")
+            f"Created {nwo} as a private draft. Review it, then use 'Publish selected draft' "
+            "above to make it public.")
         ui.titleEdit.text = ""
         ui.descEdit.text = ""
         ui.membersList.clear()

--- a/MorphoDepot/MorphoDepotLib/widget_collections.py
+++ b/MorphoDepot/MorphoDepotLib/widget_collections.py
@@ -57,13 +57,6 @@ class CollectionsTabMixin:
         ui.removeMemberButton = qt.QPushButton("Remove selected")
         createLayout.addWidget(ui.removeMemberButton)
 
-        ui.makePublicCheck = qt.QCheckBox("Make public now (org owners only)")
-        ui.makePublicCheck.checked = True
-        ui.makePublicCheck.setToolTip(
-            "Org owners can publish immediately. For other members the collection is created "
-            "private and an owner publishes it.")
-        createLayout.addWidget(ui.makePublicCheck)
-
         ui.createButton = qt.QPushButton("Create Collection")
         createLayout.addWidget(ui.createButton)
 
@@ -161,14 +154,13 @@ class CollectionsTabMixin:
         title = ui.titleEdit.text.strip()
         description = ui.descEdit.text.strip()
         members = [ui.membersList.item(i).text() for i in range(ui.membersList.count)]
-        makePublic = ui.makePublicCheck.checked
 
         ui.createButton.enabled = False
         ui.createStatus.text = "Creating collection..."
         qt.QApplication.setOverrideCursor(qt.Qt.WaitCursor)
         slicer.app.processEvents()
         try:
-            nwo = self.logic.createCollection(title, description, members, makePublic=makePublic)
+            nwo = self.logic.createCollection(title, description, members)
         except Exception as e:
             ui.createStatus.text = f"Failed to create collection: {e}"
             logging.error(f"createCollection failed: {e}")
@@ -177,10 +169,8 @@ class CollectionsTabMixin:
         finally:
             qt.QApplication.restoreOverrideCursor()
 
-        vis = "public" if makePublic else "private"
         ui.createStatus.text = (
-            f"Created {nwo} ({vis}). RepoClerk will render it shortly. "
-            "If it was created private, an org owner can publish it.")
+            f"Created {nwo} (public). It will appear on the RepoClerk dashboard shortly.")
         ui.titleEdit.text = ""
         ui.descEdit.text = ""
         ui.membersList.clear()

--- a/MorphoDepot/MorphoDepotLib/widget_collections.py
+++ b/MorphoDepot/MorphoDepotLib/widget_collections.py
@@ -88,6 +88,7 @@ class CollectionsTabMixin:
         ui = self.collectionsUI
         ui.createStatus.text = "Loading repositories from RepoClerk..."
         slicer.app.processEvents()
+        qt.QApplication.setOverrideCursor(qt.Qt.WaitCursor)
         try:
             corpus = self.logic.datasetRepoCorpus()
             collections = self.logic.collectionRepos()
@@ -95,6 +96,8 @@ class CollectionsTabMixin:
             ui.createStatus.text = f"Could not load repository data: {e}"
             logging.warning(f"Collections refresh failed: {e}")
             return
+        finally:
+            qt.QApplication.restoreOverrideCursor()
 
         ui.repoCombo.clear()
         self._collectionCorpus = {}
@@ -165,43 +168,46 @@ class CollectionsTabMixin:
         description = ui.descEdit.text.strip()
         members = [ui.membersList.item(i).text() for i in range(ui.membersList.count)]
 
-        # Fuzzy duplicate-collection check — warn (don't block, since fuzzy can false-positive)
-        # and let the user decide. Catches near-duplicate titles, not just exact ones.
-        if title:
-            try:
-                similar = self.logic.similarCollections(title)
-            except Exception as e:
-                similar = []
-                logging.warning(f"Similar-collection check failed: {e}")
-            if similar:
-                listing = "\n".join(f"  • {c['title']}   ({c['nameWithOwner']})"
-                                    for c in similar[:5])
-                if not slicer.util.confirmYesNoDisplay(
-                        f"A similar collection already exists:\n\n{listing}\n\n"
-                        "Consider adding your repositories to it instead. "
-                        "Create a new collection anyway?",
-                        windowTitle="Possible duplicate collection"):
-                    ui.createStatus.text = "Cancelled — a similar collection already exists."
-                    return
-
+        # Disable the button and show a wait cursor up front — the fuzzy-duplicate check below
+        # already makes a live `gh` call, so guard against double-submits and freeze-looking UI
+        # from the very first network round-trip.
         ui.createButton.enabled = False
         ui.createStatus.text = "Creating collection..."
         qt.QApplication.setOverrideCursor(qt.Qt.WaitCursor)
         slicer.app.processEvents()
         try:
+            # Fuzzy near-duplicate title check — warn (don't block; fuzzy can false-positive).
+            if title:
+                try:
+                    similar = self.logic.similarCollections(title)
+                except Exception as e:
+                    similar = []
+                    logging.warning(f"Similar-collection check failed: {e}")
+                if similar:
+                    listing = "\n".join(f"  • {c['title']}   ({c['nameWithOwner']})"
+                                        for c in similar[:5])
+                    qt.QApplication.restoreOverrideCursor()  # normal cursor for the modal
+                    proceed = slicer.util.confirmYesNoDisplay(
+                        f"A similar collection already exists:\n\n{listing}\n\n"
+                        "Consider adding your repositories to it instead. "
+                        "Create a new collection anyway?",
+                        windowTitle="Possible duplicate collection")
+                    qt.QApplication.setOverrideCursor(qt.Qt.WaitCursor)
+                    if not proceed:
+                        ui.createStatus.text = "Cancelled — a similar collection already exists."
+                        return
             nwo = self.logic.createCollection(title, description, members)
         except Exception as e:
             ui.createStatus.text = f"Failed to create collection: {e}"
             logging.error(f"createCollection failed: {e}")
-            ui.createButton.enabled = True
             return
         finally:
             qt.QApplication.restoreOverrideCursor()
+            ui.createButton.enabled = True
 
         ui.createStatus.text = (
             f"Created {nwo} (public). It will appear on the RepoClerk dashboard shortly.")
         ui.titleEdit.text = ""
         ui.descEdit.text = ""
         ui.membersList.clear()
-        ui.createButton.enabled = True
         self.onCollectionsRefresh()

--- a/MorphoDepot/MorphoDepotLib/widget_collections.py
+++ b/MorphoDepot/MorphoDepotLib/widget_collections.py
@@ -85,6 +85,8 @@ class CollectionsTabMixin:
         ui.addMemberButton.connect("clicked()", self.onCollectionAddMember)
         ui.removeMemberButton.connect("clicked()", self.onCollectionRemoveMember)
         ui.createButton.connect("clicked()", self.onCreateCollection)
+        ui.existingList.connect("itemDoubleClicked(QListWidgetItem*)",
+                                self.onExistingCollectionDoubleClicked)
 
     # --- Handlers ---
 
@@ -113,8 +115,11 @@ class CollectionsTabMixin:
         ui.existingList.clear()
         for c in collections:
             curator = f" — curated by @{c['curator']}" if c.get("curator") else ""
-            ui.existingList.addItem(
+            item = qt.QListWidgetItem(
                 f"{c['title']}  ({len(c.get('memberRefs', []))} members){curator}  [{c['nameWithOwner']}]")
+            item.setData(qt.Qt.UserRole, c["nameWithOwner"])
+            item.setToolTip(f"Double-click to open https://github.com/{c['nameWithOwner']}")
+            ui.existingList.addItem(item)
         if not collections:
             ui.existingList.addItem("No collections yet.")
 
@@ -139,6 +144,12 @@ class CollectionsTabMixin:
         ui.membersList.addItem(nwo)
         ui.repoCombo.setCurrentText("")
         ui.createStatus.text = ""
+
+    def onExistingCollectionDoubleClicked(self, item):
+        """Open the collection's GitHub repository page in the browser."""
+        nwo = item.data(qt.Qt.UserRole)
+        if nwo:
+            qt.QDesktopServices.openUrl(qt.QUrl(f"https://github.com/{nwo}"))
 
     def onCollectionRemoveMember(self):
         ui = self.collectionsUI

--- a/MorphoDepot/MorphoDepotLib/widget_collections.py
+++ b/MorphoDepot/MorphoDepotLib/widget_collections.py
@@ -165,6 +165,25 @@ class CollectionsTabMixin:
         description = ui.descEdit.text.strip()
         members = [ui.membersList.item(i).text() for i in range(ui.membersList.count)]
 
+        # Fuzzy duplicate-collection check — warn (don't block, since fuzzy can false-positive)
+        # and let the user decide. Catches near-duplicate titles, not just exact ones.
+        if title:
+            try:
+                similar = self.logic.similarCollections(title)
+            except Exception as e:
+                similar = []
+                logging.warning(f"Similar-collection check failed: {e}")
+            if similar:
+                listing = "\n".join(f"  • {c['title']}   ({c['nameWithOwner']})"
+                                    for c in similar[:5])
+                if not slicer.util.confirmYesNoDisplay(
+                        f"A similar collection already exists:\n\n{listing}\n\n"
+                        "Consider adding your repositories to it instead. "
+                        "Create a new collection anyway?",
+                        windowTitle="Possible duplicate collection"):
+                    ui.createStatus.text = "Cancelled — a similar collection already exists."
+                    return
+
         ui.createButton.enabled = False
         ui.createStatus.text = "Creating collection..."
         qt.QApplication.setOverrideCursor(qt.Qt.WaitCursor)

--- a/MorphoDepot/MorphoDepotLib/widget_collections.py
+++ b/MorphoDepot/MorphoDepotLib/widget_collections.py
@@ -1,0 +1,186 @@
+"""MorphoDepotWidget CollectionsTabMixin — the Collections tab UI.
+
+Lets an org member create a curated "repo of repos" collection: enter a title, pick (or paste)
+at least two member repositories from the known corpus, and create.  The member's own ``gh``
+creates the in-org repo, seeds a canonical README + ``CURATOR``, and tags it ``md-collection``;
+RepoClerk then renders it as a gallery.  See logic_collections.CollectionsMixin and
+SlicerMorph/SlicerMorphoDepot#180.
+
+The collapsible-button containers come from MorphoDepotCollections.ui; the controls are built
+here (same convention the Configure tab uses).
+"""
+import logging
+import qt
+import slicer
+
+
+class CollectionsTabMixin:
+    def setupCollectionsTab(self):
+        """Build the Collections tab controls into the .ui containers and connect them."""
+        ui = self.collectionsUI
+
+        # --- Create a Collection ---
+        createLayout = ui.createCollapsibleButton.layout()
+
+        intro = qt.QLabel(
+            "A collection groups existing MorphoDepot repositories under a theme "
+            "(e.g. \"Mammal Skulls of the PNW\"). Enter a title and add at least two repositories.")
+        intro.setWordWrap(True)
+        createLayout.addWidget(intro)
+
+        form = qt.QFormLayout()
+        ui.titleEdit = qt.QLineEdit()
+        ui.titleEdit.setPlaceholderText("e.g. Snakes of Texas")
+        ui.titleEdit.setToolTip("The collection's display name. A short repository name is derived "
+                                "from it automatically.")
+        form.addRow("Title:", ui.titleEdit)
+        ui.descEdit = qt.QLineEdit()
+        ui.descEdit.setPlaceholderText("Optional one-line description")
+        form.addRow("Description:", ui.descEdit)
+        createLayout.addLayout(form)
+
+        # Member picker: choose from the corpus or paste a GitHub URL.
+        pickRow = qt.QHBoxLayout()
+        ui.repoCombo = qt.QComboBox()
+        ui.repoCombo.editable = True
+        ui.repoCombo.setToolTip("Pick a repository from the list, or paste a GitHub URL, then Add.")
+        ui.addMemberButton = qt.QPushButton("Add")
+        pickRow.addWidget(ui.repoCombo, 1)
+        pickRow.addWidget(ui.addMemberButton)
+        createLayout.addLayout(pickRow)
+
+        ui.membersList = qt.QListWidget()
+        ui.membersList.setToolTip("Member repositories in this collection.")
+        ui.membersList.setSelectionMode(qt.QAbstractItemView.ExtendedSelection)
+        createLayout.addWidget(ui.membersList)
+
+        ui.removeMemberButton = qt.QPushButton("Remove selected")
+        createLayout.addWidget(ui.removeMemberButton)
+
+        ui.makePublicCheck = qt.QCheckBox("Make public now (org owners only)")
+        ui.makePublicCheck.checked = True
+        ui.makePublicCheck.setToolTip(
+            "Org owners can publish immediately. For other members the collection is created "
+            "private and an owner publishes it.")
+        createLayout.addWidget(ui.makePublicCheck)
+
+        ui.createButton = qt.QPushButton("Create Collection")
+        ui.createButton.enabled = False
+        createLayout.addWidget(ui.createButton)
+
+        ui.createStatus = qt.QLabel("")
+        ui.createStatus.setWordWrap(True)
+        createLayout.addWidget(ui.createStatus)
+
+        # --- Existing Collections ---
+        existingLayout = ui.existingCollapsibleButton.layout()
+        ui.existingList = qt.QListWidget()
+        ui.existingList.setToolTip("Existing collections (read-only). Click Refresh to load.")
+        existingLayout.addWidget(ui.existingList)
+
+        # Display-text -> nameWithOwner map for the corpus combo.
+        self._collectionCorpus = {}
+
+        # --- Connections ---
+        ui.refreshButton.connect("clicked()", self.onCollectionsRefresh)
+        ui.addMemberButton.connect("clicked()", self.onCollectionAddMember)
+        ui.removeMemberButton.connect("clicked()", self.onCollectionRemoveMember)
+        ui.createButton.connect("clicked()", self.onCreateCollection)
+        ui.titleEdit.connect("textChanged(QString)", lambda _t: self._updateCollectionCreateEnabled())
+        ui.membersList.connect("itemSelectionChanged()", lambda: None)
+
+    # --- Handlers ---
+
+    def onCollectionsRefresh(self):
+        """Load the dataset corpus (for the picker) and the existing collections list."""
+        ui = self.collectionsUI
+        ui.createStatus.text = "Loading repositories from RepoClerk..."
+        slicer.app.processEvents()
+        try:
+            corpus = self.logic.datasetRepoCorpus()
+            collections = self.logic.collectionRepos()
+        except Exception as e:
+            ui.createStatus.text = f"Could not load repository data: {e}"
+            logging.warning(f"Collections refresh failed: {e}")
+            return
+
+        ui.repoCombo.clear()
+        self._collectionCorpus = {}
+        for nwo in sorted(corpus):
+            species = corpus[nwo].get("species") or ""
+            display = f"{nwo}   ({species})" if species else nwo
+            self._collectionCorpus[display] = nwo
+            ui.repoCombo.addItem(display)
+        ui.repoCombo.setCurrentText("")
+
+        ui.existingList.clear()
+        for c in collections:
+            curator = f" — curated by @{c['curator']}" if c.get("curator") else ""
+            ui.existingList.addItem(
+                f"{c['title']}  ({len(c.get('memberRefs', []))} members){curator}  [{c['nameWithOwner']}]")
+        if not collections:
+            ui.existingList.addItem("No collections yet.")
+
+        ui.createStatus.text = f"Loaded {len(corpus)} repositories, {len(collections)} collections."
+
+    def _resolveComboToNwo(self, text):
+        text = (text or "").strip()
+        if text in self._collectionCorpus:
+            return self._collectionCorpus[text]
+        return self.logic.normalizeRepoRef(text)
+
+    def onCollectionAddMember(self):
+        ui = self.collectionsUI
+        nwo = self._resolveComboToNwo(ui.repoCombo.currentText)
+        if not nwo:
+            ui.createStatus.text = "Enter a repository as owner/name or a GitHub URL."
+            return
+        existing = [ui.membersList.item(i).text() for i in range(ui.membersList.count)]
+        if nwo in existing:
+            ui.createStatus.text = f"{nwo} is already in the collection."
+            return
+        ui.membersList.addItem(nwo)
+        ui.repoCombo.setCurrentText("")
+        ui.createStatus.text = ""
+        self._updateCollectionCreateEnabled()
+
+    def onCollectionRemoveMember(self):
+        ui = self.collectionsUI
+        for item in ui.membersList.selectedItems():
+            ui.membersList.takeItem(ui.membersList.row(item))
+        self._updateCollectionCreateEnabled()
+
+    def _updateCollectionCreateEnabled(self):
+        ui = self.collectionsUI
+        ui.createButton.enabled = bool(ui.titleEdit.text.strip()) and ui.membersList.count >= 2
+
+    def onCreateCollection(self):
+        ui = self.collectionsUI
+        title = ui.titleEdit.text.strip()
+        description = ui.descEdit.text.strip()
+        members = [ui.membersList.item(i).text() for i in range(ui.membersList.count)]
+        makePublic = ui.makePublicCheck.checked
+
+        ui.createButton.enabled = False
+        ui.createStatus.text = "Creating collection..."
+        qt.QApplication.setOverrideCursor(qt.Qt.WaitCursor)
+        slicer.app.processEvents()
+        try:
+            nwo = self.logic.createCollection(title, description, members, makePublic=makePublic)
+        except Exception as e:
+            ui.createStatus.text = f"Failed to create collection: {e}"
+            logging.error(f"createCollection failed: {e}")
+            self._updateCollectionCreateEnabled()
+            return
+        finally:
+            qt.QApplication.restoreOverrideCursor()
+
+        vis = "public" if makePublic else "private"
+        ui.createStatus.text = (
+            f"Created {nwo} ({vis}). RepoClerk will render it shortly. "
+            "If it was created private, an org owner can publish it.")
+        ui.titleEdit.text = ""
+        ui.descEdit.text = ""
+        ui.membersList.clear()
+        self._updateCollectionCreateEnabled()
+        self.onCollectionsRefresh()

--- a/MorphoDepot/MorphoDepotLib/widget_collections.py
+++ b/MorphoDepot/MorphoDepotLib/widget_collections.py
@@ -65,7 +65,6 @@ class CollectionsTabMixin:
         createLayout.addWidget(ui.makePublicCheck)
 
         ui.createButton = qt.QPushButton("Create Collection")
-        ui.createButton.enabled = False
         createLayout.addWidget(ui.createButton)
 
         ui.createStatus = qt.QLabel("")
@@ -86,8 +85,6 @@ class CollectionsTabMixin:
         ui.addMemberButton.connect("clicked()", self.onCollectionAddMember)
         ui.removeMemberButton.connect("clicked()", self.onCollectionRemoveMember)
         ui.createButton.connect("clicked()", self.onCreateCollection)
-        ui.titleEdit.connect("textChanged(QString)", lambda _t: self._updateCollectionCreateEnabled())
-        ui.membersList.connect("itemSelectionChanged()", lambda: None)
 
     # --- Handlers ---
 
@@ -142,17 +139,11 @@ class CollectionsTabMixin:
         ui.membersList.addItem(nwo)
         ui.repoCombo.setCurrentText("")
         ui.createStatus.text = ""
-        self._updateCollectionCreateEnabled()
 
     def onCollectionRemoveMember(self):
         ui = self.collectionsUI
         for item in ui.membersList.selectedItems():
             ui.membersList.takeItem(ui.membersList.row(item))
-        self._updateCollectionCreateEnabled()
-
-    def _updateCollectionCreateEnabled(self):
-        ui = self.collectionsUI
-        ui.createButton.enabled = bool(ui.titleEdit.text.strip()) and ui.membersList.count >= 2
 
     def onCreateCollection(self):
         ui = self.collectionsUI
@@ -170,7 +161,7 @@ class CollectionsTabMixin:
         except Exception as e:
             ui.createStatus.text = f"Failed to create collection: {e}"
             logging.error(f"createCollection failed: {e}")
-            self._updateCollectionCreateEnabled()
+            ui.createButton.enabled = True
             return
         finally:
             qt.QApplication.restoreOverrideCursor()
@@ -182,5 +173,5 @@ class CollectionsTabMixin:
         ui.titleEdit.text = ""
         ui.descEdit.text = ""
         ui.membersList.clear()
-        self._updateCollectionCreateEnabled()
+        ui.createButton.enabled = True
         self.onCollectionsRefresh()

--- a/MorphoDepot/MorphoDepotLib/widget_collections.py
+++ b/MorphoDepot/MorphoDepotLib/widget_collections.py
@@ -134,6 +134,16 @@ class CollectionsTabMixin:
         if nwo in existing:
             ui.createStatus.text = f"{nwo} is already in the collection."
             return
+        # Corpus picks are already known MorphoDepot repos; a pasted URL/owner-name must be verified
+        # to actually be a MorphoDepot dataset repo (carries the 'morphodepot' topic) before adding.
+        if nwo not in self._collectionCorpus.values():
+            ui.createStatus.text = f"Checking {nwo}…"
+            slicer.app.processEvents()
+            if not self.logic.isMorphoDepotRepo(nwo):
+                ui.createStatus.text = (
+                    f"{nwo} is not a MorphoDepot repository (it must carry the 'morphodepot' "
+                    "topic). Only MorphoDepot dataset repositories can be added.")
+                return
         ui.membersList.addItem(nwo)
         ui.repoCombo.setCurrentText("")
         ui.createStatus.text = ""

--- a/MorphoDepot/MorphoDepotLib/widget_collections.py
+++ b/MorphoDepot/MorphoDepotLib/widget_collections.py
@@ -53,7 +53,6 @@ class CollectionsTabMixin:
         ui.membersList.setToolTip("Member repositories in this collection.")
         ui.membersList.setSelectionMode(qt.QAbstractItemView.ExtendedSelection)
         createLayout.addWidget(ui.membersList)
-        self._fitCollectionList(ui.membersList)
 
         ui.removeMemberButton = qt.QPushButton("Remove selected")
         createLayout.addWidget(ui.removeMemberButton)
@@ -78,7 +77,6 @@ class CollectionsTabMixin:
         ui.existingList = qt.QListWidget()
         ui.existingList.setToolTip("Existing collections (read-only). Click Refresh to load.")
         existingLayout.addWidget(ui.existingList)
-        self._fitCollectionList(ui.existingList)
 
         # Display-text -> nameWithOwner map for the corpus combo.
         self._collectionCorpus = {}
@@ -90,14 +88,6 @@ class CollectionsTabMixin:
         ui.createButton.connect("clicked()", self.onCreateCollection)
         ui.titleEdit.connect("textChanged(QString)", lambda _t: self._updateCollectionCreateEnabled())
         ui.membersList.connect("itemSelectionChanged()", lambda: None)
-
-    def _fitCollectionList(self, listWidget, maxRows=10):
-        """Size a list to its contents, from 1 row (empty) up to ``maxRows`` — so an empty or
-        short list never leaves a large blank box.  Beyond ``maxRows`` a scrollbar appears."""
-        rowH = qt.QFontMetrics(listWidget.font).lineSpacing() + 4
-        rows = min(max(listWidget.count, 1), maxRows)
-        listWidget.setFixedHeight(rows * rowH + 8)
-        listWidget.setVerticalScrollBarPolicy(qt.Qt.ScrollBarAsNeeded)
 
     # --- Handlers ---
 
@@ -130,7 +120,6 @@ class CollectionsTabMixin:
                 f"{c['title']}  ({len(c.get('memberRefs', []))} members){curator}  [{c['nameWithOwner']}]")
         if not collections:
             ui.existingList.addItem("No collections yet.")
-        self._fitCollectionList(ui.existingList)
 
         ui.createStatus.text = f"Loaded {len(corpus)} repositories, {len(collections)} collections."
 
@@ -153,14 +142,12 @@ class CollectionsTabMixin:
         ui.membersList.addItem(nwo)
         ui.repoCombo.setCurrentText("")
         ui.createStatus.text = ""
-        self._fitCollectionList(ui.membersList)
         self._updateCollectionCreateEnabled()
 
     def onCollectionRemoveMember(self):
         ui = self.collectionsUI
         for item in ui.membersList.selectedItems():
             ui.membersList.takeItem(ui.membersList.row(item))
-        self._fitCollectionList(ui.membersList)
         self._updateCollectionCreateEnabled()
 
     def _updateCollectionCreateEnabled(self):
@@ -195,6 +182,5 @@ class CollectionsTabMixin:
         ui.titleEdit.text = ""
         ui.descEdit.text = ""
         ui.membersList.clear()
-        self._fitCollectionList(ui.membersList)
         self._updateCollectionCreateEnabled()
         self.onCollectionsRefresh()

--- a/MorphoDepot/MorphoDepotLib/widget_collections.py
+++ b/MorphoDepot/MorphoDepotLib/widget_collections.py
@@ -76,6 +76,10 @@ class CollectionsTabMixin:
         existingLayout = ui.existingCollapsibleButton.layout()
         ui.existingList = qt.QListWidget()
         ui.existingList.setToolTip("Existing collections (read-only). Click Refresh to load.")
+        # Show at most ~10 rows; a vertical scrollbar appears when there are more.
+        rowHeight = qt.QFontMetrics(ui.existingList.font).lineSpacing() + 4
+        ui.existingList.setMaximumHeight(rowHeight * 10 + 8)
+        ui.existingList.setVerticalScrollBarPolicy(qt.Qt.ScrollBarAsNeeded)
         existingLayout.addWidget(ui.existingList)
 
         # Display-text -> nameWithOwner map for the corpus combo.

--- a/MorphoDepot/MorphoDepotLib/widget_collections.py
+++ b/MorphoDepot/MorphoDepotLib/widget_collections.py
@@ -53,6 +53,7 @@ class CollectionsTabMixin:
         ui.membersList.setToolTip("Member repositories in this collection.")
         ui.membersList.setSelectionMode(qt.QAbstractItemView.ExtendedSelection)
         createLayout.addWidget(ui.membersList)
+        self._fitCollectionList(ui.membersList)
 
         ui.removeMemberButton = qt.QPushButton("Remove selected")
         createLayout.addWidget(ui.removeMemberButton)
@@ -76,11 +77,8 @@ class CollectionsTabMixin:
         existingLayout = ui.existingCollapsibleButton.layout()
         ui.existingList = qt.QListWidget()
         ui.existingList.setToolTip("Existing collections (read-only). Click Refresh to load.")
-        # Show at most ~10 rows; a vertical scrollbar appears when there are more.
-        rowHeight = qt.QFontMetrics(ui.existingList.font).lineSpacing() + 4
-        ui.existingList.setMaximumHeight(rowHeight * 10 + 8)
-        ui.existingList.setVerticalScrollBarPolicy(qt.Qt.ScrollBarAsNeeded)
         existingLayout.addWidget(ui.existingList)
+        self._fitCollectionList(ui.existingList)
 
         # Display-text -> nameWithOwner map for the corpus combo.
         self._collectionCorpus = {}
@@ -92,6 +90,14 @@ class CollectionsTabMixin:
         ui.createButton.connect("clicked()", self.onCreateCollection)
         ui.titleEdit.connect("textChanged(QString)", lambda _t: self._updateCollectionCreateEnabled())
         ui.membersList.connect("itemSelectionChanged()", lambda: None)
+
+    def _fitCollectionList(self, listWidget, maxRows=10):
+        """Size a list to its contents, from 1 row (empty) up to ``maxRows`` — so an empty or
+        short list never leaves a large blank box.  Beyond ``maxRows`` a scrollbar appears."""
+        rowH = qt.QFontMetrics(listWidget.font).lineSpacing() + 4
+        rows = min(max(listWidget.count, 1), maxRows)
+        listWidget.setFixedHeight(rows * rowH + 8)
+        listWidget.setVerticalScrollBarPolicy(qt.Qt.ScrollBarAsNeeded)
 
     # --- Handlers ---
 
@@ -124,6 +130,7 @@ class CollectionsTabMixin:
                 f"{c['title']}  ({len(c.get('memberRefs', []))} members){curator}  [{c['nameWithOwner']}]")
         if not collections:
             ui.existingList.addItem("No collections yet.")
+        self._fitCollectionList(ui.existingList)
 
         ui.createStatus.text = f"Loaded {len(corpus)} repositories, {len(collections)} collections."
 
@@ -146,12 +153,14 @@ class CollectionsTabMixin:
         ui.membersList.addItem(nwo)
         ui.repoCombo.setCurrentText("")
         ui.createStatus.text = ""
+        self._fitCollectionList(ui.membersList)
         self._updateCollectionCreateEnabled()
 
     def onCollectionRemoveMember(self):
         ui = self.collectionsUI
         for item in ui.membersList.selectedItems():
             ui.membersList.takeItem(ui.membersList.row(item))
+        self._fitCollectionList(ui.membersList)
         self._updateCollectionCreateEnabled()
 
     def _updateCollectionCreateEnabled(self):
@@ -186,5 +195,6 @@ class CollectionsTabMixin:
         ui.titleEdit.text = ""
         ui.descEdit.text = ""
         ui.membersList.clear()
+        self._fitCollectionList(ui.membersList)
         self._updateCollectionCreateEnabled()
         self.onCollectionsRefresh()

--- a/MorphoDepot/MorphoDepotLib/widget_search.py
+++ b/MorphoDepot/MorphoDepotLib/widget_search.py
@@ -219,12 +219,19 @@ class SearchTabMixin:
 
         menu = qt.QMenu()
         openRepoAction = menu.addAction("Open Repository Page")
+        copyUrlAction = menu.addAction("Copy Repository URL")
         previewAction = menu.addAction("Preview in Slicer")
 
         action = menu.exec_(self.searchUI.resultsTable.mapToGlobal(point))
 
         if action == openRepoAction:
             qt.QDesktopServices.openUrl(qt.QUrl(f"https://github.com/{fullRepoName}"))
+        elif action == copyUrlAction:
+            # Copy the GitHub URL so it can be pasted straight into the Collections member
+            # picker (which accepts a URL or owner/name) -- avoids retyping and typos.
+            url = f"https://github.com/{fullRepoName}"
+            qt.QApplication.clipboard().setText(url)
+            slicer.util.showStatusMessage(f"Copied {url} to clipboard", 3000)
         elif action == previewAction:
             self.previewRepository(fullRepoName)
 

--- a/MorphoDepot/Resources/UI/MorphoDepotCollections.ui
+++ b/MorphoDepot/Resources/UI/MorphoDepotCollections.ui
@@ -42,6 +42,19 @@
      </layout>
     </widget>
    </item>
+   <item>
+    <spacer name="bottomSpacer">
+     <property name="orientation">
+      <enum>Qt::Vertical</enum>
+     </property>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>20</width>
+       <height>0</height>
+      </size>
+     </property>
+    </spacer>
+   </item>
   </layout>
  </widget>
  <customwidgets>

--- a/MorphoDepot/Resources/UI/MorphoDepotCollections.ui
+++ b/MorphoDepot/Resources/UI/MorphoDepotCollections.ui
@@ -1,0 +1,58 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>MorphoDepotCollections</class>
+ <widget class="qMRMLWidget" name="MorphoDepotCollections">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>325</width>
+    <height>700</height>
+   </rect>
+  </property>
+  <layout class="QVBoxLayout" name="verticalLayout">
+   <item>
+    <widget class="QPushButton" name="refreshButton">
+     <property name="text">
+      <string>Refresh collections and repository list</string>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <widget class="ctkCollapsibleButton" name="createCollapsibleButton">
+     <property name="text">
+      <string>Create a Collection</string>
+     </property>
+     <layout class="QVBoxLayout" name="createLayout">
+     </layout>
+    </widget>
+   </item>
+   <item>
+    <widget class="ctkCollapsibleButton" name="existingCollapsibleButton">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Minimum" vsizetype="Preferred">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="text">
+      <string>Existing Collections</string>
+     </property>
+     <layout class="QVBoxLayout" name="existingLayout">
+     </layout>
+    </widget>
+   </item>
+  </layout>
+ </widget>
+ <customwidgets>
+  <customwidget>
+   <class>ctkCollapsibleButton</class>
+   <extends>QWidget</extends>
+   <header>ctkCollapsibleButton.h</header>
+   <container>1</container>
+  </customwidget>
+ </customwidgets>
+ <resources/>
+ <connections>
+ </connections>
+</ui>

--- a/MorphoDepot/Resources/UI/MorphoDepotCollections.ui
+++ b/MorphoDepot/Resources/UI/MorphoDepotCollections.ui
@@ -43,14 +43,14 @@
     </widget>
    </item>
    <item>
-    <spacer name="bottomSpacer">
+    <spacer name="verticalSpacer">
      <property name="orientation">
       <enum>Qt::Vertical</enum>
      </property>
      <property name="sizeHint" stdset="0">
       <size>
        <width>20</width>
-       <height>0</height>
+       <height>40</height>
       </size>
      </property>
     </spacer>

--- a/MorphoDepot/Resources/UI/MorphoDepotCollections.ui
+++ b/MorphoDepot/Resources/UI/MorphoDepotCollections.ui
@@ -19,16 +19,16 @@
     </widget>
    </item>
    <item>
-    <widget class="ctkCollapsibleButton" name="createCollapsibleButton">
+    <widget class="ctkCollapsibleButton" name="existingCollapsibleButton">
      <property name="text">
-      <string>Create a Collection</string>
+      <string>Existing Collections</string>
      </property>
-     <layout class="QVBoxLayout" name="createLayout">
+     <layout class="QVBoxLayout" name="existingLayout">
      </layout>
     </widget>
    </item>
    <item>
-    <widget class="ctkCollapsibleButton" name="existingCollapsibleButton">
+    <widget class="ctkCollapsibleButton" name="createCollapsibleButton">
      <property name="sizePolicy">
       <sizepolicy hsizetype="Minimum" vsizetype="Preferred">
        <horstretch>0</horstretch>
@@ -36,9 +36,9 @@
       </sizepolicy>
      </property>
      <property name="text">
-      <string>Existing Collections</string>
+      <string>Create a Collection</string>
      </property>
-     <layout class="QVBoxLayout" name="existingLayout">
+     <layout class="QVBoxLayout" name="createLayout">
      </layout>
     </widget>
    </item>


### PR DESCRIPTION
## Collections tab: create curated "repo of repos" collections

Implements #180. Companion RepoClerk rendering (parse `md-collection` repos → dashboard tile + screenshot slide deck) is already on `MorphoDepot/RepoClerk` main (MorphoDepot/RepoClerk#411).

### What this adds
A **Collections** tab (right-most) that lets an org member create a curated collection — a themed grouping of existing MorphoDepot repos — using their own `gh`. It's been exercised live (real collections created and rendered on repoclerk.morphodepot.org).

### Design decisions (context for review)
- **Repo name is opaque:** `collection-` + 8 random hex chars (`repoExists`-checked). Not derived from the title — avoids lossy truncation/collisions and is clearly distinct from human dataset repos.
- **Title = the repo *description*** (GitHub metadata), set at create. PR-proof: a member's README PR can't change it, only a repo-admin can. RepoClerk reads the title from the description; the README holds only the member list.
- **Created public** (the org allows members to create public repos), so collections are immediately visible; no owner publish gate (a collection is just a title + a list of URLs — nothing to review).
- **Governance is simple:** one `CURATOR` (the creator) for attribution; others contribute via standard fork-and-PR.
- **Member validation:** a pasted member repo is verified live to carry the `morphodepot` topic (and not be a collection) before it's added; corpus picks skip the check.
- **Fuzzy near-duplicate title check** on create (token-set + sequence similarity): warns + confirms rather than blocking.

### Files
- `MorphoDepotLib/logic_collections.py` (new) — CollectionsMixin: list collections/corpus from RepoClerk journals, opaque slug, ref normalization, member validation, fuzzy dedup, create.
- `MorphoDepotLib/widget_collections.py` (new) + `Resources/UI/MorphoDepotCollections.ui` (new) — the tab UI.
- `MorphoDepot.py` — wire the tab + both mixins.
- `MorphoDepotLib/widget_search.py` — right-click "Copy Repository URL" on Search results (paste into the Collections picker).
- `CMakeLists.txt` — package the new lib modules + `.ui`.

### Notes for review
- An earlier attempt at graying member-only tabs (Release / Collections-create) for non-members was **reverted** — it ran a synchronous control-plane call on the UI thread in `enter()` and froze the module. Not in this diff; to be reworked separately if desired.
- Please flag anything that could block the UI thread, any `gh`/network call on a hot path, and the CMake packaging (every `MorphoDepotLib/*.py` must be listed or the factory ships a broken module).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
