### PR TITLE
Search: don't exclude repos with an empty multi-select field

### DIFF
--- a/MorphoDepot/MorphoDepotLib/logic_search.py
+++ b/MorphoDepot/MorphoDepotLib/logic_search.py
@@ -79,11 +79,14 @@ class SearchMixin:
                 if question in repoData:
                     repoValue = repoData[question][1]
                     if isinstance(repoValue, list):
-                        # Exclude only if NONE of the repo's values matches the criteria — decided
-                        # AFTER scanning all values.  (The old in-loop check excluded on the first
-                        # non-match, and a set can't un-exclude a later match.)  An empty list matches
-                        # nothing the user selected, so it is excluded.
-                        if not any(value in criteria[question] for value in repoValue):
+                        # Exclude only if the repo HAS value(s) for this field and NONE match the
+                        # criteria — decided AFTER scanning all values.  (The old in-loop check
+                        # excluded on the first non-match, and a set can't un-exclude a later match.)
+                        # An EMPTY/unspecified multi-select does NOT exclude the repo — mirroring the
+                        # scalar branch below (which ignores an empty value).  Otherwise a repo that
+                        # simply left this field blank (e.g. a whole-specimen atlas with no
+                        # anatomicalAreas) becomes invisible in EVERY search, even the default browse.
+                        if repoValue and not any(value in criteria[question] for value in repoValue):
                             excludedRepos.add(nameWithOwner)
                     else:
                         if repoValue != "" and repoValue not in criteria[question]:


### PR DESCRIPTION
## Symptom
`MorphoDepot/E15-Atlas` (transferred into the org) never appeared in the Search tab — under either owner, even after the RepoClerk journals were fully up to date and deduped. Turned out **not** to be an indexing problem.

## Root cause
E15-Atlas has `anatomicalAreas: []` (empty — it's a whole-embryo atlas, no specific region selected). The list-field branch of `search()` excluded a repo when *none* of its values for a multi-select field matched the criteria:

```python
if not any(value in criteria[question] for value in repoValue):
    excludedRepos.add(nameWithOwner)
```

For an **empty list**, `any(...)` is `False` → the repo is excluded outright. So any repo that left `anatomicalAreas` or `imageContents` blank was invisible in **every** search, including the default all-boxes-checked browse.

This was also **inconsistent with the scalar branch** immediately below, which already ignores an empty value (`if repoValue != "" and ...`).

## Fix
Make the list branch match the scalar branch — an empty/unspecified multi-select no longer participates in filtering:

```python
if repoValue and not any(value in criteria[question] for value in repoValue):
    excludedRepos.add(nameWithOwner)
```

A non-empty list with no matching value still excludes, exactly as before.

## Verification
Simulated against the real data:
- `anatomicalAreas=[]` (E15-Atlas) → **not excluded** ✓
- non-empty with a matching value → not excluded ✓
- non-empty with only non-matching values → still excluded ✓
- `py_compile` clean.

Affects any repo with a blank multi-select field, not just E15-Atlas.

🤖 Generated with [Claude Code](https://claude.com/claude-code)