### PR TITLE
Fix stale submit-confirmation copy to match right-click Publish flow

### DIFF
--- a/MorphoDepot/MorphoDepotLib/logic_accession.py
+++ b/MorphoDepot/MorphoDepotLib/logic_accession.py
@@ -708,7 +708,7 @@ jobs:
                 self.controlPlaneRequest("repos/finalize", {"repo": repoName}, timeout=30)
             except Exception as e:
                 logging.warning(f"DOI finalize did not complete for {finalNameWithOwner} "
-                                f"(the repo is public; re-run Make Public to finish the DOI): {e}")
+                                f"(the repo is public; re-run Publish to finish the DOI): {e}")
             self.addMorphoTopics(finalNameWithOwner, species)
             self.ghTopicClearCache()
             self.localRepo = None

--- a/MorphoDepot/MorphoDepotLib/widget_create.py
+++ b/MorphoDepot/MorphoDepotLib/widget_create.py
@@ -1211,10 +1211,10 @@ class CreateTabMixin:
                 "Review request is successfully completed",
                 f"'{where}' has been submitted for review.\n\n"
                 f"Publishing is a two-step process. A request was emailed to {to}. Once a reviewer "
-                "approves, you'll get an email; then reopen this repo from your unpublished list (it "
-                "will be marked 'approved') and click Publish again to do the final flip to public "
-                "— within 14 days of approval. Until then it stays private (reopening to make changes "
-                "will require requesting review again).")
+                "approves, you'll get an email; then find this repo at the top of the staged-"
+                "repositories list (it will be marked '✓ approved'), right-click it, and choose "
+                "Publish to do the final flip to public — within 14 days of approval. Until then it "
+                "stays private (editing it will require requesting review again).")
             return
         # Now that the repo is actually public, add the creator to the contact list (best-effort,
         # background).  Done here — never at stage — so discarded/abandoned repos never leak a

--- a/MorphoDepot/MorphoDepotLib/widget_create.py
+++ b/MorphoDepot/MorphoDepotLib/widget_create.py
@@ -1205,7 +1205,7 @@ class CreateTabMixin:
             self.createUI.discardButton.enabled = False
             self.createUI.openRepository.enabled = False
             self.createUI.stagingStatusLabel.text = (
-                f"Submitted for review: {where} — once approved, you need to click Publish once more to make it public.")
+                f"Submitted for review: {where} — once approved, right-click it in the staged-repositories list and choose Publish to make it public.")
             self.refreshStagedReposList(force=True)
             self._completeStepReset(
                 "Review request is successfully completed",


### PR DESCRIPTION
## What

Two curator-facing strings in the extension still described the **pre-#200 publish flow** — including the extension contradicting its own new behavior.

Since #200 (*"Right-click Publish for approved staged repos (no reopen)"*), an approved staged repo is published by **right-clicking it** on the Create tab; reopening/editing an approved repo is blocked.

## Changes

- **`MorphoDepot/MorphoDepotLib/widget_create.py`** — the confirmation dialog shown right after a curator submits for review told them to *"reopen this repo from your unpublished list … and click Publish again."* Updated to: *"find it at the top of the staged-repositories list (marked ✓ approved), right-click it, and choose Publish."*
- **`MorphoDepot/MorphoDepotLib/logic_accession.py`** — a log warning said "re-run Make Public" → "re-run **Publish**".

## Verification

Both files parse cleanly (`py_compile`). Copy-only; no behavior change.

## Note

Companion PR in `MorphoDepot/morphodepot-intake` fixes the matching stale copy in the App's emails, auto-bounce, and tracking-issue bodies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
