### PR TITLE
Shorten the repository-type radio labels

### DIFF
--- a/MorphoDepot/MorphoDepot.py
+++ b/MorphoDepot/MorphoDepot.py
@@ -509,10 +509,9 @@ class MorphoDepotWidget(ScriptedLoadableModuleWidget, VTKObservationMixin, Enabl
         self.createUI.repoTypeGroup = qt.QGroupBox("Repository type")
         repoTypeGroupLayout = qt.QVBoxLayout(self.createUI.repoTypeGroup)
         self.createUI.archivalRadio = qt.QRadioButton(
-            "Archival - maintained and citable; created in the MorphoDepot organization "
-            "(members only) and gets a DOI")
+            "Archival (members only): in the MorphoDepot org, citable with a DOI")
         self.createUI.shortTermRadio = qt.QRadioButton(
-            "Short-term - disposable / classroom; created on your own account, no DOI")
+            "Short-term (personal): on your own account, disposable, no DOI")
         repoTypeGroupLayout.addWidget(self.createUI.archivalRadio)
         repoTypeGroupLayout.addWidget(self.createUI.shortTermRadio)
         headerIndex = self.createUI.verticalLayout.indexOf(self.createUI.createSectionHeader)


### PR DESCRIPTION
The Archival/Short-term radio labels on the Create tab were long comma-spliced sentences. Reworded to a compact `(who): what` form that leads with the two consequences that actually matter — **where the repo lives / who can create it**, and **DOI vs no DOI**:

**Before**
```
Archival - maintained and citable; created in the MorphoDepot organization (members only) and gets a DOI
Short-term - disposable / classroom; created on your own account, no DOI
```
**After**
```
Archival (members only): in the MorphoDepot org, citable with a DOI
Short-term (personal): on your own account, disposable, no DOI
```

Display-only change: the repository type is decided by `archivalRadio.checked` (a bool) — never the label text (verified: nothing reads `archivalRadio.text` / `shortTermRadio.text`), and the accession-form's separate repoType value string is untouched. No logic affected. `py_compile` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)