### PR TITLE
Create tab: label the second repo type "Personal" (was "Short-term")

### DIFF
--- a/MorphoDepot/MorphoDepot.py
+++ b/MorphoDepot/MorphoDepot.py
@@ -511,7 +511,7 @@ class MorphoDepotWidget(ScriptedLoadableModuleWidget, VTKObservationMixin, Enabl
         self.createUI.archivalRadio = qt.QRadioButton(
             "Archival (members only): in the MorphoDepot org, citable with a DOI")
         self.createUI.shortTermRadio = qt.QRadioButton(
-            "Short-term (personal): on your own account, disposable, no DOI")
+            "Personal: on your own account, no DOI")
         repoTypeGroupLayout.addWidget(self.createUI.archivalRadio)
         repoTypeGroupLayout.addWidget(self.createUI.shortTermRadio)
         headerIndex = self.createUI.verticalLayout.indexOf(self.createUI.createSectionHeader)


### PR DESCRIPTION
Changes only the radio-button label text on the Create tab from `Short-term (personal): on your own account, disposable, no DOI` to `Personal: on your own account, no DOI`. The dichotomy is Archival (org) vs Personal; whether the owner keeps it short-term or for years is not our decision, so the "short-term/disposable" framing is dropped. UI text only — the `repoType` variable, stored value, and all logic are unchanged.