### PR TITLE
Speed up the staged-repos list: query owner + MorphoDepot org, not every org

### DIFF
--- a/MorphoDepot/MorphoDepotLib/logic_accession.py
+++ b/MorphoDepot/MorphoDepotLib/logic_accession.py
@@ -682,14 +682,21 @@ jobs:
         are reflected immediately, unlike the search index which lags for fresh repos), so it
         is reliable right after staging and from any machine.  Returns marker-shaped dicts."""
         me = self.whoami()
-        # Include org repos too — member-tier staged repos are born in MorphoDepot, owned by the
-        # org but accessible only to the member's {handle}-team.
-        try:
-            repos = self.ghJSON(["api", "/user/repos?affiliation=owner,organization_member&per_page=100", "--paginate"])
-        except Exception as e:
-            logging.warning(f"listStagedRepos: could not list repositories: {e}")
-            return []
+        # Staged repos can live in the user's personal account (personal-tier staging) or the
+        # MorphoDepot org (member-tier — owned by the org, reachable via the {handle}-team); both
+        # paths tag the repo `morphodepot-staging`.  Query exactly those two scopes rather than
+        # `/user/repos?affiliation=owner,organization_member --paginate`, which walks every repo of
+        # every org the user belongs to just to keep the few staged ones — bounded here regardless
+        # of how many repos live in the user's other orgs.
+        repos = []
+        for endpoint in ("/user/repos?affiliation=owner&per_page=100",
+                         f"/orgs/{self.morphoDepotOrg}/repos?per_page=100"):
+            try:
+                repos.extend(self.ghJSON(["api", endpoint, "--paginate"]) or [])
+            except Exception as e:
+                logging.warning(f"listStagedRepos: could not list {endpoint}: {e}")
         staged = []
+        seen = set()
         for repo in repos:
             if not isinstance(repo, dict):
                 continue
@@ -700,6 +707,9 @@ jobs:
                 continue
             name = repo.get("name")
             nameWithOwner = repo.get("full_name") or f"{owner}/{name}"
+            if nameWithOwner in seen:  # defensive de-dup (a repo can't be in both lists)
+                continue
+            seen.add(nameWithOwner)
             staged.append({
                 "nameWithOwner": nameWithOwner,
                 "repoName": name,


### PR DESCRIPTION
### Problem
Opening the module / activating the **Create** tab was slow. `onCurrentTabChanged` (Create branch) → `refreshStagedReposList` → `listStagedRepos()` ran:

`gh api /user/repos?affiliation=owner,organization_member&per_page=100 --paginate`

The `organization_member` affiliation makes it **crawl every repo of every org the user belongs to** (measured 148 repos across orgs for one account; far more for users in large orgs), then discards almost all of it to keep the few tagged `morphodepot-staging`. That multi-page crawl on the UI thread is the lag (it also showed up in a console trace the user captured).

### Change
Staged repos can only ever live in two places — the user's **personal account** (personal-tier staging) or the **MorphoDepot org** (member-tier; owned by the org, reachable via the `{handle}-team`). Both paths tag the repo `morphodepot-staging` (`logic_accession.py` lines 369 and 494). So query exactly those two scopes:

- `/user/repos?affiliation=owner`
- `/orgs/MorphoDepot/repos`

Merge, then the same filter as before (staging topic; owner is you or MorphoDepot). This is **bounded to those two scopes regardless of how many repos the user has in other orgs** — no assumptions about relative sizes (personal vs org). Also made it resilient to one endpoint failing (logs and continues) and de-dups defensively.

### Review focus
- Correctness of the two staging paths (personal + org) — does this keep both?
- Does `/orgs/MorphoDepot/repos` return a **member's private, team-scoped staged repo**? (It lists repos the caller can access; for an owner it returned the private org repos. Worth confirming for the regular-member case.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)