### PR TITLE
Call repos/finalize after Make-Public flip (DOI mint-at-flip)

### DIFF
--- a/MorphoDepot/MorphoDepotLib/logic_accession.py
+++ b/MorphoDepot/MorphoDepotLib/logic_accession.py
@@ -691,11 +691,22 @@ jobs:
                     "reviewSentTo": resp.get("review_sent_to")}
 
         if status == "approved" and resp.get("flip"):
-            # Member-driven go-live (#20): the reviewer approved and the App minted the DOI WITHOUT
-            # flipping.  The MEMBER now flips the repo public and swaps the staging topic for the
-            # discovery topics, both with their own gh — so the App never needs Administration.
+            # Member-driven go-live (#20): the reviewer approved.  The MEMBER now flips the repo public
+            # and swaps the staging topic for the discovery topics, both with their own gh — so the App
+            # never needs Administration.
             self.progressMethod(f"Approved -- publishing {finalNameWithOwner}...")
             self.setRepoVisibility(finalNameWithOwner, public=True)
+            # Finalize: the App mints the v1 DOI on the now-public repo (docs/doi-mint-at-flip.md),
+            # part of the single Make-Public action.  Best-effort and idempotent — the repo IS public
+            # (the go-live succeeded); a mint hiccup only leaves the DOI pending, and re-running Make
+            # Public finalizes it.  When the App still mints at approval, this is a harmless no-op that
+            # returns the existing DOI; if the endpoint is absent (older App), it 404s and is skipped.
+            try:
+                self.progressMethod(f"Finalizing DOI for {finalNameWithOwner}...")
+                self.controlPlaneRequest("repos/finalize", {"repo": repoName})
+            except Exception as e:
+                logging.warning(f"DOI finalize did not complete for {finalNameWithOwner} "
+                                f"(the repo is public; re-run Make Public to finish the DOI): {e}")
             self.addMorphoTopics(finalNameWithOwner, species)
             self.ghTopicClearCache()
             self.localRepo = None

--- a/MorphoDepot/MorphoDepotLib/logic_accession.py
+++ b/MorphoDepot/MorphoDepotLib/logic_accession.py
@@ -703,7 +703,9 @@ jobs:
             # returns the existing DOI; if the endpoint is absent (older App), it 404s and is skipped.
             try:
                 self.progressMethod(f"Finalizing DOI for {finalNameWithOwner}...")
-                self.controlPlaneRequest("repos/finalize", {"repo": repoName})
+                # Best-effort: a short timeout so a slow/down App can't stall Make Public for the
+                # full default; the repo is already public and re-running finishes the DOI.
+                self.controlPlaneRequest("repos/finalize", {"repo": repoName}, timeout=30)
             except Exception as e:
                 logging.warning(f"DOI finalize did not complete for {finalNameWithOwner} "
                                 f"(the repo is public; re-run Make Public to finish the DOI): {e}")

--- a/MorphoDepot/MorphoDepotLib/logic_controlplane.py
+++ b/MorphoDepot/MorphoDepotLib/logic_controlplane.py
@@ -94,15 +94,17 @@ class ControlPlaneMixin:
         joining the org so the cached result refreshes.)"""
         return self.orgMembershipStatus(org) == "member"
 
-    def controlPlaneRequest(self, path, body):
+    def controlPlaneRequest(self, path, body, timeout=120):
         """POST to the intake App control plane, authenticated by the user's gh token.
-        Returns the parsed JSON, or raises with the server's error detail."""
+        Returns the parsed JSON, or raises with the server's error detail.  `timeout` (seconds) can
+        be shortened for best-effort calls so a slow/down App doesn't stall the UI for the full
+        default."""
         import requests
         token = self._ghToken()
         if not token:
             raise RuntimeError("Not signed in to GitHub — run `gh auth login` first.")
         r = requests.post(f"{self.controlPlaneBase()}/{path}", json=body,
-                          headers={"Authorization": f"Bearer {token}"}, timeout=120)
+                          headers={"Authorization": f"Bearer {token}"}, timeout=timeout)
         if r.status_code != 200:
             try:
                 detail = r.json().get("detail", r.text)


### PR DESCRIPTION
Companion to `morphodepot-intake` **mint-at-finalize** (Option B, `docs/doi-mint-at-flip.md`).

After the member flips their approved org repo public in `_publishStagedRepoInOrg`, the extension now calls the App's `POST /repos/finalize` as part of the **same Make-Public action** — so the App mints the v1 DOI on the **now-public** repo (rather than at approval, on a still-private repo that might never go public).

**Safe / graceful:**
- The repo is already public (the go-live succeeded) before finalize runs, so a finalize failure only leaves the **DOI pending** — re-running Make Public finishes it (the App's finalize is idempotent).
- Against an **older App** without the endpoint, finalize 404s and is skipped (best-effort `try/except`), so this is safe to ship ahead of the App deploy.
- **No behavior change** while the App still mints at approval: finalize is then a no-op that returns the existing DOI.

Requires the App PR (`MorphoDepot/morphodepot-intake` #47) deployed with `MINT_AT_FINALIZE=true` to exercise the new timing end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)