### PR TITLE
Search: exclude collections (md-collection repos) from results

### DIFF
--- a/MorphoDepot/MorphoDepotLib/logic_search.py
+++ b/MorphoDepot/MorphoDepotLib/logic_search.py
@@ -39,6 +39,11 @@ class SearchMixin:
             if journals:
                 for j in journals:
                     try:
+                        # Collections (md-collection "repos of repos") are not datasets to segment,
+                        # so keep them out of Search entirely.  drain.py stamps their journal with a
+                        # `collection` key (absent on dataset journals).
+                        if j.get("collection"):
+                            continue
                         owner, repo = j["nameWithOwner"].split("/", 1)
                         key = f"{owner}^{repo}"
                         repoData = dict(j.get("accession", {}))


### PR DESCRIPTION
The owner-based tier filter (#194) classifies MorphoDepot-org repos as Archival, and collections are org repos — so a collection (e.g. `collection-2716acfd`) showed up as an N/A row in Search alongside real datasets.

Collections are curated "repos of repos," not datasets to segment, so they should never appear in Search. `refreshSearchCache` now skips any journal carrying the `collection` key that `drain.py` stamps on `md-collection` repos (absent on dataset journals) — the same signal the Release tab already uses (`isCollection`, #185). Skipping at load keeps them out of the corpus entirely (default list and every filtered search).

Verified: `MorphoDepot^collection-2716acfd.json` has `collection: true` and no accession; dataset journals have no `collection` key. `py_compile` clean.