### PR TITLE
Check org membership directly from GitHub, not the control-plane App

### DIFF
--- a/MorphoDepot/MorphoDepotLib/logic_controlplane.py
+++ b/MorphoDepot/MorphoDepotLib/logic_controlplane.py
@@ -59,7 +59,15 @@ class ControlPlaneMixin:
             # is_active_member semantics).
             state = (self.gh(["api", f"/user/memberships/orgs/{org}", "--jq", ".state"],
                              quietErrors=True) or "").strip()
-            status = "member" if state == "active" else "non_member"
+            if state == "active":
+                status = "member"
+            elif state:
+                status = "non_member"
+            else:
+                # exit 0 but no state (a 200 with an unexpected JSON shape) is indeterminate, NOT a
+                # confirmed non-member — return 'unknown' without caching, so a malformed response
+                # can't silently lock out a real member until the next module reload.
+                return "unknown"
         except Exception as e:
             # A 404 from this endpoint is authoritative: the user is not a member of the org.  Any
             # other failure (network, missing read:org scope) is genuinely 'unknown'.  Do NOT cache

--- a/MorphoDepot/MorphoDepotLib/logic_controlplane.py
+++ b/MorphoDepot/MorphoDepotLib/logic_controlplane.py
@@ -69,11 +69,12 @@ class ControlPlaneMixin:
                 # can't silently lock out a real member until the next module reload.
                 return "unknown"
         except Exception as e:
-            # A 404 from this endpoint is authoritative: the user is not a member of the org.  Any
-            # other failure (network, missing read:org scope) is genuinely 'unknown'.  Do NOT cache
-            # 'unknown' — it would also evict a prior confirmed result, and a transient failure must
-            # re-check on the next call rather than stick.
-            if "404" in str(e) or "Not Found" in str(e):
+            # A 404 from this endpoint is authoritative: the user is not a member of the org (gh
+            # prints the literal "HTTP 404" on its non-zero exit).  Any other failure (network,
+            # missing read:org scope) is genuinely 'unknown'.  Do NOT cache 'unknown' — it would
+            # also evict a prior confirmed result, and a transient failure must re-check on the next
+            # call rather than stick.
+            if "HTTP 404" in str(e):
                 status = "non_member"
             else:
                 logging.warning(f"Membership check failed (status unknown): {e}")

--- a/MorphoDepot/MorphoDepotLib/logic_controlplane.py
+++ b/MorphoDepot/MorphoDepotLib/logic_controlplane.py
@@ -38,9 +38,15 @@ class ControlPlaneMixin:
         return base
 
     def orgMembershipStatus(self, org=None):
-        """Tri-state membership against the MorphoDepot org via the App control plane (`/me`):
-        'member' | 'non_member' | 'unknown' (could not determine — App unreachable / invalid token).
-        The App verifies membership with its OWN token, so the user's gh token needs no org scope.
+        """Tri-state membership against the MorphoDepot org, asked DIRECTLY of GitHub via
+        `gh api /user/memberships/orgs/{org}`:
+        'member' | 'non_member' | 'unknown' (could not determine — GitHub unreachable, or the token
+        lacks read:org).  GitHub is authoritative and fast (~0.5s).  This deliberately does NOT go
+        through the control-plane App: the App's `/me` only proxied this same GitHub endpoint with
+        its own token (to spare the user's token an org scope), but `gh auth login` already grants
+        read:org, and the App's host is intermittently 20-40s just to accept a TCP connection —
+        which froze the UI thread for that long on every Create-tab activation.  (The App is still
+        used elsewhere — e.g. to read the member's private contact email.)
         Caches only a CONFIRMED result; 'unknown' is never trusted from cache, so a transient failure
         re-checks (and never reports a real member's outage as a membership problem)."""
         org = org or self.morphoDepotOrg
@@ -48,13 +54,22 @@ class ControlPlaneMixin:
         if cache is not None and cache[0] == org and cache[1] in ("member", "non_member"):
             return cache[1]
         try:
-            info = self.controlPlaneRequest("me", {})
-            status = "member" if bool(info.get("is_member")) else "non_member"
+            # GitHub returns the caller's OWN membership: state 'active' (full member) or 'pending'
+            # (invited, not yet accepted — treated as not-yet-a-member, matching the App's prior
+            # is_active_member semantics).
+            state = (self.gh(["api", f"/user/memberships/orgs/{org}", "--jq", ".state"],
+                             quietErrors=True) or "").strip()
+            status = "member" if state == "active" else "non_member"
         except Exception as e:
-            # Do NOT cache 'unknown' (it would also evict a prior confirmed result) — a transient
-            # failure must re-check on the next call rather than stick.
-            logging.warning(f"Membership check failed (status unknown): {e}")
-            return "unknown"
+            # A 404 from this endpoint is authoritative: the user is not a member of the org.  Any
+            # other failure (network, missing read:org scope) is genuinely 'unknown'.  Do NOT cache
+            # 'unknown' — it would also evict a prior confirmed result, and a transient failure must
+            # re-check on the next call rather than stick.
+            if "404" in str(e) or "Not Found" in str(e):
+                status = "non_member"
+            else:
+                logging.warning(f"Membership check failed (status unknown): {e}")
+                return "unknown"
         self._orgMemberCache = (org, status)
         return status
 
@@ -62,8 +77,8 @@ class ControlPlaneMixin:
         """True only when membership is CONFIRMED.  Boolean callers treat 'unknown' as non-member;
         the create path uses orgMembershipStatus() directly to distinguish 'not a member' from
         'could not verify' so a transient outage is never reported as a membership problem.  (Asks
-        the App `/me`, which checks membership with the App token — the user's gh token needs no
-        org scope.  Reload the module after switching gh accounts or joining the org.)"""
+        GitHub directly via orgMembershipStatus(); reload the module after switching gh accounts or
+        joining the org so the cached result refreshes.)"""
         return self.orgMembershipStatus(org) == "member"
 
     def controlPlaneRequest(self, path, body):


### PR DESCRIPTION
## The freeze

Switching to the **Create** tab froze Slicer for ~37s. The console showed the entire gap between opening a connection to `join.morphodepot.org` and getting the `POST /me` response — i.e. the extension was blocked on the control-plane App's membership check, on the UI thread.

Measuring `POST /me` directly: **1s, then 36s, then 20s** across three calls, and the time is in the **TCP connect** (`connect=35s`, handler ~0.8s). The App's JS2 host is intermittently 20–40s just to *accept a connection*.

## Why the App was even involved

The App's `/me` handler (`github_client.py get_org_membership_state`) just calls GitHub's `GET /orgs/{org}/memberships/{user}` with the App's **own installation token**. The only reason to route membership through the App was so the user's gh token wouldn't need an org scope. But `gh auth login` already grants `read:org` (visible in the token scopes), so the extension can ask GitHub the same question directly.

## The change

`orgMembershipStatus()` now calls `gh api /user/memberships/orgs/{org}` — the caller's own membership, **~0.5s**, authoritative, no dependency on the App.

- `state == "active"` → `member`
- `"pending"` / 404 → `non_member`
- any other failure (network, missing scope) → `unknown` (never cached)

Tri-state + caching semantics are unchanged. The App is **still** used elsewhere (e.g. reading the member's private contact email); only the membership check moved off it.

## Verification
- `/user/memberships/orgs/MorphoDepot` → `active` in 0.5s on the muratmaga token.
- `py_compile` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)