### PR TITLE
Gate the Release tab and collection-creation by org membership

### DIFF
--- a/MorphoDepot/MorphoDepot.py
+++ b/MorphoDepot/MorphoDepot.py
@@ -220,8 +220,11 @@ class MorphoDepotWidget(ScriptedLoadableModuleWidget, VTKObservationMixin, Enabl
 
         uiWidget = slicer.util.loadUI(os.path.normpath(self.resourcePath("UI/MorphoDepotRelease.ui")))
         uiWidget.setMRMLScene(slicer.mrmlScene)
+        # -1 when the Release tab isn't built (release UI disabled); no real tab index equals -1,
+        # so the membership gating in enter() safely skips it in that case.
+        self.releaseTabIndex = -1
         if self.includeReleaseUI:
-            self.tabWidget.addTab(uiWidget, "Release")
+            self.releaseTabIndex = self.tabWidget.addTab(uiWidget, "Release")
         self.releaseUI = slicer.util.childWidgetVariables(uiWidget)
 
         self.adminTab = qt.QScrollArea()
@@ -765,13 +768,32 @@ class MorphoDepotWidget(ScriptedLoadableModuleWidget, VTKObservationMixin, Enabl
         ScriptedLoadableModuleWidget.onReload(self)
 
     def enter(self):
-        """Disable everything except the configUI"""
+        """Disable everything except the configUI, then apply org-membership gating.
+
+        Membership is looked up at most ONCE here (cached in the logic's _orgMemberCache for the
+        rest of the session — never re-checked on tab switches) and drives which member-only
+        surfaces are enabled.  Only a CONFIRMED non-member is restricted: 'member' and 'unknown' (a
+        network/scope failure, which orgMembershipStatus never caches) both fail OPEN, so a
+        transient error can never lock a real member out of the Release tab or collection creation.
+        The membership call is short-circuited unless the module's dependencies are set up, and is
+        itself bounded by a short timeout, so enter() cannot hang."""
         moduleEnabled = self.checkModuleEnabled()
+        confirmedNonMember = moduleEnabled and self.logic.orgMembershipStatus() == "non_member"
         for tabIndex in range(self.tabWidget.count):
-            if tabIndex != self.configureTabIndex:
-                self.tabWidget.setTabEnabled(tabIndex, moduleEnabled)
-            else:
+            if tabIndex == self.configureTabIndex:
                 self.tabWidget.setTabEnabled(tabIndex, True)
+            elif tabIndex == self.releaseTabIndex and confirmedNonMember:
+                # Releases are archival-only and org-members-only, so hide Release from non-members.
+                self.tabWidget.setTabEnabled(tabIndex, False)
+            else:
+                self.tabWidget.setTabEnabled(tabIndex, moduleEnabled)
+        # Collections: only the "Create a Collection" section is member-gated; the existing-
+        # collections list stays browsable by everyone.
+        self.collectionsUI.createCollapsibleButton.enabled = not confirmedNonMember
+        # If the restored/selected tab is the one we just disabled, land on Create rather than
+        # leaving a disabled tab selected.
+        if not self.tabWidget.isTabEnabled(self.tabWidget.currentIndex):
+            self.tabWidget.currentIndex = self.createTabIndex
 
     def onCurrentTabChanged(self,index):
         qt.QSettings().setValue("MorphoDepot/tabIndex", index)

--- a/MorphoDepot/MorphoDepot.py
+++ b/MorphoDepot/MorphoDepot.py
@@ -790,9 +790,12 @@ class MorphoDepotWidget(ScriptedLoadableModuleWidget, VTKObservationMixin, Enabl
         # Collections: only the "Create a Collection" section is member-gated; the existing-
         # collections list stays browsable by everyone.
         self.collectionsUI.createCollapsibleButton.enabled = not confirmedNonMember
-        # If the restored/selected tab is the one we just disabled, land on Create rather than
-        # leaving a disabled tab selected.
-        if not self.tabWidget.isTabEnabled(self.tabWidget.currentIndex):
+        # If membership gating just disabled the currently-selected tab (Release), land on Create
+        # instead of leaving a disabled tab selected.  Guarded on confirmedNonMember: only then did
+        # we newly disable a tab AND is Create guaranteed enabled.  In the deps-not-ready case
+        # (moduleEnabled False) Create is disabled too, so redirecting there would just swap one
+        # disabled tab for another — leave the selection alone, as before this gating existed.
+        if confirmedNonMember and not self.tabWidget.isTabEnabled(self.tabWidget.currentIndex):
             self.tabWidget.currentIndex = self.createTabIndex
 
     def onCurrentTabChanged(self,index):

--- a/MorphoDepot/MorphoDepotLib/logic_controlplane.py
+++ b/MorphoDepot/MorphoDepotLib/logic_controlplane.py
@@ -57,8 +57,10 @@ class ControlPlaneMixin:
             # GitHub returns the caller's OWN membership: state 'active' (full member) or 'pending'
             # (invited, not yet accepted — treated as not-yet-a-member, matching the App's prior
             # is_active_member semantics).
+            # Bound the timeout: this runs on the UI thread at module enter() to drive gating, so a
+            # dead network must degrade to 'unknown' (fail-open) in seconds, never hang the module.
             state = (self.gh(["api", f"/user/memberships/orgs/{org}", "--jq", ".state"],
-                             quietErrors=True) or "").strip()
+                             timeout=10, quietErrors=True) or "").strip()
             if state == "active":
                 status = "member"
             elif state:

--- a/MorphoDepot/MorphoDepotLib/logic_controlplane.py
+++ b/MorphoDepot/MorphoDepotLib/logic_controlplane.py
@@ -64,6 +64,8 @@ class ControlPlaneMixin:
             if state == "active":
                 status = "member"
             elif state:
+                # Any other non-empty state ('pending' = invited-not-yet-accepted, or any future
+                # GitHub state) is deliberately treated as not-yet-a-member, not an error.
                 status = "non_member"
             else:
                 # exit 0 but no state (a 200 with an unexpected JSON shape) is indeterminate, NOT a

--- a/MorphoDepot/MorphoDepotLib/logic_github.py
+++ b/MorphoDepot/MorphoDepotLib/logic_github.py
@@ -46,8 +46,11 @@ class GitHubMixin:
             raise TypeError("gh command must be a string or list")
         # A `gh auth switch` changes the active account, so any cached whoami() is now stale.
         # Invalidate here so no call site (e.g. the self-test's switchUser) has to know about it.
+        # Org membership is per-account too, so drop its cache as well — the UI gating recomputes
+        # on the next module enter().
         if "auth" in commandList and "switch" in commandList:
             self._whoamiCache = None
+            self._orgMemberCache = None
         self.progressMethod(" ".join(commandList))
         fullCommandList = [self.ghExecutablePath] + commandList
 


### PR DESCRIPTION
Confirmed **non-members** of the MorphoDepot org now get:
- the **Release tab disabled** (releases are archival-only, org-members-only), and
- the Collections tab's **"Create a Collection" section disabled** — the existing-collections list stays fully browsable.

Members (and the `unknown` state) see everything enabled, exactly as today.

### Why this is safe now (it wasn't before)
A previous attempt at this gating **froze the UI** because it looked up membership synchronously in `enter()` via the control-plane App (`POST /me`) — the JS2 host that takes 20–40s to accept a connection. That path is gone: as of #184, `orgMembershipStatus()` is a **direct GitHub call** (`gh api /user/memberships/orgs/MorphoDepot`, ~0.5s), and the Create tab already warms its cache on entry.

### Design (per the agreed plan)
1. **Look up once, cache, never re-check mid-session.** Membership is read at most once in `enter()`, cached in `_orgMemberCache`. `onCurrentTabChanged` is untouched — tab switches never trigger a lookup.
2. **Fail OPEN.** Only a *confirmed* `non_member` is restricted. `member` and the never-cached `unknown` (network/scope failure) both leave everything enabled → a transient error can never lock out a real member.
3. **Single owner of tab-enabled state.** The Release gating folds into the *existing* `enter()` `setTabEnabled` loop, not a separate method that could race it (that race was part of the earlier breakage).
4. **Can't hang.** The membership call is short-circuited unless the module is dependency-ready (no gh call otherwise) and bounded by a 10s timeout.

### Supporting changes
- `setup()` stores `self.releaseTabIndex` (`-1` when the Release tab isn't built, which the gating skips).
- `gh()` clears `_orgMemberCache` on `gh auth switch` alongside `_whoamiCache`, so a dev account switch recomputes on the next `enter()`.
- If `enter()` disables the currently-selected tab, selection moves to Create (no disabled tab left selected).

### Testing
- `py_compile` clean on all three files.
- Author is an org **owner** → always resolves to `member`, so no visible change for the author. **Real verification requires a non-member gh account** (e.g. `slicermorph`), which the reviewer/author will drive after merge-readiness.

🤖 Generated with [Claude Code](https://claude.com/claude-code)