### PR TITLE
Search: classify Archival/Personal by repo owner (MorphoDepot org), not self-declared repoType

### DIFF
--- a/MorphoDepot/MorphoDepotLib/logic_search.py
+++ b/MorphoDepot/MorphoDepotLib/logic_search.py
@@ -61,10 +61,14 @@ class SearchMixin:
         excludedRepos = set()
         for nameWithOwner, repoData in self.repoDataByNameWithOwner.items():
             for question in criteria:
-                # Handle repoType with default assumption
-                if question == "repoType":
-                    repoValue = repoData.get("repoType", (None, "Archival (intended for long-term maintenance)"))[1]
-                    if repoValue not in criteria["repoType"]:
+                # Repository tier is decided by OWNER, not the self-declared accession repoType: a
+                # repo is "Archival" only if it lives in the MorphoDepot org (the gated, reviewed
+                # home); everything else (personal accounts, other orgs) is "Personal".  This ignores
+                # what a repo *claims* in its accession, so old personal test repos that picked
+                # "Archival" are correctly classified as Personal.  (nameWithOwner is "{owner}^{repo}".)
+                if question == "tier":
+                    tier = "Archival" if nameWithOwner.split("^", 1)[0] == self.morphoDepotOrg else "Personal"
+                    if tier not in criteria["tier"]:
                         excludedRepos.add(nameWithOwner)
                     continue
 

--- a/MorphoDepot/MorphoDepotLib/search_form.py
+++ b/MorphoDepot/MorphoDepotLib/search_form.py
@@ -29,6 +29,14 @@ class MorphoDepotSearchForm():
         "developmentalStage": "Stage:",
         "anatomicalAreas": "Anatomical Areas:",
     }
+
+    # The "Repository" tier filter is OWNER-based, NOT the self-declared accession repoType:
+    # Archival = repos owned by the MorphoDepot org (the gated, reviewed home); Personal = everything
+    # else (personal accounts, other orgs).  Options are fixed here and matched against each repo's
+    # owner in MorphoDepotLogic.search() -- so a personal repo that *claimed* "Archival" in its
+    # accession is correctly classified as Personal.
+    TIER_OPTIONS = ["Archival", "Personal"]
+
     def __init__(self, updateCallback=lambda : None):
         self.updateCallback = updateCallback
         self.form = qt.QWidget()
@@ -45,15 +53,19 @@ class MorphoDepotSearchForm():
         self.searchBox.textChanged.connect(self.updateCallback)
         self.searchBox.setPlaceholderText("Fetch repository data to search...")
 
-        # Add repoType filter separately to control default
-        self.repoTypeComboBox = ctk.ctkCheckableComboBox()
-        self.searchFormLayout.addRow("Repository Type:", self.repoTypeComboBox)
-        repoTypeQuestionData = MorphoDepotAccessionForm.formQuestions["repoType"]
-        for option in repoTypeQuestionData[1]:
-            self.repoTypeComboBox.addItem(option)
-        model = self.repoTypeComboBox.checkableModel()
-        self.repoTypeComboBox.setCheckState(model.index(0, 0), qt.Qt.Checked) # Default to Archival
-        self.repoTypeComboBox.checkedIndexesChanged.connect(self.updateCallback)
+        # Repository tier filter (OWNER-based; see TIER_OPTIONS) -- added separately to control its
+        # default.  Default to Archival so the many personal / pre-org repos are hidden unless the
+        # user opts into Personal.
+        self.tierComboBox = ctk.ctkCheckableComboBox()
+        self.searchFormLayout.addRow("Repository:", self.tierComboBox)
+        self.tierComboBox.setToolTip(
+            "Archival = repositories in the MorphoDepot organization (curated, reviewed). "
+            "Personal = personal-account repositories.")
+        for option in MorphoDepotSearchForm.TIER_OPTIONS:
+            self.tierComboBox.addItem(option)
+        model = self.tierComboBox.checkableModel()
+        self.tierComboBox.setCheckState(model.index(0, 0), qt.Qt.Checked)  # Default to Archival
+        self.tierComboBox.checkedIndexesChanged.connect(self.updateCallback)
 
         self.comboBoxesByQuestion = {}
         questions = MorphoDepotAccessionForm.formQuestions
@@ -78,14 +90,13 @@ class MorphoDepotSearchForm():
     def criteria(self):
         criteria = {"freeText": self.searchBox.text}
 
-        # Handle repoType separately
-        repoTypeQuestionData = MorphoDepotAccessionForm.formQuestions["repoType"]
-        criteria["repoType"] = []
-        model = self.repoTypeComboBox.checkableModel()
+        # Repository tier (owner-based) -- matched against each repo's owner in MorphoDepotLogic.search().
+        criteria["tier"] = []
+        model = self.tierComboBox.checkableModel()
         for row in range(model.rowCount()):
             index = model.index(row, 0)
-            if self.repoTypeComboBox.checkState(index) == qt.Qt.Checked:
-                criteria["repoType"].append(repoTypeQuestionData[1][row])
+            if self.tierComboBox.checkState(index) == qt.Qt.Checked:
+                criteria["tier"].append(MorphoDepotSearchForm.TIER_OPTIONS[row])
 
         questions = MorphoDepotAccessionForm.formQuestions
         for question, questionData in questions.items():


### PR DESCRIPTION
Implements the extension half of the coupled owner-based-classification work (#193; RepoClerk half: MorphoDepot/RepoClerk#427).

## Problem
The Search "Repository Type" filter keyed on each repo's **self-declared accession `repoType`**, so a personal-account repo that merely *chose* "Archival" appeared under Archival. Today **~65 of 67** indexed repos are personal-account, pre-org test repos in accounts we don't control — they clutter Search and are low-quality. Since archival creation is now gated to the MorphoDepot org, the authoritative signal is the **owner**.

## Change
- **`logic_search.py`** — the tier branch derives the tier from the **owner** (`nameWithOwner` = `{owner}^{repo}`): `Archival` iff `owner == MorphoDepot`, else `Personal`. It no longer reads the accession `repoType`, so a repo that *claimed* Archival but lives in a personal account is correctly **Personal**.
- **`search_form.py`** — the filter now offers fixed **`Archival` / `Personal`** options (`TIER_OPTIONS`), **default Archival**, with a tooltip. Renames the old "Short-term" concept to **"Personal"**.

## Behavior (verified by simulation)
| repo | tier | default (Archival-only) |
|---|---|---|
| `MorphoDepot/E15-Atlas` | Archival | shown |
| `muratmaga/test-repo` | Personal | hidden |
| `MorphoDepotTesting/foo` | Personal | hidden |
| `CDonatelli/bar` | Personal | hidden |

## Backward compatibility
- Owner is already in every journal (`nameWithOwner`) and Search already splits it out — **no journal-schema change, nothing deleted.** Personal repos remain reachable via the (default-unchecked) **Personal** option.
- The accession `repoType` **value strings are left unchanged** (still used by create/edit and compared elsewhere with `.startswith("Archival")`); only the Search *filter* changed.
- `py_compile` clean; no leftover references to the old `repoTypeComboBox`/`criteria["repoType"]`.

## Open question (from #193)
Should **Personal** stay a checkable option, or be fully hidden from Search? This PR keeps it checkable (default off).

🤖 Generated with [Claude Code](https://claude.com/claude-code)