### PR TITLE
Review tab: repoadmin-only App-proxied candidate inspection

### DIFF
--- a/MorphoDepot/MorphoDepot.py
+++ b/MorphoDepot/MorphoDepot.py
@@ -212,6 +212,7 @@ class MorphoDepotWidget(ScriptedLoadableModuleWidget, VTKObservationMixin, Enabl
         uiWidget.setMRMLScene(slicer.mrmlScene)
         self.tabWidget.addTab(uiWidget, "Review")
         self.reviewUI = slicer.util.childWidgetVariables(uiWidget)
+        self.reviewTabWidget = uiWidget  # kept so the repoadmin-only reviewer section can be inserted
 
         uiWidget = slicer.util.loadUI(os.path.normpath(self.resourcePath("UI/MorphoDepotCreate.ui")))
         uiWidget.setMRMLScene(slicer.mrmlScene)
@@ -712,6 +713,7 @@ class MorphoDepotWidget(ScriptedLoadableModuleWidget, VTKObservationMixin, Enabl
         self.reviewUI.hideDraftsCheckBox.stateChanged.connect(self.onHideDraftsChanged)
         self.reviewUI.requestChangesButton.clicked.connect(self.onRequestChanges)
         self.reviewUI.approveButton.clicked.connect(self.onApprove)
+        self._setupReviewerInspect()
         self.releaseUI.refreshButton.clicked.connect(self.onRefreshReleaseTab)
         self.releaseUI.repoList.itemDoubleClicked.connect(self.onReleaseRepoDoubleClicked)
         self.releaseUI.makeReleaseButton.clicked.connect(self.onMakeRelease)
@@ -789,6 +791,11 @@ class MorphoDepotWidget(ScriptedLoadableModuleWidget, VTKObservationMixin, Enabl
         # Collections: only the "Create a Collection" section is member-gated; the existing-
         # collections list stays browsable by everyone.
         self.collectionsUI.createCollapsibleButton.enabled = not confirmedNonMember
+        # Reviewer tools (Review tab): show the "awaiting review" section ONLY for a CONFIRMED
+        # repoadminteam member; fail-closed (hidden) otherwise, incl. 'unknown' (org-design Sec.11.6).
+        # The App is the hard gate regardless; this only declutters the tab for non-reviewers.
+        if getattr(self, "reviewerInspectSection", None) is not None:
+            self.reviewerInspectSection.visible = moduleEnabled and self.logic.isRepoAdmin()
         # If membership gating just disabled the currently-selected tab (Release), land on Create
         # instead of leaving a disabled tab selected.  Guarded on confirmedNonMember: only then did
         # we newly disable a tab AND is Create guaranteed enabled.  In the deps-not-ready case

--- a/MorphoDepot/MorphoDepot.py
+++ b/MorphoDepot/MorphoDepot.py
@@ -795,7 +795,7 @@ class MorphoDepotWidget(ScriptedLoadableModuleWidget, VTKObservationMixin, Enabl
         # repoadminteam member; fail-closed (hidden) otherwise, incl. 'unknown' (org-design Sec.11.6).
         # The App is the hard gate regardless; this only declutters the tab for non-reviewers.
         if getattr(self, "reviewerInspectSection", None) is not None:
-            self.reviewerInspectSection.visible = moduleEnabled and self.logic.isRepoAdmin()
+            self.reviewerInspectSection.visible = moduleEnabled and self.logic.isRepoAdmin(forceRefresh=True)
         # If membership gating just disabled the currently-selected tab (Release), land on Create
         # instead of leaving a disabled tab selected.  Guarded on confirmedNonMember: only then did
         # we newly disable a tab AND is Create guaranteed enabled.  In the deps-not-ready case

--- a/MorphoDepot/MorphoDepotLib/logic_controlplane.py
+++ b/MorphoDepot/MorphoDepotLib/logic_controlplane.py
@@ -119,14 +119,17 @@ class ControlPlaneMixin:
     # client-side check only decides whether to SHOW the reviewer UI.
     repoAdminTeam = "repoadminteam"
 
-    def repoAdminStatus(self):
+    def repoAdminStatus(self, forceRefresh=False):
         """Whether the active user is a member of the reviewer team (repoadminteam), asked DIRECTLY
         of GitHub (fast; avoids the intermittently-slow App). Returns 'yes' | 'no' | 'unknown'.
         Caches only a CONFIRMED result. Used to show/hide the Review-tab reviewer tools — fail-CLOSED
         for the UI (a non-'yes' hides the section); the App enforces access regardless (Sec.11.6).
-        Reload the module after being added to / removed from the team so the cache refreshes."""
+        ``forceRefresh`` drops the cache and re-queries GitHub, so adding/removing the user from the
+        team is reflected on the next Review-tab Refresh without a full module reload."""
         org = self.morphoDepotOrg
         team = self.repoAdminTeam
+        if forceRefresh:
+            self._repoAdminCache = None
         cache = getattr(self, "_repoAdminCache", None)
         if cache is not None and cache[0] == (org, team) and cache[1] in ("yes", "no"):
             return cache[1]
@@ -152,9 +155,11 @@ class ControlPlaneMixin:
         self._repoAdminCache = ((org, team), status)
         return status
 
-    def isRepoAdmin(self):
-        """True only when repoadminteam membership is CONFIRMED (fail-closed: 'unknown' -> False)."""
-        return self.repoAdminStatus() == "yes"
+    def isRepoAdmin(self, forceRefresh=False):
+        """True only when repoadminteam membership is CONFIRMED (fail-closed: 'unknown' -> False).
+        ``forceRefresh`` re-queries GitHub (used when re-evaluating the reviewer-section visibility
+        on a manual Refresh, so a team change takes effect without a module reload)."""
+        return self.repoAdminStatus(forceRefresh=forceRefresh) == "yes"
 
     def reviewQueue(self):
         """The reviewer queue from the App (repoadmin-gated + staging-only server-side): a list of

--- a/MorphoDepot/MorphoDepotLib/logic_controlplane.py
+++ b/MorphoDepot/MorphoDepotLib/logic_controlplane.py
@@ -113,6 +113,61 @@ class ControlPlaneMixin:
             raise RuntimeError(f"Control plane '{path}' failed ({r.status_code}): {detail}")
         return r.json()
 
+    # --- reviewer tools (repoadmin-gated; org-design Sec.11.6) ---
+    # The org team whose members may use the App-proxied candidate-inspection tools. It is an
+    # AUTHORIZATION LIST the App checks, never a repo grant. The App is the hard gate; this
+    # client-side check only decides whether to SHOW the reviewer UI.
+    repoAdminTeam = "repoadminteam"
+
+    def repoAdminStatus(self):
+        """Whether the active user is a member of the reviewer team (repoadminteam), asked DIRECTLY
+        of GitHub (fast; avoids the intermittently-slow App). Returns 'yes' | 'no' | 'unknown'.
+        Caches only a CONFIRMED result. Used to show/hide the Review-tab reviewer tools — fail-CLOSED
+        for the UI (a non-'yes' hides the section); the App enforces access regardless (Sec.11.6).
+        Reload the module after being added to / removed from the team so the cache refreshes."""
+        org = self.morphoDepotOrg
+        team = self.repoAdminTeam
+        cache = getattr(self, "_repoAdminCache", None)
+        if cache is not None and cache[0] == (org, team) and cache[1] in ("yes", "no"):
+            return cache[1]
+        me = self.whoami()
+        try:
+            # 'active' = a member OR maintainer of the team (both count); 'pending' = invited but not
+            # yet accepted (not a reviewer yet). A 404 exits non-zero with "HTTP 404" = not on the team.
+            state = (self.gh(["api", f"/orgs/{org}/teams/{team}/memberships/{me}", "--jq", ".state"],
+                             timeout=10, quietErrors=True) or "").strip()
+            if state == "active":
+                status = "yes"
+            elif state:
+                status = "no"
+            else:
+                # exit 0 but no state (unexpected shape) -> indeterminate; don't cache.
+                return "unknown"
+        except Exception as e:
+            if "HTTP 404" in str(e):
+                status = "no"
+            else:
+                logging.warning(f"repoadmin check failed (status unknown): {e}")
+                return "unknown"
+        self._repoAdminCache = ((org, team), status)
+        return status
+
+    def isRepoAdmin(self):
+        """True only when repoadminteam membership is CONFIRMED (fail-closed: 'unknown' -> False)."""
+        return self.repoAdminStatus() == "yes"
+
+    def reviewQueue(self):
+        """The reviewer queue from the App (repoadmin-gated + staging-only server-side): a list of
+        staged candidates awaiting review. Raises on transport/policy error so the caller surfaces it."""
+        result = self.controlPlaneRequest("reviews/queue", {}, timeout=60)
+        return result.get("candidates", []) if isinstance(result, dict) else []
+
+    def inspectCandidate(self, repoName):
+        """Fetch the App-served review payload for a staged candidate (repoadmin-gated, staging-only,
+        read-only server-side). `repoName` is the bare repo name; returns the inspection payload
+        (source_volume pointer + checksum, color table, segmentation(s))."""
+        return self.controlPlaneRequest("reviews/inspect", {"repo": repoName}, timeout=120)
+
     def reviewStatus(self, repoNames):
         """The caller's own per-repo review state {name: 'approved'|'pending'|'none'} from the control
         plane, used to label the unpublished list.  Best-effort -> {} on any error so the list still

--- a/MorphoDepot/MorphoDepotLib/logic_repo.py
+++ b/MorphoDepot/MorphoDepotLib/logic_repo.py
@@ -229,6 +229,63 @@ class RepoMixin:
         self.loadFromLocalRepository(remoteName="origin", configuration="preview")
         return True
 
+    def loadCandidateForReview(self, payload):
+        """Load an App-served review candidate into Slicer READ-ONLY, without cloning (org-design
+        Sec.11.6). The color table + baseline segmentation(s) come from `payload` (the App read them
+        with its own token, gated to repoadminteam + staging-only); the source VOLUME is downloaded
+        from its public-read S3 URL. The caller clears the scene first. Returns True on success.
+
+        This is the reviewer counterpart to loadRepoForPreview: same read-only result, but a reviewer
+        needs no GitHub access to the private candidate — the App is the reader."""
+        import base64
+        nameWithOwner = payload.get("nameWithOwner", "candidate")
+        cacheDir = os.path.join(self.localRepositoryDirectory(), "MorphoDepotCaches", "ReviewInspect")
+        os.makedirs(cacheDir, exist_ok=True)
+
+        # Color table (payload bytes -> temp file -> load).
+        self.colorTableNode = None
+        ct = payload.get("colorTable")
+        if ct and ct.get("contentB64"):
+            # basename(): the file name comes from repo content — never let it escape the cache dir.
+            ctPath = os.path.join(cacheDir, os.path.basename(ct.get("name") or "colors.csv"))
+            with open(ctPath, "wb") as fp:
+                fp.write(base64.b64decode(ct["contentB64"]))
+            try:
+                self.colorTableNode = slicer.util.loadColorTable(ctPath)
+            except Exception as e:
+                self.progressMethod(f"Could not load color table: {e}")
+
+        # Source volume from the public-read object store (same path as a normal load).
+        volumeRef = (payload.get("sourceVolume") or "").strip()
+        if not volumeRef:
+            raise RuntimeError("Candidate has no source_volume pointer")
+        volumeURL = self.resolveVolumeURL(volumeRef, nameWithOwner)
+        checksum = (payload.get("sourceVolumeChecksum") or "").strip() or None
+        volumeCacheDir = os.path.join(self.localRepositoryDirectory(), "MorphoDepotCaches", "Volumes")
+        os.makedirs(volumeCacheDir, exist_ok=True)
+        nrrdPath = os.path.join(volumeCacheDir, f"{nameWithOwner.replace('/', '-')}-volume.nrrd")
+        if checksum and os.path.exists(nrrdPath) and not self._fileMatchesChecksum(nrrdPath, checksum):
+            try:
+                os.remove(nrrdPath)   # stale/tampered cache -> re-fetch (matches loadFromLocalRepository)
+            except OSError:
+                pass
+        if not os.path.exists(nrrdPath):
+            slicer.util.downloadFile(volumeURL, nrrdPath, checksum=checksum)
+        self.sourceVolumeNode = slicer.util.loadVolume(nrrdPath)
+
+        # Baseline segmentation(s) from the payload — shown read-only (no Segment Editor set-up).
+        for seg in payload.get("segmentations") or []:
+            if not seg.get("contentB64"):
+                continue
+            segPath = os.path.join(cacheDir, os.path.basename(seg.get("name") or "baseline.seg.nrrd"))
+            with open(segPath, "wb") as fp:
+                fp.write(base64.b64decode(seg["contentB64"]))
+            try:
+                slicer.util.loadSegmentation(segPath)
+            except Exception as e:
+                self.progressMethod(f"Could not load segmentation {os.path.basename(segPath)}: {e}")
+        return True
+
     def _fileMatchesChecksum(self, filePath, checksum):
         """True if filePath's digest matches `checksum` ('<algo>:<hex>', e.g. 'SHA256:ab...', or a
         bare SHA-256 hex).  Used to re-verify the name-keyed volume cache on every load (review S4)."""

--- a/MorphoDepot/MorphoDepotLib/logic_repo.py
+++ b/MorphoDepot/MorphoDepotLib/logic_repo.py
@@ -239,7 +239,10 @@ class RepoMixin:
         needs no GitHub access to the private candidate — the App is the reader."""
         import base64
         nameWithOwner = payload.get("nameWithOwner", "candidate")
-        cacheDir = os.path.join(self.localRepositoryDirectory(), "MorphoDepotCaches", "ReviewInspect")
+        # Per-candidate cache subdir so segmentation/color files from different candidates (keyed only
+        # by basename) can never clobber each other, even out of the sequential scene-cleared flow.
+        cacheDir = os.path.join(self.localRepositoryDirectory(), "MorphoDepotCaches", "ReviewInspect",
+                                nameWithOwner.replace("/", "-"))
         os.makedirs(cacheDir, exist_ok=True)
 
         # Color table (payload bytes -> temp file -> load).
@@ -261,14 +264,20 @@ class RepoMixin:
             raise RuntimeError("Candidate has no source_volume pointer")
         volumeURL = self.resolveVolumeURL(volumeRef, nameWithOwner)
         checksum = (payload.get("sourceVolumeChecksum") or "").strip() or None
+        if not checksum:
+            # Parity with loadFromLocalRepository (S4): no checksum -> integrity can't be verified.
+            self.progressMethod("Warning: payload has no sourceVolumeChecksum; cannot verify volume integrity.")
         volumeCacheDir = os.path.join(self.localRepositoryDirectory(), "MorphoDepotCaches", "Volumes")
         os.makedirs(volumeCacheDir, exist_ok=True)
         nrrdPath = os.path.join(volumeCacheDir, f"{nameWithOwner.replace('/', '-')}-volume.nrrd")
         if checksum and os.path.exists(nrrdPath) and not self._fileMatchesChecksum(nrrdPath, checksum):
             try:
                 os.remove(nrrdPath)   # stale/tampered cache -> re-fetch (matches loadFromLocalRepository)
-            except OSError:
-                pass
+            except OSError as e:
+                # S4: if the bad file can't be evicted we must NOT fall through — the `if not
+                # os.path.exists` below would skip the re-download and loadVolume the known-bad cache.
+                raise RuntimeError(
+                    f"Cached volume failed checksum and could not be removed for re-download: {e}")
         if not os.path.exists(nrrdPath):
             slicer.util.downloadFile(volumeURL, nrrdPath, checksum=checksum)
         self.sourceVolumeNode = slicer.util.loadVolume(nrrdPath)

--- a/MorphoDepot/MorphoDepotLib/widget_review.py
+++ b/MorphoDepot/MorphoDepotLib/widget_review.py
@@ -178,7 +178,8 @@ class ReviewTabMixin:
             return
         with slicer.util.tryWithErrorDisplay("Failed to inspect the candidate", waitCursor=True):
             slicer.util.showStatusMessage(f"Loading {nameWithOwner} for review...")
-            payload = self.logic.inspectCandidate(candidate.get("name"))
+            repoName = candidate.get("name") or (candidate.get("nameWithOwner") or "").split("/")[-1]
+            payload = self.logic.inspectCandidate(repoName)
             slicer.mrmlScene.Clear()
             self.logic.loadCandidateForReview(payload)
             slicer.util.showStatusMessage(f"Loaded {nameWithOwner} (read-only review)")

--- a/MorphoDepot/MorphoDepotLib/widget_review.py
+++ b/MorphoDepot/MorphoDepotLib/widget_review.py
@@ -40,6 +40,13 @@ class ReviewTabMixin:
             with slicer.util.tryWithErrorDisplay("Failed to update PR list", waitCursor=True):
                 self.updateReviewPRList()
         self.reviewUI.repoClerkStatusLabel.hide()
+        # Re-evaluate the reviewer section here (with a FRESH team-membership check), because Slicer's
+        # module Reload rebuilds the widget but does NOT call enter() — so without this a repoadminteam
+        # change (or the section being rebuilt hidden on reload) is only reflected on a full module
+        # re-entry. Now clicking Refresh Github updates it. Fail-closed (hidden) on 'unknown'.
+        section = getattr(self, "reviewerInspectSection", None)
+        if section is not None:
+            section.visible = self.logic.isRepoAdmin(forceRefresh=True)
 
     def updateReviewPRList(self):
         with slicer.util.tryWithErrorDisplay("Failed to update PR list", waitCursor=True):

--- a/MorphoDepot/MorphoDepotLib/widget_review.py
+++ b/MorphoDepot/MorphoDepotLib/widget_review.py
@@ -99,4 +99,87 @@ class ReviewTabMixin:
             self._completeStepReset("Review (approve) is successfully completed",
                                     "The pull request was approved and merged.")
 
+    # --- Reviewer tools: inspect a staged publish candidate (repoadminteam only; org-design Sec.11.6) ---
+
+    def _setupReviewerInspect(self):
+        """Build the repoadmin-only 'Repositories awaiting review' section and insert it at the TOP of
+        the Review tab. Hidden by default; enter() reveals it only for a confirmed repoadminteam
+        member. Loads a staged candidate's volume + segmentation read-only via the App (no clone,
+        no GitHub access to the private repo needed)."""
+        self._reviewCandidatesByItem = {}
+        section = ctk.ctkCollapsibleButton()
+        section.text = "Repositories awaiting review (reviewers only)"
+        section.collapsed = False
+        layout = qt.QVBoxLayout(section)
+        hint = qt.QLabel(
+            "Inspect a staged publish candidate's source volume and segmentation in Slicer, "
+            "read-only. Approve or request changes from the review email.")
+        hint.wordWrap = True
+        layout.addWidget(hint)
+        self.reviewQueueRefreshButton = qt.QPushButton("Refresh review queue")
+        layout.addWidget(self.reviewQueueRefreshButton)
+        self.reviewQueueList = qt.QListWidget()
+        self.reviewQueueList.setToolTip("Staged candidates awaiting publication review.")
+        layout.addWidget(self.reviewQueueList)
+        self.inspectCandidateButton = qt.QPushButton("Inspect in Slicer (read-only)")
+        self.inspectCandidateButton.enabled = False
+        layout.addWidget(self.inspectCandidateButton)
+
+        self.reviewTabWidget.layout().insertWidget(0, section)
+        self.reviewerInspectSection = section
+        section.visible = False  # enter() reveals it only for a confirmed repoadminteam member
+
+        self.reviewQueueRefreshButton.connect("clicked(bool)", self.onReviewQueueRefresh)
+        self.reviewQueueList.itemSelectionChanged.connect(self.onReviewQueueSelectionChanged)
+        self.reviewQueueList.itemDoubleClicked.connect(self.onInspectCandidate)
+        self.inspectCandidateButton.connect("clicked(bool)", self.onInspectCandidate)
+
+    def onReviewQueueRefresh(self):
+        with slicer.util.tryWithErrorDisplay("Failed to load the review queue", waitCursor=True):
+            slicer.util.showStatusMessage("Loading review queue...")
+            self.reviewQueueList.clear()
+            self._reviewCandidatesByItem = {}
+            self.inspectCandidateButton.enabled = False
+            candidates = self.logic.reviewQueue()
+            if not candidates:
+                placeholder = qt.QListWidgetItem("(no repositories awaiting review)")
+                placeholder.setFlags(qt.Qt.NoItemFlags)
+                self.reviewQueueList.addItem(placeholder)
+                return
+            for c in candidates:
+                curator = c.get("curator") or "?"
+                item = qt.QListWidgetItem(f"{c.get('nameWithOwner')}    (curator: {curator})")
+                self._reviewCandidatesByItem[item] = c
+                self.reviewQueueList.addItem(item)
+            slicer.util.showStatusMessage(f"{len(candidates)} awaiting review")
+
+    def onReviewQueueSelectionChanged(self):
+        selected = self.reviewQueueList.selectedItems()
+        self.inspectCandidateButton.enabled = any(
+            i in self._reviewCandidatesByItem for i in selected)
+
+    def onInspectCandidate(self, item=None):
+        candidate = self._reviewCandidatesByItem.get(item) if item is not None else None
+        if candidate is None:
+            selected = self.reviewQueueList.selectedItems()
+            candidate = self._reviewCandidatesByItem.get(selected[0]) if selected else None
+        if candidate is None:
+            return
+        nameWithOwner = candidate.get("nameWithOwner")
+        if not (self.testingMode or slicer.util.confirmOkCancelDisplay(
+                f"Close the current scene and load {nameWithOwner} for review?")):
+            return
+        with slicer.util.tryWithErrorDisplay("Failed to inspect the candidate", waitCursor=True):
+            slicer.util.showStatusMessage(f"Loading {nameWithOwner} for review...")
+            payload = self.logic.inspectCandidate(candidate.get("name"))
+            slicer.mrmlScene.Clear()
+            self.logic.loadCandidateForReview(payload)
+            slicer.util.showStatusMessage(f"Loaded {nameWithOwner} (read-only review)")
+            slicer.util.infoDisplay(
+                f"Loaded {nameWithOwner} for review (read-only).\n\n"
+                "This is a reviewer preview — inspect the source volume and segmentation. "
+                "Approve or request changes from the review email.",
+                windowTitle="Reviewing a candidate",
+                dontShowAgainSettingsKey="MorphoDepot/DontShowReviewInspectNotice")
+
     # Release


### PR DESCRIPTION
## What
The extension half of App-proxied reviewer inspection (org-design §11.6). A **repoadminteam** member sees a **"Repositories awaiting review"** section at the top of the Review tab and can load any staged publish candidate's **source volume + segmentation read-only** — without cloning the private repo and without any GitHub access to it. The App is the reader (repoadminteam-gated, `morphodepot-staging`-only, read-only server-side, PR #50 in morphodepot-intake); the extension only shows the reviewer UI.

## Changes
- **`logic_controlplane.py`** — `repoAdminStatus()`/`isRepoAdmin()`: a fast gh-direct team-membership check (cached, **fail-closed** so a non-reviewer never sees the section); `reviewQueue()`/`inspectCandidate()`: the control-plane calls to the new App endpoints.
- **`logic_repo.py`** — `loadCandidateForReview(payload)`: materialize the App payload (color table + baseline segmentation(s)) to a cache dir and load it **read-only**; the volume is downloaded from its public-read S3 URL. `basename()` guards payload file names against path traversal. This is the reviewer counterpart to `loadRepoForPreview`.
- **`widget_review.py`** — `_setupReviewerInspect()` builds the section (refresh + queue list + "Inspect in Slicer (read-only)"); handlers for refresh/selection/inspect.
- **`MorphoDepot.py`** — builds the section in `setup`; `enter()` reveals it **only** for a confirmed repoadminteam member (hidden otherwise, incl. `unknown` → fail-closed).

## Security posture
The **App** is the hard gate (403s a non-reviewer regardless of client UI). The client `isRepoAdmin()` check is a UI declutter only. Inspection is read-only; the reviewer needs **no** GitHub access to the private candidate and the team holds **no** repo permissions. Approval stays on the existing email path (unchanged).

## Testing
Manual E2E to follow (create as `muratmaga`, review as `amm554` added temporarily to `repoadminteam`). No new files added (no CMakeLists change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)