### PR TITLE
Release tab: list only MorphoDepot-org repos, and never collections

### DIFF
--- a/MorphoDepot/MorphoDepotLib/logic_github.py
+++ b/MorphoDepot/MorphoDepotLib/logic_github.py
@@ -257,18 +257,23 @@ class GitHubMixin:
         return issueList
 
     def administratedRepoList(self):
-        # Releases are ARCHIVAL-ONLY (org-design Sec.9.6): only org repos the user curates can be
-        # released, so the Release tab lists only those.  Personal short-term repos are excluded —
-        # they cannot be released, and showing them is misleading.  A member's archival repo is owned
-        # by the MorphoDepot org (owner != me); the journaled CURATOR (RepoClerk schema v3) is the
-        # authoritative "this is mine to release" signal.  (curator is None on pre-v3 journals, so an
-        # org repo lights up once RepoClerk re-drains with the field.)
+        # Releases are ARCHIVAL-ONLY (org-design Sec.9.6): only MorphoDepot-org repos the user
+        # curates can be released, so the Release tab lists exactly those.  Excluded: personal
+        # short-term repos (owner == me) AND repos in OTHER orgs the user belongs to (e.g. the
+        # MorphoDepotTesting scratch org) — neither is releasable here, both are just noise.  Also
+        # excluded: collections (md-collection "repos of repos", flagged in the journal), which carry
+        # no segmentation payload and cannot be released.  The journaled CURATOR (RepoClerk schema v3)
+        # is the authoritative "this is mine to release" signal.  (curator is None on pre-v3 journals,
+        # so an org repo lights up once RepoClerk re-drains with the field.)
         me = self.whoami()
         returnRepos = []
         for repo in self.morphoRepos():
             ownerLogin = repo['owner']['login']
-            isArchival = ownerLogin != me           # archival repos live in the org, not on my account
-            if isArchival and repo.get('curator') == me:
+            if ownerLogin != self.morphoDepotOrg:   # only the MorphoDepot org — not me, not other orgs
+                continue
+            if repo.get('isCollection'):             # collections are not releasable
+                continue
+            if repo.get('curator') == me:
                 repo['nameWithOwner'] = f"{ownerLogin}/{repo['name']}"
                 returnRepos.append(repo)
         return returnRepos

--- a/MorphoDepot/MorphoDepotLib/logic_repoclerk.py
+++ b/MorphoDepot/MorphoDepotLib/logic_repoclerk.py
@@ -179,6 +179,9 @@ class RepoClerkMixin:
                         "owner": {"login": j["nameWithOwner"].split("/")[0]},
                         "pushedAt": j.get("pushedAt", ""),
                         "curator": j.get("curator"),
+                        # A collection ("repo of repos", md-collection topic) carries this journal
+                        # key; surface it so the Release tab can exclude collections (not releasable).
+                        "isCollection": bool(j.get("collection")),
                         "issues": {"totalCount": len(openIssues), "nodes": issueNodes},
                         "pullRequests": {"totalCount": len(openPRs), "nodes": prNodes},
                     })


### PR DESCRIPTION
Two cleanups to the Release tab's **Owned Repositories** list (`administratedRepoList()`), both driven entirely by data already in the RepoClerk journal — no extra GitHub calls.

### 1. Only the MorphoDepot org
The list kept any archival repo (`owner != me`) the user curates, regardless of which org owned it — so repos from **other** orgs the user belongs to (e.g. the `MorphoDepotTesting` scratch org) leaked in. Now it requires `owner == MorphoDepot`.

### 2. Never list collections
Collections (`md-collection` "repos of repos") share the `morphodepot` topic and are curated by their creator, so they were passing the filter — but they carry no segmentation payload and **cannot be released**. `morphoRepos()` now surfaces the journal's existing `collection` key as `isCollection`, and `administratedRepoList()` skips flagged repos.

### Before → after (the screenshot list)
```
MorphoDepotTesting/test-picosaurus-testus-170   ← dropped (other org)
MorphoDepot/collection-92329d25                 ← dropped (collection)
MorphoDepot/collection-ca12ba06                 ← dropped (collection)
```
…leaving only genuine, releasable MorphoDepot dataset repos.

### Notes
- The `collection` journal key is written by RepoClerk's `drain.py` for every `md-collection` repo (confirmed present on collection journals, absent on dataset journals).
- `py_compile` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)