### PR TITLE
Trigger Claude on @claude in a new issue's body

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -1,12 +1,18 @@
 name: Claude Code
 
-# On-demand Claude: mention @claude in a PR/issue comment or review to ask
-# for a (re-)review, an explanation, or a change. Restricted to org members
-# and collaborators — this is a public repo, and without the guard any
-# GitHub account could burn the subscription quota (or steer Claude) by
-# commenting.
+# On-demand Claude: mention @claude in a new issue's body, or in a PR/issue
+# comment or review, to ask for a (re-)review, an explanation, or a change.
+# Restricted to org members and collaborators — this is a public repo, and
+# without the guard any GitHub account could burn the subscription quota (or
+# steer Claude) by commenting.
+#
+# Note: only `issues: opened` is watched, not `edited` — editing a body that
+# already says @claude would re-run Claude on every typo fix. To re-invoke on
+# an existing issue, comment on it.
 
 on:
+  issues:
+    types: [opened]
   issue_comment:
     types: [created]
   pull_request_review_comment:
@@ -17,8 +23,9 @@ on:
 jobs:
   claude:
     if: |
-      contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.comment.author_association || github.event.review.author_association) &&
-      ((github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
+      contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.comment.author_association || github.event.review.author_association || github.event.issue.author_association) &&
+      ((github.event_name == 'issues' && contains(github.event.issue.body, '@claude')) ||
+      (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
       (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
       (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')))
     runs-on: ubuntu-latest


### PR DESCRIPTION
Opening an issue whose body contains `@claude` (as in #203) never queued a run: `claude.yml` listened only to `issue_comment`, `pull_request_review_comment`, and `pull_request_review`. GitHub delivers that as an `issues: opened` event, which the workflow did not subscribe to.

Two changes:

- Add the `issues: [opened]` trigger and the matching `github.event.issue.body` branch to the `if:` guard.
- Extend the member/collaborator guard's fallback chain with `github.event.issue.author_association`. On an `issues` event both `github.event.comment` and `github.event.review` are absent, so the existing chain evaluated to empty and the job would have skipped even with the trigger added.

`edited` is intentionally left out of the trigger types: a body that already says `@claude` would re-run Claude on every subsequent edit, including typo fixes. Re-invoking on an existing issue stays a comment away.

The org-member/collaborator restriction is unchanged, so the public-repo quota guard still holds.

Verification is inherently post-merge — workflow triggers fire from the file on the default branch, so a new issue opened after merge is the test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)