### PR TITLE
Notify about and apply MorphoDepot updates (#203)

### DIFF
--- a/MorphoDepot/CMakeLists.txt
+++ b/MorphoDepot/CMakeLists.txt
@@ -23,6 +23,7 @@ set(MODULE_PYTHON_SCRIPTS
   ${MODULE_NAME}Lib/logic_repo.py
   ${MODULE_NAME}Lib/logic_repoclerk.py
   ${MODULE_NAME}Lib/logic_search.py
+  ${MODULE_NAME}Lib/logic_version.py
   ${MODULE_NAME}Lib/screenshot_dialog.py
   ${MODULE_NAME}Lib/search_form.py
   ${MODULE_NAME}Lib/widget_annotate.py
@@ -33,6 +34,7 @@ set(MODULE_PYTHON_SCRIPTS
   ${MODULE_NAME}Lib/widget_review.py
   ${MODULE_NAME}Lib/widget_search.py
   ${MODULE_NAME}Lib/widget_validation.py
+  ${MODULE_NAME}Lib/widget_version.py
   )
 
 set(MODULE_PYTHON_RESOURCES

--- a/MorphoDepot/MorphoDepot.py
+++ b/MorphoDepot/MorphoDepot.py
@@ -52,6 +52,7 @@ from MorphoDepotLib.logic_release import ReleaseMixin
 from MorphoDepotLib.logic_accession import AccessionMixin
 from MorphoDepotLib.logic_search import SearchMixin
 from MorphoDepotLib.logic_collections import CollectionsMixin
+from MorphoDepotLib.logic_version import VersionMixin
 from MorphoDepotLib.widget_create import CreateTabMixin
 from MorphoDepotLib.widget_configure import ConfigureTabMixin
 from MorphoDepotLib.widget_annotate import AnnotateTabMixin
@@ -60,6 +61,7 @@ from MorphoDepotLib.widget_release import ReleaseTabMixin
 from MorphoDepotLib.widget_search import SearchTabMixin
 from MorphoDepotLib.widget_collections import CollectionsTabMixin
 from MorphoDepotLib.widget_validation import ValidationMixin
+from MorphoDepotLib.widget_version import VersionUIMixin
 
 
 class MorphoDepot(ScriptedLoadableModule):
@@ -152,7 +154,7 @@ class EnableModuleMixin:
         return True
 
 
-class MorphoDepotWidget(ScriptedLoadableModuleWidget, VTKObservationMixin, EnableModuleMixin, ValidationMixin, CreateTabMixin, ConfigureTabMixin, AnnotateTabMixin, ReviewTabMixin, ReleaseTabMixin, SearchTabMixin, CollectionsTabMixin):
+class MorphoDepotWidget(ScriptedLoadableModuleWidget, VTKObservationMixin, EnableModuleMixin, ValidationMixin, CreateTabMixin, ConfigureTabMixin, AnnotateTabMixin, ReviewTabMixin, ReleaseTabMixin, SearchTabMixin, CollectionsTabMixin, VersionUIMixin):
     """Uses ScriptedLoadableModuleWidget base class, available at:
     https://github.com/Slicer/Slicer/blob/main/Base/Python/slicer/ScriptedLoadableModule.py
     """
@@ -679,6 +681,10 @@ class MorphoDepotWidget(ScriptedLoadableModuleWidget, VTKObservationMixin, Enabl
         self.searchUI.resultsCollapsibleButton.layout().addLayout(self.searchUI.resultsButtonsLayout)
 
 
+        # Update notice (issue #203).  Built last so the banner lands at the top of the
+        # module layout, above the tab widget, where it is visible from every tab.
+        self.setupVersionUI()
+
         # Connections
         self.tabWidget.currentChanged.connect(self.onCurrentTabChanged)
         self.configureUI.repoDirectory.comboBox().connect("currentTextChanged(QString)", self.onRepoDirectoryChanged)
@@ -753,6 +759,8 @@ class MorphoDepotWidget(ScriptedLoadableModuleWidget, VTKObservationMixin, Enabl
 
     def cleanup(self) -> None:
         """Called when the application closes and the module widget is destroyed."""
+        # Tells an in-flight version check to stop polling and not touch these widgets.
+        self._versionWidgetAlive = False
         self.removeObservers()
 
     def onReload(self):
@@ -803,6 +811,9 @@ class MorphoDepotWidget(ScriptedLoadableModuleWidget, VTKObservationMixin, Enabl
         # disabled tab for another — leave the selection alone, as before this gating existed.
         if confirmedNonMember and not self.tabWidget.isTabEnabled(self.tabWidget.currentIndex):
             self.tabWidget.currentIndex = self.createTabIndex
+        # Look for a newer MorphoDepot (issue #203).  Cached for a day and run off the main
+        # thread, so entering the module stays as fast as it was.
+        self.startVersionCheck()
 
     def onCurrentTabChanged(self,index):
         qt.QSettings().setValue("MorphoDepot/tabIndex", index)
@@ -812,7 +823,7 @@ class MorphoDepotWidget(ScriptedLoadableModuleWidget, VTKObservationMixin, Enabl
             self._refreshArchivalAvailability()
             self.refreshStagedReposList()
 
-class MorphoDepotLogic(ScriptedLoadableModuleLogic, DepsMixin, GitHubMixin, ControlPlaneMixin, ObjectStoreMixin, RepoClerkMixin, RepoMixin, ContributeMixin, ReleaseMixin, AccessionMixin, SearchMixin, CollectionsMixin):
+class MorphoDepotLogic(ScriptedLoadableModuleLogic, DepsMixin, GitHubMixin, ControlPlaneMixin, ObjectStoreMixin, RepoClerkMixin, RepoMixin, ContributeMixin, ReleaseMixin, AccessionMixin, SearchMixin, CollectionsMixin, VersionMixin):
     """This class should implement all the actual
     computation done by your module.  The interface
     should be such that other python code can import

--- a/MorphoDepot/MorphoDepot.py
+++ b/MorphoDepot/MorphoDepot.py
@@ -333,6 +333,8 @@ class MorphoDepotWidget(ScriptedLoadableModuleWidget, VTKObservationMixin, Enabl
         self.configureUI.testingCollapsibleButton.visible = slicer.util.settingsValue("Developer/DeveloperMode", False, converter=slicer.util.toBool)
 
         testingLayout = qt.QFormLayout(self.configureUI.testingCollapsibleButton)
+        # Kept so other setup code (the update check) can add developer-only rows here.
+        self.configureUI.testingLayout = testingLayout
 
         self.configureUI.creatorUser = qt.QLineEdit()
         self.configureUI.creatorUser.text = slicer.util.settingsValue("MorphoDepot/testingCreatorUser", "")

--- a/MorphoDepot/MorphoDepotLib/logic_version.py
+++ b/MorphoDepot/MorphoDepotLib/logic_version.py
@@ -76,6 +76,22 @@ UPDATABLE_SHAPES = (SHAPE_EXTENSION, SHAPE_CLONE)
 
 class VersionMixin:
 
+    # ------------------------------------------------------------- what to track
+
+    def versionCheckRepository(self):
+        """The repository to compare against.
+
+        Overridable so the check can be pointed at a branch under development, and so a
+        repository move -- this one has already moved from MorphoCloud to SlicerMorph --
+        does not strand installed copies until they are updated.
+        """
+        return slicer.util.settingsValue(
+            "MorphoDepot/versionCheck/repository", VERSION_CHECK_REPO) or VERSION_CHECK_REPO
+
+    def versionCheckBranch(self):
+        return slicer.util.settingsValue(
+            "MorphoDepot/versionCheck/branch", VERSION_CHECK_BRANCH) or VERSION_CHECK_BRANCH
+
     # ------------------------------------------------------------------ identity
 
     def moduleDirectory(self):
@@ -251,7 +267,7 @@ class VersionMixin:
             pass
         try:
             branch = repository.active_branch.name
-            if branch != VERSION_CHECK_BRANCH:
+            if branch != self.versionCheckBranch():
                 reasons.append(_("it is on branch '{branch}'").format(branch=branch))
         except TypeError:
             reasons.append(_("it has a detached HEAD"))
@@ -261,7 +277,8 @@ class VersionMixin:
             remoteUrl = repository.remotes.origin.url
         except Exception:
             remoteUrl = ""
-        if "slicermorphodepot" not in remoteUrl.lower():
+        repositoryName = self.versionCheckRepository().split("/")[-1].lower()
+        if repositoryName not in remoteUrl.lower():
             reasons.append(_("its origin remote is not the MorphoDepot repository"))
 
         if reasons:
@@ -412,12 +429,16 @@ class VersionMixin:
                 return True
         return False
 
-    def fetchUpdateStatus(self, installedSha, environment=None):
+    def fetchUpdateStatus(self, installedSha, environment=None, repository=None, branch=None):
         """Compare the installed revision against upstream.
 
-        BACKGROUND THREAD SAFE -- subprocess and json only.  Returns a dict with
-        `available`, `latestSha`, `latestDate`, `aheadBy`, `compareUrl` and `error`.
+        BACKGROUND THREAD SAFE -- subprocess and json only.  `repository` and `branch` are
+        resolved by the caller on the main thread, since reading them touches QSettings.
+        Returns a dict with `available`, `latestSha`, `latestDate`, `aheadBy`, `compareUrl`
+        and `error`.
         """
+        repository = repository or VERSION_CHECK_REPO
+        branch = branch or VERSION_CHECK_BRANCH
         status = {
             "available": False,
             "latestSha": "",
@@ -429,7 +450,7 @@ class VersionMixin:
 
         if not installedSha:
             latest = self._ghJson(
-                ["api", f"repos/{VERSION_CHECK_REPO}/commits/{VERSION_CHECK_BRANCH}",
+                ["api", f"repos/{repository}/commits/{branch}",
                  "--jq", "{sha: .sha, date: .commit.committer.date}"],
                 environment=environment)
             if latest is None:
@@ -446,7 +467,7 @@ class VersionMixin:
             " file_count: ((.files // []) | length),"
             " files: [(.files // [])[].filename]}")
         comparison = self._ghJson(
-            ["api", f"repos/{VERSION_CHECK_REPO}/compare/{installedSha}...{VERSION_CHECK_BRANCH}",
+            ["api", f"repos/{repository}/compare/{installedSha}...{branch}",
              "--jq", jqFilter],
             environment=environment)
         if comparison is None:
@@ -487,7 +508,7 @@ class VersionMixin:
         self.progressMethod(f"Updating the MorphoDepot clone at {repositoryRoot}")
         try:
             repository = git.Repo(repositoryRoot)
-            repository.git.pull("--ff-only", "origin", VERSION_CHECK_BRANCH)
+            repository.git.pull("--ff-only", "origin", self.versionCheckBranch())
         except Exception as e:
             logging.error(f"MorphoDepot update: git pull failed: {e}")
             return False, _("Could not fast-forward the clone: {error}").format(error=str(e))
@@ -556,7 +577,7 @@ class VersionMixin:
     def _downloadModuleTree(self, sha, workDirectory):
         """Download and unpack the repository at `sha`; return its MorphoDepot/ directory."""
         archivePath = os.path.join(workDirectory, "morphodepot.tar.gz")
-        url = f"https://codeload.github.com/{VERSION_CHECK_REPO}/tar.gz/{sha}"
+        url = f"https://codeload.github.com/{self.versionCheckRepository()}/tar.gz/{sha}"
         self.progressMethod(f"Downloading MorphoDepot {sha[:7]}")
         response = requests.get(url, timeout=120, stream=True)
         response.raise_for_status()

--- a/MorphoDepot/MorphoDepotLib/logic_version.py
+++ b/MorphoDepot/MorphoDepotLib/logic_version.py
@@ -31,6 +31,7 @@ import datetime
 import json
 import logging
 import os
+import posixpath
 import shutil
 import subprocess
 import tarfile
@@ -46,6 +47,13 @@ from slicer.i18n import tr as _
 VERSION_CHECK_REPO = "SlicerMorph/SlicerMorphoDepot"
 VERSION_CHECK_BRANCH = "main"
 VERSION_CHECK_TTL_SECONDS = 24 * 60 * 60
+
+# Locations this repository used to live at.  Their URLs still redirect here, so a clone
+# made before the move is a canonical clone and should still be offered updates.
+PREVIOUS_REPOSITORIES = ("MorphoCloud/SlicerMorphoDepot",)
+
+# Backups are the undo for an in-place update, but they should not accumulate forever.
+BACKUPS_TO_KEEP = 3
 
 # The installed module is exactly the repository's MorphoDepot/ directory minus the two
 # entries the extension build strips.  Verified by diffing an Extension Manager install
@@ -224,6 +232,21 @@ class VersionMixin:
 
     # ------------------------------------------------------------- installed side
 
+    def _remoteIsCanonical(self, remoteUrl):
+        """Whether a clone's origin is the repository the update check tracks.
+
+        Matches owner AND name.  Matching the name alone would accept a fork at
+        github.com/someone/SlicerMorphoDepot, and fast-forwarding a clone whose origin is
+        a fork would quietly install somebody else's code.  Both URL forms carry
+        "owner/name": https://github.com/Owner/Name.git and git@github.com:Owner/Name.git.
+        """
+        if not remoteUrl:
+            return False
+        normalized = remoteUrl.lower()
+        candidates = [self.versionCheckRepository().lower()]
+        candidates += [previous.lower() for previous in PREVIOUS_REPOSITORIES]
+        return any(candidate in normalized for candidate in candidates)
+
     def _cloneDescription(self, moduleDirectory):
         """Describe the git clone containing the module, or None if there is not one.
 
@@ -277,8 +300,7 @@ class VersionMixin:
             remoteUrl = repository.remotes.origin.url
         except Exception:
             remoteUrl = ""
-        repositoryName = self.versionCheckRepository().split("/")[-1].lower()
-        if repositoryName not in remoteUrl.lower():
+        if not self._remoteIsCanonical(remoteUrl):
             reasons.append(_("its origin remote is not the MorphoDepot repository"))
 
         if reasons:
@@ -559,6 +581,7 @@ class VersionMixin:
             self._writeMarker(
                 moduleDirectory, targetSha, datetime.datetime.now().strftime("%Y-%m-%d"),
                 installed.get("extensionRevision", ""))
+            self._pruneBackups(keep=backupPath)
         except Exception as e:
             logging.error(f"MorphoDepot update failed: {e}")
             if backupPath:
@@ -579,7 +602,10 @@ class VersionMixin:
         archivePath = os.path.join(workDirectory, "morphodepot.tar.gz")
         url = f"https://codeload.github.com/{self.versionCheckRepository()}/tar.gz/{sha}"
         self.progressMethod(f"Downloading MorphoDepot {sha[:7]}")
-        response = requests.get(url, timeout=120, stream=True)
+        # (connect, read) rather than one long budget: the archive is well under a
+        # megabyte, so a slow or hung server should give up quickly instead of holding the
+        # user-initiated update -- and the UI with it -- for minutes.
+        response = requests.get(url, timeout=(10, 60), stream=True)
         response.raise_for_status()
         with open(archivePath, "wb") as archiveFile:
             for chunk in response.iter_content(chunk_size=65536):
@@ -592,16 +618,32 @@ class VersionMixin:
             # GitHub names the top level <repo>-<ref>, where <ref> depends on what was
             # requested; read it rather than reconstructing it.
             topLevel = names[0].split("/")[0]
-            try:
-                archive.extractall(path=workDirectory, filter="data")
-            except TypeError:
-                # Python older than 3.12 has no extraction filters.
-                archive.extractall(path=workDirectory)
+            self._extractArchive(archive, workDirectory)
 
         sourceDirectory = os.path.join(workDirectory, topLevel, MODULE_SUBDIRECTORY)
         if not os.path.isdir(sourceDirectory):
             raise RuntimeError(f"the downloaded archive has no {MODULE_SUBDIRECTORY} directory")
         return sourceDirectory
+
+    def _extractArchive(self, archive, workDirectory):
+        """Unpack, refusing anything that would write outside `workDirectory`.
+
+        tarfile's `filter="data"` only exists on Python 3.12 and later, and MorphoDepot
+        supports Slicer versions that ship older ones, so the members are checked here
+        rather than relying on a guard that silently is not there.
+        """
+        for member in archive.getmembers():
+            memberPath = posixpath.normpath(member.name)
+            if posixpath.isabs(memberPath) or memberPath.startswith(".."):
+                raise RuntimeError(f"archive entry outside the extraction directory: {member.name}")
+            if not (member.isfile() or member.isdir()):
+                # GitHub source tarballs are plain files and directories; a link or device
+                # entry means this is not the archive we think it is.
+                raise RuntimeError(f"unexpected archive entry type: {member.name}")
+        try:
+            archive.extractall(path=workDirectory, filter="data")
+        except TypeError:
+            archive.extractall(path=workDirectory)
 
     def _moduleFileList(self, sourceDirectory):
         """Relative paths of the files an extension build ships."""
@@ -641,6 +683,27 @@ class VersionMixin:
             moduleDirectory, backupPath, dirs_exist_ok=True,
             ignore=shutil.ignore_patterns("__pycache__", "*.pyc"))
         return backupPath
+
+    def _pruneBackups(self, keep=""):
+        """Drop all but the most recent backups.
+
+        Called only after an update succeeds, so the copy that was just made -- and the
+        one before it, in case a problem only shows up later -- always survive.
+        """
+        backupRoot = self._backupRoot()
+        try:
+            candidates = [os.path.join(backupRoot, name) for name in os.listdir(backupRoot)]
+        except OSError:
+            return
+        directories = [path for path in candidates if os.path.isdir(path)]
+        try:
+            directories.sort(key=os.path.getmtime, reverse=True)
+        except OSError:
+            return
+        for stale in directories[BACKUPS_TO_KEEP:]:
+            if stale == keep:
+                continue
+            shutil.rmtree(stale, ignore_errors=True)
 
     def _restoreModuleTree(self, backupPath, moduleDirectory):
         """Copy the backup back over the module directory.

--- a/MorphoDepot/MorphoDepotLib/logic_version.py
+++ b/MorphoDepot/MorphoDepotLib/logic_version.py
@@ -1,0 +1,685 @@
+"""MorphoDepotLogic VersionMixin (issue #203): update detection and manual update.
+
+Slicer's extension server only builds MorphoDepot for the Slicer version that is current,
+so users on an older Slicer silently stop receiving updates.  This mixin notices that and
+offers to apply the update itself.
+
+Threading contract
+------------------
+`installedVersion()` and `applyUpdate()` read Slicer application state and MUST run on the
+main thread.  `fetchUpdateStatus()` is the only method the background check thread calls;
+it touches nothing but `subprocess` and `json`.  In particular it does NOT go through
+`MorphoDepotLogic.gh()`: that helper reports progress via `progressMethod()`, which calls
+`slicer.app.processEvents()` -- driving the Qt event loop from a worker thread would be a
+crash waiting to happen.  The caller resolves anything Qt-flavored (the installed version,
+the startup environment) on the main thread and hands the results to the worker.
+
+Install shapes
+--------------
+The gate on offering an update is whether writing is SAFE, not how the user installed:
+
+  extension   Extension Manager install; revision comes from the .s4ext metadata.
+  clone       git clone on an additional module path; clean, on the release branch, and
+              pointing at the canonical repository.
+  devclone    a clone that is dirty, on another branch, detached, or pointing at a fork.
+              Reported, never written to -- this is somebody's working tree.
+  buildtree   built from source with CMake; the next build would revert any write.
+  unknown     anything else (for example an unpacked zip).  Reported, never written to.
+"""
+
+import datetime
+import json
+import logging
+import os
+import shutil
+import subprocess
+import tarfile
+import tempfile
+import time
+
+import git
+import requests
+import slicer
+from slicer.i18n import tr as _
+
+
+VERSION_CHECK_REPO = "SlicerMorph/SlicerMorphoDepot"
+VERSION_CHECK_BRANCH = "main"
+VERSION_CHECK_TTL_SECONDS = 24 * 60 * 60
+
+# The installed module is exactly the repository's MorphoDepot/ directory minus the two
+# entries the extension build strips.  Verified by diffing an Extension Manager install
+# against the repository tree -- keep this in sync if MorphoDepot/CMakeLists.txt changes
+# what it ships.
+MODULE_SUBDIRECTORY = "MorphoDepot"
+UPDATE_EXCLUDED_FILES = ("CMakeLists.txt",)
+UPDATE_EXCLUDED_DIRECTORIES = ("Testing", "__pycache__")
+
+# GitHub caps the compare endpoint's file list at 300 entries; past that we cannot tell
+# whether module files changed, so we assume they did rather than under-report.
+COMPARE_FILE_CAP = 300
+
+# Written into the installed tree after an in-place update.  An official Extension Manager
+# update removes the whole install directory first, so this file cannot outlive the patch
+# it describes; the recorded .s4ext revision catches anything that replaces metadata
+# without removing files.
+MARKER_FILENAME = ".applied_update.json"
+
+SHAPE_EXTENSION = "extension"
+SHAPE_CLONE = "clone"
+SHAPE_DEV_CLONE = "devclone"
+SHAPE_BUILD_TREE = "buildtree"
+SHAPE_UNKNOWN = "unknown"
+
+UPDATABLE_SHAPES = (SHAPE_EXTENSION, SHAPE_CLONE)
+
+
+class VersionMixin:
+
+    # ------------------------------------------------------------------ identity
+
+    def moduleDirectory(self):
+        """Absolute, symlink-resolved directory holding MorphoDepot.py.
+
+        realpath matters on macOS, where the Extension Manager path can be reached through
+        /private symlinks; without it the containment test below fails and an ordinary
+        extension install is misreported as an unknown shape.
+        """
+        try:
+            modulePath = slicer.modules.morphodepot.path
+        except AttributeError:
+            return ""
+        return os.path.realpath(os.path.dirname(modulePath))
+
+    def _buildTreeRoot(self, directory):
+        """Return the enclosing CMake build directory, or "" if there is none."""
+        current = directory
+        for _depth in range(6):
+            if os.path.exists(os.path.join(current, "CMakeCache.txt")):
+                return current
+            parent = os.path.dirname(current)
+            if parent == current:
+                break
+            current = parent
+        return ""
+
+    def _extensionsManagerModel(self):
+        """The extensions manager, or None.
+
+        Slicer compiles the accessor out entirely when built without
+        Slicer_BUILD_EXTENSIONMANAGER_SUPPORT, so the attribute can be missing rather than
+        merely returning None.
+        """
+        accessor = getattr(slicer.app, "extensionsManagerModel", None)
+        if accessor is None:
+            return None
+        try:
+            return accessor()
+        except Exception:
+            return None
+
+    def _extensionInstallDirectory(self):
+        """Root of the Extension Manager install of MorphoDepot, or ""."""
+        model = self._extensionsManagerModel()
+        if model is None:
+            return ""
+        try:
+            if not model.isExtensionInstalled("MorphoDepot"):
+                return ""
+            installPath = model.extensionInstallPath("MorphoDepot")
+        except Exception as e:
+            logging.debug(f"MorphoDepot version check: extension install path unavailable: {e}")
+            return ""
+        return os.path.realpath(installPath) if installPath else ""
+
+    def _extensionRevision(self):
+        """The upstream revision the installed extension was built from, or ""."""
+        model = self._extensionsManagerModel()
+        if model is None:
+            return ""
+        try:
+            metadata = model.extensionMetadata("MorphoDepot")
+        except Exception as e:
+            logging.debug(f"MorphoDepot version check: extension metadata unavailable: {e}")
+            return ""
+        if not metadata:
+            return ""
+        try:
+            return str(metadata["revision"]).strip()
+        except (KeyError, TypeError):
+            return ""
+
+    # -------------------------------------------------------------------- marker
+
+    def _markerPath(self, moduleDirectory):
+        return os.path.join(moduleDirectory, "MorphoDepotLib", MARKER_FILENAME)
+
+    def _readMarker(self, moduleDirectory, extensionRevision):
+        """Revision recorded by our own in-place update, or None.
+
+        Ignored unless the .s4ext revision still matches what it recorded, so that any
+        reinstall by the Extension Manager wins over a stale marker.
+        """
+        markerPath = self._markerPath(moduleDirectory)
+        if not os.path.exists(markerPath):
+            return None
+        try:
+            with open(markerPath) as markerFile:
+                marker = json.load(markerFile)
+        except (OSError, ValueError) as e:
+            logging.debug(f"MorphoDepot version check: unreadable update marker: {e}")
+            return None
+        if not isinstance(marker, dict) or not marker.get("sha"):
+            return None
+        if marker.get("s4extRevision", "") != extensionRevision:
+            logging.debug("MorphoDepot version check: update marker predates the installed extension; ignoring it")
+            return None
+        return marker
+
+    def _writeMarker(self, moduleDirectory, sha, date, extensionRevision):
+        marker = {
+            "sha": sha,
+            "date": date,
+            "s4extRevision": extensionRevision,
+            "appliedAt": datetime.datetime.now().astimezone().isoformat(),
+        }
+        markerPath = self._markerPath(moduleDirectory)
+        try:
+            with open(markerPath, "w") as markerFile:
+                json.dump(marker, markerFile, indent=1)
+        except OSError as e:
+            logging.warning(f"MorphoDepot: could not record the applied update revision: {e}")
+
+    # ------------------------------------------------------------- write safety
+
+    def _directoryIsWritable(self, directory):
+        if not os.path.isdir(directory):
+            return False
+        try:
+            handle, probePath = tempfile.mkstemp(prefix=".morphodepot-write-probe", dir=directory)
+        except OSError:
+            return False
+        os.close(handle)
+        try:
+            os.remove(probePath)
+        except OSError:
+            pass
+        return True
+
+    # ------------------------------------------------------------- installed side
+
+    def _cloneDescription(self, moduleDirectory):
+        """Describe the git clone containing the module, or None if there is not one.
+
+        The repository must hold the module at <root>/MorphoDepot -- the layout of this
+        repository -- so that an install that merely happens to sit inside some unrelated
+        checkout (a dotfiles repository under $HOME, say) is not mistaken for a clone.
+        """
+        try:
+            repository = git.Repo(moduleDirectory, search_parent_directories=True)
+        except (git.exc.InvalidGitRepositoryError, git.exc.NoSuchPathError):
+            return None
+        except Exception as e:
+            logging.debug(f"MorphoDepot version check: git inspection failed: {e}")
+            return None
+
+        workingTree = repository.working_tree_dir
+        if not workingTree:
+            return None
+        expected = os.path.realpath(os.path.join(workingTree, MODULE_SUBDIRECTORY))
+        if expected != moduleDirectory:
+            return None
+
+        description = {
+            "repositoryRoot": os.path.realpath(workingTree),
+            "sha": "",
+            "date": "",
+            "blockedReason": "",
+        }
+        try:
+            commit = repository.head.commit
+            description["sha"] = commit.hexsha
+            description["date"] = datetime.datetime.fromtimestamp(commit.committed_date).strftime("%Y-%m-%d")
+        except Exception as e:
+            logging.debug(f"MorphoDepot version check: could not read HEAD: {e}")
+
+        reasons = []
+        try:
+            if repository.is_dirty(untracked_files=False):
+                reasons.append(_("it has uncommitted changes"))
+        except Exception:
+            pass
+        try:
+            branch = repository.active_branch.name
+            if branch != VERSION_CHECK_BRANCH:
+                reasons.append(_("it is on branch '{branch}'").format(branch=branch))
+        except TypeError:
+            reasons.append(_("it has a detached HEAD"))
+        except Exception:
+            pass
+        try:
+            remoteUrl = repository.remotes.origin.url
+        except Exception:
+            remoteUrl = ""
+        if "slicermorphodepot" not in remoteUrl.lower():
+            reasons.append(_("its origin remote is not the MorphoDepot repository"))
+
+        if reasons:
+            description["blockedReason"] = _(
+                "This is a working clone of MorphoDepot ({reasons}), so MorphoDepot will not "
+                "modify it.  Update it yourself with git.").format(reasons=", ".join(reasons))
+        return description
+
+    def installedVersion(self):
+        """Where MorphoDepot is installed, which revision it is, and whether we may write.
+
+        MAIN THREAD ONLY -- reads slicer.app and slicer.modules.
+        """
+        installed = {
+            "shape": SHAPE_UNKNOWN,
+            "sha": "",
+            "date": "",
+            "moduleDirectory": "",
+            "repositoryRoot": "",
+            "extensionRevision": "",
+            "canUpdate": False,
+            "blockedReason": "",
+        }
+
+        moduleDirectory = self.moduleDirectory()
+        if not moduleDirectory:
+            installed["blockedReason"] = _("The MorphoDepot module directory could not be located.")
+            return installed
+        installed["moduleDirectory"] = moduleDirectory
+
+        buildTree = self._buildTreeRoot(moduleDirectory)
+        if buildTree:
+            installed["shape"] = SHAPE_BUILD_TREE
+            installed["blockedReason"] = _(
+                "MorphoDepot is running from a CMake build tree, so an update would be undone by "
+                "the next build.  Update the source checkout and rebuild.")
+            clone = self._cloneDescription(moduleDirectory)
+            if clone:
+                installed["sha"] = clone["sha"]
+                installed["date"] = clone["date"]
+                installed["repositoryRoot"] = clone["repositoryRoot"]
+            return installed
+
+        extensionDirectory = self._extensionInstallDirectory()
+        if extensionDirectory and (moduleDirectory + os.sep).startswith(extensionDirectory + os.sep):
+            extensionRevision = self._extensionRevision()
+            installed["shape"] = SHAPE_EXTENSION
+            installed["extensionRevision"] = extensionRevision
+            installed["sha"] = extensionRevision
+            marker = self._readMarker(moduleDirectory, extensionRevision)
+            if marker:
+                installed["sha"] = marker["sha"]
+                installed["date"] = marker.get("date", "")
+            if not installed["sha"]:
+                installed["blockedReason"] = _(
+                    "The installed extension does not record which revision it was built from.")
+                return installed
+            if not self._directoryIsWritable(moduleDirectory):
+                installed["blockedReason"] = _(
+                    "MorphoDepot cannot write to its own install directory, so it cannot update "
+                    "itself.  Reinstall through the Extension Manager, or reinstall Slicer "
+                    "somewhere you can write to.")
+                return installed
+            installed["canUpdate"] = True
+            return installed
+
+        clone = self._cloneDescription(moduleDirectory)
+        if clone:
+            installed["sha"] = clone["sha"]
+            installed["date"] = clone["date"]
+            installed["repositoryRoot"] = clone["repositoryRoot"]
+            if clone["blockedReason"]:
+                installed["shape"] = SHAPE_DEV_CLONE
+                installed["blockedReason"] = clone["blockedReason"]
+                return installed
+            installed["shape"] = SHAPE_CLONE
+            if not self._directoryIsWritable(installed["repositoryRoot"]):
+                installed["blockedReason"] = _("MorphoDepot cannot write to its git clone.")
+                return installed
+            installed["canUpdate"] = True
+            return installed
+
+        installed["blockedReason"] = _(
+            "MorphoDepot cannot tell which version is installed.  Install it through the "
+            "Extension Manager or from a git clone to get update notifications.")
+        return installed
+
+    # ---------------------------------------------------------------- remote side
+
+    def _runGh(self, arguments, environment=None, timeout=30):
+        """Run gh and return stdout, or None on any failure.
+
+        Deliberately not MorphoDepotLogic.gh(): see this module's threading contract.
+        """
+        ghPath = self.ghExecutablePath
+        if not ghPath:
+            return None
+        childEnvironment = dict(environment) if environment else None
+        popenArguments = {}
+        if os.name == "nt":
+            # Hide the console window, the way slicer.util.launchConsoleProcess does.
+            startupInfo = subprocess.STARTUPINFO()
+            startupInfo.dwFlags = 1
+            startupInfo.wShowWindow = 0
+            popenArguments["startupinfo"] = startupInfo
+        try:
+            completed = subprocess.run(
+                [ghPath] + arguments,
+                capture_output=True,
+                text=True,
+                timeout=timeout,
+                env=childEnvironment,
+                **popenArguments)
+        except (OSError, subprocess.SubprocessError) as e:
+            logging.debug(f"MorphoDepot version check: gh could not be run: {e}")
+            return None
+        if completed.returncode != 0:
+            stderr = (completed.stderr or "").strip()
+            if "422" in stderr:
+                logging.warning(
+                    "MorphoDepot version check: GitHub could not resolve the installed revision "
+                    f"(HTTP 422). The abbreviated SHA may be ambiguous: {stderr}")
+            else:
+                logging.debug(f"MorphoDepot version check: gh exited {completed.returncode}: {stderr}")
+            return None
+        return completed.stdout
+
+    def _ghJson(self, arguments, environment=None, timeout=30):
+        output = self._runGh(arguments, environment=environment, timeout=timeout)
+        if not output:
+            return None
+        try:
+            parsed = json.loads(output)
+        except ValueError as e:
+            logging.debug(f"MorphoDepot version check: unparsable gh output: {e}")
+            return None
+        return parsed if isinstance(parsed, dict) else None
+
+    def moduleFilesChanged(self, filenames, fileCount):
+        """True when a compare result touches files that ship inside the module."""
+        if fileCount >= COMPARE_FILE_CAP:
+            # Truncated file list: assume the module changed rather than miss an update.
+            return True
+        modulePrefix = MODULE_SUBDIRECTORY + "/"
+        testingPrefix = modulePrefix + "Testing/"
+        for filename in filenames:
+            if filename.startswith(modulePrefix) and not filename.startswith(testingPrefix):
+                return True
+        return False
+
+    def fetchUpdateStatus(self, installedSha, environment=None):
+        """Compare the installed revision against upstream.
+
+        BACKGROUND THREAD SAFE -- subprocess and json only.  Returns a dict with
+        `available`, `latestSha`, `latestDate`, `aheadBy`, `compareUrl` and `error`.
+        """
+        status = {
+            "available": False,
+            "latestSha": "",
+            "latestDate": "",
+            "aheadBy": 0,
+            "compareUrl": "",
+            "error": "",
+        }
+
+        if not installedSha:
+            latest = self._ghJson(
+                ["api", f"repos/{VERSION_CHECK_REPO}/commits/{VERSION_CHECK_BRANCH}",
+                 "--jq", "{sha: .sha, date: .commit.committer.date}"],
+                environment=environment)
+            if latest is None:
+                status["error"] = _("Could not reach GitHub to check for updates.")
+                return status
+            status["latestSha"] = latest.get("sha", "")
+            status["latestDate"] = (latest.get("date") or "")[:10]
+            return status
+
+        jqFilter = (
+            "{status: .status, ahead_by: .ahead_by, html_url: .html_url,"
+            " head_sha: (.commits | last | .sha),"
+            " head_date: (.commits | last | .commit.committer.date),"
+            " file_count: ((.files // []) | length),"
+            " files: [(.files // [])[].filename]}")
+        comparison = self._ghJson(
+            ["api", f"repos/{VERSION_CHECK_REPO}/compare/{installedSha}...{VERSION_CHECK_BRANCH}",
+             "--jq", jqFilter],
+            environment=environment)
+        if comparison is None:
+            status["error"] = _("Could not reach GitHub to check for updates.")
+            return status
+
+        status["compareUrl"] = comparison.get("html_url", "") or ""
+        status["aheadBy"] = comparison.get("ahead_by", 0) or 0
+        status["latestSha"] = comparison.get("head_sha") or installedSha
+        status["latestDate"] = (comparison.get("head_date") or "")[:10]
+
+        if comparison.get("status") == "diverged":
+            # The installed revision is not an ancestor of the release branch, so "behind"
+            # is not a meaningful thing to say about it.
+            status["error"] = _("The installed revision is not on the MorphoDepot release branch.")
+            return status
+
+        if status["aheadBy"] > 0:
+            status["available"] = self.moduleFilesChanged(
+                comparison.get("files", []) or [], comparison.get("file_count", 0) or 0)
+        return status
+
+    # -------------------------------------------------------------- applying it
+
+    def applyUpdate(self, installed, targetSha):
+        """Update the installed module to `targetSha`.
+
+        MAIN THREAD ONLY.  Returns (succeeded, message).
+        """
+        if installed.get("shape") == SHAPE_CLONE:
+            return self._updateClone(installed)
+        if installed.get("shape") == SHAPE_EXTENSION:
+            return self._updateExtensionInPlace(installed, targetSha)
+        return False, _("MorphoDepot does not know how to update this installation.")
+
+    def _updateClone(self, installed):
+        repositoryRoot = installed.get("repositoryRoot", "")
+        self.progressMethod(f"Updating the MorphoDepot clone at {repositoryRoot}")
+        try:
+            repository = git.Repo(repositoryRoot)
+            repository.git.pull("--ff-only", "origin", VERSION_CHECK_BRANCH)
+        except Exception as e:
+            logging.error(f"MorphoDepot update: git pull failed: {e}")
+            return False, _("Could not fast-forward the clone: {error}").format(error=str(e))
+        return True, _("The MorphoDepot clone was updated.")
+
+    def _backupRoot(self):
+        settingsFilePath = getattr(slicer.app, "slicerUserSettingsFilePath", "")
+        root = os.path.dirname(settingsFilePath) if settingsFilePath else tempfile.gettempdir()
+        return os.path.join(root, "MorphoDepotUpdateBackups")
+
+    def _updateExtensionInPlace(self, installed, targetSha):
+        """Replace the installed module files with `targetSha` from GitHub.
+
+        The module is pure Python, so there is nothing to compile: the installed
+        qt-scripted-modules tree is the repository's MorphoDepot/ directory minus
+        CMakeLists.txt and Testing/.  The old tree is backed up outside the module
+        directory first -- a backup left beside the module would be scanned by Slicer's
+        module factory and register duplicate modules.
+        """
+        moduleDirectory = installed.get("moduleDirectory", "")
+        if not moduleDirectory or not os.path.isdir(moduleDirectory):
+            return False, _("The MorphoDepot module directory could not be located.")
+        if not self._directoryIsWritable(moduleDirectory):
+            return False, _("MorphoDepot cannot write to its own install directory.")
+
+        workDirectory = tempfile.mkdtemp(prefix="morphodepot-update-")
+        backupPath = ""
+        try:
+            sourceDirectory = self._downloadModuleTree(targetSha, workDirectory)
+            files = self._moduleFileList(sourceDirectory)
+            if not files or "MorphoDepot.py" not in files:
+                return False, _("The downloaded MorphoDepot archive is not what was expected.")
+
+            backupPath = self._backupModuleTree(moduleDirectory, installed.get("sha", ""))
+            self.progressMethod(f"Installing {len(files)} MorphoDepot files")
+            for relativePath in files:
+                destination = os.path.join(moduleDirectory, relativePath)
+                os.makedirs(os.path.dirname(destination), exist_ok=True)
+                self._copyWithRetry(os.path.join(sourceDirectory, relativePath), destination)
+
+            self._removeRetiredFiles(moduleDirectory, files)
+            self._purgeCompiledFiles(moduleDirectory)
+
+            problem = self._verifyModuleTree(sourceDirectory, moduleDirectory, files)
+            if problem:
+                raise RuntimeError(problem)
+
+            self._writeMarker(
+                moduleDirectory, targetSha, datetime.datetime.now().strftime("%Y-%m-%d"),
+                installed.get("extensionRevision", ""))
+        except Exception as e:
+            logging.error(f"MorphoDepot update failed: {e}")
+            if backupPath:
+                restored = self._restoreModuleTree(backupPath, moduleDirectory)
+                if not restored:
+                    return False, _(
+                        "The update failed and the previous version could not be restored "
+                        "automatically.  A copy of it is at {path}.").format(path=backupPath)
+                return False, _("The update failed and the previous version was restored: {error}").format(error=str(e))
+            return False, _("The update failed: {error}").format(error=str(e))
+        finally:
+            shutil.rmtree(workDirectory, ignore_errors=True)
+
+        return True, _("MorphoDepot was updated.  The previous version was kept at {path}.").format(path=backupPath)
+
+    def _downloadModuleTree(self, sha, workDirectory):
+        """Download and unpack the repository at `sha`; return its MorphoDepot/ directory."""
+        archivePath = os.path.join(workDirectory, "morphodepot.tar.gz")
+        url = f"https://codeload.github.com/{VERSION_CHECK_REPO}/tar.gz/{sha}"
+        self.progressMethod(f"Downloading MorphoDepot {sha[:7]}")
+        response = requests.get(url, timeout=120, stream=True)
+        response.raise_for_status()
+        with open(archivePath, "wb") as archiveFile:
+            for chunk in response.iter_content(chunk_size=65536):
+                archiveFile.write(chunk)
+
+        with tarfile.open(archivePath, "r:gz") as archive:
+            names = archive.getnames()
+            if not names:
+                raise RuntimeError("the downloaded archive is empty")
+            # GitHub names the top level <repo>-<ref>, where <ref> depends on what was
+            # requested; read it rather than reconstructing it.
+            topLevel = names[0].split("/")[0]
+            try:
+                archive.extractall(path=workDirectory, filter="data")
+            except TypeError:
+                # Python older than 3.12 has no extraction filters.
+                archive.extractall(path=workDirectory)
+
+        sourceDirectory = os.path.join(workDirectory, topLevel, MODULE_SUBDIRECTORY)
+        if not os.path.isdir(sourceDirectory):
+            raise RuntimeError(f"the downloaded archive has no {MODULE_SUBDIRECTORY} directory")
+        return sourceDirectory
+
+    def _moduleFileList(self, sourceDirectory):
+        """Relative paths of the files an extension build ships."""
+        files = []
+        for root, directories, names in os.walk(sourceDirectory):
+            directories[:] = [d for d in directories if d not in UPDATE_EXCLUDED_DIRECTORIES]
+            relativeRoot = os.path.relpath(root, sourceDirectory)
+            relativeRoot = "" if relativeRoot == "." else relativeRoot
+            for name in names:
+                relativePath = os.path.join(relativeRoot, name) if relativeRoot else name
+                if relativePath in UPDATE_EXCLUDED_FILES:
+                    continue
+                files.append(relativePath)
+        return sorted(files)
+
+    def _copyWithRetry(self, source, destination, attempts=3):
+        """Copy, retrying briefly: on Windows a sync client or scanner can hold a file open."""
+        for attempt in range(attempts):
+            try:
+                shutil.copy2(source, destination)
+                return
+            except OSError:
+                if attempt == attempts - 1:
+                    raise
+                time.sleep(0.5)
+
+    def _backupModuleTree(self, moduleDirectory, installedSha):
+        stamp = datetime.datetime.now().strftime("%Y%m%d-%H%M%S")
+        label = (installedSha or "unknown")[:7]
+        backupRoot = self._backupRoot()
+        os.makedirs(backupRoot, exist_ok=True)
+        # mkdtemp rather than a bare timestamp: retrying a failed update within the same
+        # second would otherwise collide with the backup the first attempt left behind.
+        backupPath = tempfile.mkdtemp(prefix=f"MorphoDepot-{label}-{stamp}-", dir=backupRoot)
+        self.progressMethod(f"Backing up the installed MorphoDepot to {backupPath}")
+        shutil.copytree(
+            moduleDirectory, backupPath, dirs_exist_ok=True,
+            ignore=shutil.ignore_patterns("__pycache__", "*.pyc"))
+        return backupPath
+
+    def _restoreModuleTree(self, backupPath, moduleDirectory):
+        """Copy the backup back over the module directory.
+
+        Copies rather than replacing wholesale: a failed rmtree partway through would
+        leave the user with no module at all, whereas leftover new files are inert once
+        MorphoDepot.py is the old one again and no longer imports them.
+        """
+        try:
+            shutil.copytree(backupPath, moduleDirectory, dirs_exist_ok=True)
+            self._purgeCompiledFiles(moduleDirectory)
+        except Exception as e:
+            logging.error(f"MorphoDepot update: restoring the previous version failed: {e}")
+            return False
+        return True
+
+    def _removeRetiredFiles(self, moduleDirectory, files):
+        """Delete installed files that upstream no longer ships."""
+        keep = set(files)
+        for root, directories, names in os.walk(moduleDirectory):
+            directories[:] = [d for d in directories if d != "__pycache__"]
+            for name in names:
+                relativePath = os.path.relpath(os.path.join(root, name), moduleDirectory)
+                if relativePath in keep or name == MARKER_FILENAME or name.endswith(".pyc"):
+                    continue
+                try:
+                    os.remove(os.path.join(root, name))
+                    logging.info(f"MorphoDepot update: removed retired file {relativePath}")
+                except OSError as e:
+                    logging.warning(f"MorphoDepot update: could not remove {relativePath}: {e}")
+
+    def _purgeCompiledFiles(self, moduleDirectory):
+        """Drop cached bytecode so nothing stale can shadow the new sources."""
+        for root, directories, names in os.walk(moduleDirectory, topdown=False):
+            for name in names:
+                if name.endswith(".pyc"):
+                    try:
+                        os.remove(os.path.join(root, name))
+                    except OSError:
+                        pass
+            for directory in directories:
+                if directory == "__pycache__":
+                    shutil.rmtree(os.path.join(root, directory), ignore_errors=True)
+
+    def _verifyModuleTree(self, sourceDirectory, moduleDirectory, files):
+        """Return a problem description, or "" when the installed tree looks sound.
+
+        Compiling without executing catches a truncated or corrupted write -- the failure
+        mode of copying onto a network drive -- while the backup is still around.
+        """
+        for relativePath in files:
+            destination = os.path.join(moduleDirectory, relativePath)
+            if not os.path.exists(destination):
+                return f"{relativePath} is missing after the update"
+            if os.path.getsize(destination) != os.path.getsize(os.path.join(sourceDirectory, relativePath)):
+                return f"{relativePath} is the wrong size after the update"
+            if relativePath.endswith(".py"):
+                try:
+                    with open(destination, "rb") as sourceFile:
+                        compile(sourceFile.read(), destination, "exec")
+                except (SyntaxError, ValueError) as e:
+                    return f"{relativePath} did not survive the update ({e})"
+        return ""

--- a/MorphoDepot/MorphoDepotLib/logic_version.py
+++ b/MorphoDepot/MorphoDepotLib/logic_version.py
@@ -273,6 +273,7 @@ class VersionMixin:
             "repositoryRoot": os.path.realpath(workingTree),
             "sha": "",
             "date": "",
+            "branch": "",
             "blockedReason": "",
         }
         try:
@@ -290,9 +291,11 @@ class VersionMixin:
             pass
         try:
             branch = repository.active_branch.name
+            description["branch"] = branch
             if branch != self.versionCheckBranch():
                 reasons.append(_("it is on branch '{branch}'").format(branch=branch))
         except TypeError:
+            description["branch"] = _("detached HEAD")
             reasons.append(_("it has a detached HEAD"))
         except Exception:
             pass
@@ -320,6 +323,7 @@ class VersionMixin:
             "date": "",
             "moduleDirectory": "",
             "repositoryRoot": "",
+            "branch": "",
             "extensionRevision": "",
             "canUpdate": False,
             "blockedReason": "",
@@ -341,6 +345,7 @@ class VersionMixin:
             if clone:
                 installed["sha"] = clone["sha"]
                 installed["date"] = clone["date"]
+                installed["branch"] = clone["branch"]
                 installed["repositoryRoot"] = clone["repositoryRoot"]
             return installed
 
@@ -371,6 +376,7 @@ class VersionMixin:
         if clone:
             installed["sha"] = clone["sha"]
             installed["date"] = clone["date"]
+            installed["branch"] = clone["branch"]
             installed["repositoryRoot"] = clone["repositoryRoot"]
             if clone["blockedReason"]:
                 installed["shape"] = SHAPE_DEV_CLONE
@@ -467,6 +473,7 @@ class VersionMixin:
             "latestDate": "",
             "aheadBy": 0,
             "compareUrl": "",
+            "compareStatus": "",
             "error": "",
         }
 
@@ -497,6 +504,9 @@ class VersionMixin:
             return status
 
         status["compareUrl"] = comparison.get("html_url", "") or ""
+        # "identical", "ahead" (the branch has commits we do not), "behind" (we have
+        # commits the branch does not -- a development build), or "diverged".
+        status["compareStatus"] = comparison.get("status", "") or ""
         status["aheadBy"] = comparison.get("ahead_by", 0) or 0
         status["latestSha"] = comparison.get("head_sha") or installedSha
         status["latestDate"] = (comparison.get("head_date") or "")[:10]

--- a/MorphoDepot/MorphoDepotLib/widget_version.py
+++ b/MorphoDepot/MorphoDepotLib/widget_version.py
@@ -1,0 +1,414 @@
+"""MorphoDepotWidget VersionUIMixin (issue #203): update notification and manual update.
+
+The check runs in the background whenever the module is entered, at most once a day, and
+says nothing at all unless there is something to say.  Updating is always the user's
+explicit choice.
+
+The background call follows the pattern slicer.util uses for non-blocking process output:
+the worker thread only puts its result on a queue, and a QTimer started on the MAIN thread
+polls that queue.  Posting the result with QTimer.singleShot from inside the worker would
+create a timer on a thread with no event loop, where it would never fire.
+"""
+
+import datetime
+import logging
+import queue
+import threading
+
+import qt
+import ctk
+import slicer
+from slicer.i18n import tr as _
+
+from MorphoDepotLib.logic_version import (
+    VERSION_CHECK_REPO,
+    VERSION_CHECK_TTL_SECONDS,
+    SHAPE_BUILD_TREE,
+    SHAPE_CLONE,
+    SHAPE_DEV_CLONE,
+    SHAPE_EXTENSION,
+    SHAPE_UNKNOWN,
+)
+
+VERSION_SETTINGS_PREFIX = "MorphoDepot/versionCheck/"
+VERSION_POLL_INTERVAL_MS = 200
+# Bounds the poll loop if the worker dies before it can report anything.
+VERSION_POLL_DEADLINE_SECONDS = 120
+
+SHAPE_DESCRIPTIONS = {
+    SHAPE_EXTENSION: "Extension Manager",
+    SHAPE_CLONE: "git clone",
+    SHAPE_DEV_CLONE: "git clone (working copy)",
+    SHAPE_BUILD_TREE: "build tree",
+    SHAPE_UNKNOWN: "unrecognized install",
+}
+
+
+class VersionUIMixin:
+
+    # ---------------------------------------------------------------- settings
+
+    def versionSetting(self, name, default=""):
+        return slicer.util.settingsValue(VERSION_SETTINGS_PREFIX + name, default)
+
+    def setVersionSetting(self, name, value):
+        qt.QSettings().setValue(VERSION_SETTINGS_PREFIX + name, value)
+
+    def versionCheckEnabled(self):
+        return slicer.util.settingsValue(
+            VERSION_SETTINGS_PREFIX + "enabled", True, converter=slicer.util.toBool)
+
+    def cachedVersionStatus(self):
+        """The last check result if it is still fresh, otherwise None."""
+        checkedAt = self.versionSetting("lastCheckAt")
+        if not checkedAt:
+            return None
+        try:
+            age = (datetime.datetime.now().astimezone()
+                   - datetime.datetime.fromisoformat(checkedAt)).total_seconds()
+        except ValueError:
+            return None
+        if age < 0 or age > VERSION_CHECK_TTL_SECONDS:
+            return None
+        latestSha = self.versionSetting("latestSha")
+        if not latestSha:
+            return None
+        return {
+            "available": slicer.util.settingsValue(
+                VERSION_SETTINGS_PREFIX + "available", False, converter=slicer.util.toBool),
+            "latestSha": latestSha,
+            "latestDate": self.versionSetting("latestDate"),
+            "aheadBy": int(self.versionSetting("aheadBy", "0") or 0),
+            "compareUrl": self.versionSetting("compareUrl"),
+            "error": "",
+        }
+
+    def cacheVersionStatus(self, status):
+        self.setVersionSetting("available", status.get("available", False))
+        self.setVersionSetting("latestSha", status.get("latestSha", ""))
+        self.setVersionSetting("latestDate", status.get("latestDate", ""))
+        self.setVersionSetting("aheadBy", str(status.get("aheadBy", 0)))
+        self.setVersionSetting("compareUrl", status.get("compareUrl", ""))
+        self.setVersionSetting("lastCheckAt", datetime.datetime.now().astimezone().isoformat())
+
+    # ---------------------------------------------------------------------- UI
+
+    def setupVersionUI(self):
+        """Build the update banner and the version controls on the Configure tab."""
+        self._versionWidgetAlive = True
+        self._versionCheckRunning = False
+        self._versionInstalled = None
+        self._versionStatus = None
+
+        self.versionBanner = qt.QFrame()
+        self.versionBanner.setFrameShape(qt.QFrame.StyledPanel)
+        # palette() keeps this readable in both the light and dark Slicer themes.
+        self.versionBanner.setStyleSheet(
+            """
+            QFrame {
+                background-color: palette(midlight);
+                border: 1px solid palette(highlight);
+                border-radius: 4px;
+                padding: 4px;
+            }
+            """
+        )
+        bannerLayout = qt.QVBoxLayout(self.versionBanner)
+        bannerLayout.setContentsMargins(6, 6, 6, 6)
+
+        self.versionBannerLabel = qt.QLabel()
+        self.versionBannerLabel.wordWrap = True
+        bannerLayout.addWidget(self.versionBannerLabel)
+
+        buttonRow = qt.QHBoxLayout()
+        self.versionUpdateButton = qt.QPushButton(_("Update Now"))
+        self.versionUpdateButton.toolTip = _("Download and install the latest MorphoDepot")
+        self.versionWhatsNewButton = qt.QPushButton(_("What's New"))
+        self.versionWhatsNewButton.toolTip = _("Show the changes on GitHub")
+        self.versionDismissButton = qt.QPushButton(_("Dismiss"))
+        self.versionDismissButton.toolTip = _("Hide this notice until the next update is released")
+        buttonRow.addWidget(self.versionUpdateButton)
+        buttonRow.addWidget(self.versionWhatsNewButton)
+        buttonRow.addWidget(self.versionDismissButton)
+        buttonRow.addStretch(1)
+        bannerLayout.addLayout(buttonRow)
+
+        self.versionBanner.visible = False
+        # Above the tab widget, so the notice is visible from every tab.
+        self.layout.insertWidget(0, self.versionBanner)
+
+        self.versionUpdateButton.connect("clicked()", self.onVersionUpdate)
+        self.versionWhatsNewButton.connect("clicked()", self.onVersionWhatsNew)
+        self.versionDismissButton.connect("clicked()", self.onVersionDismiss)
+
+        # Configure tab: always available, whatever the banner is doing.
+        self.configureUI.versionCollapsibleButton = ctk.ctkCollapsibleButton()
+        self.configureUI.versionCollapsibleButton.text = _("MorphoDepot Version")
+        self.configureUI.versionCollapsibleButton.collapsed = True
+        versionLayout = qt.QFormLayout(self.configureUI.versionCollapsibleButton)
+
+        self.configureUI.installedVersionLabel = qt.QLabel(_("Checking..."))
+        self.configureUI.installedVersionLabel.wordWrap = True
+        versionLayout.addRow(_("Installed:"), self.configureUI.installedVersionLabel)
+
+        self.configureUI.versionStatusLabel = qt.QLabel("")
+        self.configureUI.versionStatusLabel.wordWrap = True
+        versionLayout.addRow(_("Status:"), self.configureUI.versionStatusLabel)
+
+        self.configureUI.versionCheckNowButton = qt.QPushButton(_("Check for Updates Now"))
+        versionLayout.addRow(self.configureUI.versionCheckNowButton)
+
+        self.configureUI.versionCheckEnabledCheckBox = qt.QCheckBox(_("Check for updates at startup"))
+        self.configureUI.versionCheckEnabledCheckBox.checked = self.versionCheckEnabled()
+        versionLayout.addRow(self.configureUI.versionCheckEnabledCheckBox)
+
+        self.configureUI.configureCollapsibleButton.layout().addWidget(
+            self.configureUI.versionCollapsibleButton)
+
+        self.configureUI.versionCheckNowButton.connect("clicked()", self.onVersionCheckNow)
+        self.configureUI.versionCheckEnabledCheckBox.connect("toggled(bool)", self.onVersionCheckEnabledToggled)
+
+    # ----------------------------------------------------------------- running
+
+    def startVersionCheck(self, force=False):
+        """Resolve the installed version, then check GitHub on a background thread.
+
+        Called from enter().  Everything that reads Slicer state happens here, on the main
+        thread; the worker only runs gh.
+        """
+        if not getattr(self, "_versionWidgetAlive", False) or self._versionCheckRunning:
+            return
+        if not force and not self.versionCheckEnabled():
+            return
+        # gh is how the check talks to GitHub, so there is nothing to do (and nothing worth
+        # complaining about) until the user has finished setting up their dependencies.
+        if not self.logic or not self.logic.ghExecutablePath:
+            return
+
+        installed = self.logic.installedVersion()
+        self._versionInstalled = installed
+        self._refreshVersionDisplay()
+
+        if not force:
+            cached = self.cachedVersionStatus()
+            if cached:
+                self._versionStatus = cached
+                self._refreshVersionDisplay()
+                return
+
+        installedSha = installed.get("sha", "")
+        try:
+            environment = slicer.util.startupEnvironment()
+        except Exception:
+            environment = None
+
+        resultQueue = queue.Queue()
+        deadline = datetime.datetime.now() + datetime.timedelta(seconds=VERSION_POLL_DEADLINE_SECONDS)
+
+        def check():
+            try:
+                resultQueue.put(self.logic.fetchUpdateStatus(installedSha, environment))
+            except Exception as e:
+                logging.debug(f"MorphoDepot version check failed: {e}")
+                resultQueue.put({"available": False, "error": str(e), "latestSha": "",
+                                 "latestDate": "", "aheadBy": 0, "compareUrl": ""})
+
+        def poll():
+            if not getattr(self, "_versionWidgetAlive", False):
+                return
+            try:
+                status = resultQueue.get_nowait()
+            except queue.Empty:
+                if datetime.datetime.now() > deadline:
+                    logging.debug("MorphoDepot version check: giving up waiting for a result")
+                    self._versionCheckRunning = False
+                    return
+                qt.QTimer.singleShot(VERSION_POLL_INTERVAL_MS, poll)
+                return
+            self._versionCheckRunning = False
+            self._onVersionCheckFinished(status)
+
+        self._versionCheckRunning = True
+        threading.Thread(target=check, daemon=True).start()
+        qt.QTimer.singleShot(0, poll)
+
+    def _onVersionCheckFinished(self, status):
+        if not getattr(self, "_versionWidgetAlive", False):
+            return
+        self._versionStatus = status
+        if not status.get("error"):
+            self.cacheVersionStatus(status)
+        self._refreshVersionDisplay()
+
+    # ------------------------------------------------------------------ display
+
+    def _versionDisplayName(self, sha, date):
+        if not sha:
+            return _("unknown")
+        label = sha[:7]
+        return f"{label} ({date})" if date else label
+
+    def _sameRevision(self, first, second):
+        """Whether two revisions are the same commit.
+
+        One side is usually the .s4ext's abbreviated SHA and the other a full one, so this
+        compares by prefix.  It is what keeps a cached "update available" from surviving an
+        update that happened some other way -- through the Extension Manager, say -- in
+        between two checks.
+        """
+        if not first or not second:
+            return False
+        length = min(len(first), len(second), 40)
+        if length < 7:
+            return False
+        return first[:length] == second[:length]
+
+    def _refreshVersionDisplay(self):
+        installed = self._versionInstalled or {}
+        status = self._versionStatus or {}
+
+        shape = installed.get("shape", SHAPE_UNKNOWN)
+        installedLabel = self._versionDisplayName(installed.get("sha", ""), installed.get("date", ""))
+        self.configureUI.installedVersionLabel.text = "{version} - {shape}".format(
+            version=installedLabel, shape=SHAPE_DESCRIPTIONS.get(shape, shape))
+
+        upToDate = self._sameRevision(installed.get("sha", ""), status.get("latestSha", ""))
+        if status.get("error"):
+            self.configureUI.versionStatusLabel.text = status["error"]
+        elif not status:
+            self.configureUI.versionStatusLabel.text = _("Not checked yet.")
+        elif status.get("available") and not upToDate:
+            self.configureUI.versionStatusLabel.text = _("Update available: {version}").format(
+                version=self._versionDisplayName(status.get("latestSha", ""), status.get("latestDate", "")))
+        elif installed.get("sha"):
+            self.configureUI.versionStatusLabel.text = _("Up to date.")
+        else:
+            self.configureUI.versionStatusLabel.text = _("The installed version could not be determined.")
+
+        if installed.get("blockedReason"):
+            self.configureUI.versionStatusLabel.text += "\n" + installed["blockedReason"]
+
+        self._refreshVersionBanner(installed, status)
+
+    def _refreshVersionBanner(self, installed, status):
+        latestSha = status.get("latestSha", "")
+        if not status.get("available") or not latestSha:
+            self.versionBanner.visible = False
+            return
+        if self._sameRevision(installed.get("sha", ""), latestSha):
+            # A cached result that the install has since caught up with.
+            self.versionBanner.visible = False
+            return
+        if self.versionSetting("dismissedSha") == latestSha:
+            self.versionBanner.visible = False
+            return
+
+        aheadBy = status.get("aheadBy", 0)
+        message = _("A newer MorphoDepot is available: {latest} (you have {installed}).").format(
+            latest=self._versionDisplayName(latestSha, status.get("latestDate", "")),
+            installed=self._versionDisplayName(installed.get("sha", ""), installed.get("date", "")))
+        if aheadBy:
+            message += " " + _("{count} commits behind.").format(count=aheadBy)
+        if installed.get("blockedReason"):
+            message += "\n" + installed["blockedReason"]
+        self.versionBannerLabel.text = message
+
+        self.versionUpdateButton.visible = bool(installed.get("canUpdate"))
+        self.versionWhatsNewButton.visible = bool(status.get("compareUrl"))
+        self.versionBanner.visible = True
+
+    # ----------------------------------------------------------------- handlers
+
+    def onVersionCheckNow(self):
+        self.startVersionCheck(force=True)
+
+    def onVersionCheckEnabledToggled(self, checked):
+        self.setVersionSetting("enabled", checked)
+
+    def onVersionWhatsNew(self):
+        url = (self._versionStatus or {}).get("compareUrl") or f"https://github.com/{VERSION_CHECK_REPO}"
+        qt.QDesktopServices.openUrl(qt.QUrl(url))
+
+    def onVersionDismiss(self):
+        latestSha = (self._versionStatus or {}).get("latestSha", "")
+        if latestSha:
+            # Suppress this version only, so the next release speaks up again.
+            self.setVersionSetting("dismissedSha", latestSha)
+        self.versionBanner.visible = False
+
+    def onVersionUpdate(self):
+        installed = self._versionInstalled or {}
+        status = self._versionStatus or {}
+        targetSha = status.get("latestSha", "")
+        if not installed.get("canUpdate") or not targetSha:
+            slicer.util.messageBox(installed.get("blockedReason")
+                                   or _("MorphoDepot cannot update this installation."))
+            return
+
+        confirmation = qt.QMessageBox()
+        confirmation.setWindowTitle(_("Update MorphoDepot"))
+        confirmation.setIcon(qt.QMessageBox.Question)
+        if installed.get("shape") == SHAPE_CLONE:
+            confirmation.setText(_("Fast-forward the MorphoDepot clone to {version}?").format(
+                version=self._versionDisplayName(targetSha, status.get("latestDate", ""))))
+            confirmation.setInformativeText(_("Location: {path}").format(
+                path=installed.get("repositoryRoot", "")))
+        else:
+            confirmation.setText(_("Install MorphoDepot {version}?").format(
+                version=self._versionDisplayName(targetSha, status.get("latestDate", ""))))
+            confirmation.setInformativeText(_(
+                "The installed module files will be replaced.  A copy of the current version is "
+                "kept so the update can be undone.\n\nLocation: {path}").format(
+                    path=installed.get("moduleDirectory", "")))
+        confirmation.addButton(qt.QMessageBox.Cancel)
+        updateButton = confirmation.addButton(_("Update"), qt.QMessageBox.AcceptRole)
+        confirmation.exec_()
+        if confirmation.clickedButton() != updateButton:
+            return
+
+        slicer.app.setOverrideCursor(qt.Qt.WaitCursor)
+        try:
+            succeeded, message = self.logic.applyUpdate(installed, targetSha)
+        finally:
+            slicer.app.restoreOverrideCursor()
+
+        if not succeeded:
+            slicer.util.errorDisplay(message, windowTitle=_("MorphoDepot Update"))
+            return
+
+        self.versionBanner.visible = False
+        # Drop the cached result and re-read what is now on disk, so the Configure tab is
+        # honest even if the user picks "Later" and keeps working in this session.
+        self.setVersionSetting("lastCheckAt", "")
+        self._versionInstalled = self.logic.installedVersion()
+        self._refreshVersionDisplay()
+        self._offerReloadAfterUpdate(message)
+
+    def _offerReloadAfterUpdate(self, message):
+        """Ask how to apply the new files; never restart on the user's behalf.
+
+        Reloading is enough for a pure-Python module and keeps the scene, which matters
+        because a MorphoDepot user usually has an unsaved segmentation open.
+        """
+        prompt = qt.QMessageBox()
+        prompt.setWindowTitle(_("MorphoDepot Update"))
+        prompt.setIcon(qt.QMessageBox.Information)
+        prompt.setText(message)
+        prompt.setInformativeText(_(
+            "Reload MorphoDepot to use the new version now, or restart Slicer if anything "
+            "looks wrong afterwards."))
+        reloadButton = prompt.addButton(_("Reload MorphoDepot"), qt.QMessageBox.AcceptRole)
+        restartButton = prompt.addButton(_("Restart Slicer"), qt.QMessageBox.DestructiveRole)
+        prompt.addButton(_("Later"), qt.QMessageBox.RejectRole)
+        prompt.exec_()
+
+        clicked = prompt.clickedButton()
+        if clicked == reloadButton:
+            # Deferred: onReload destroys this widget, which is running the current slot.
+            qt.QTimer.singleShot(0, self.onReload)
+        elif clicked == restartButton:
+            if slicer.mrmlScene.GetStorableNodesModifiedSinceRead():
+                if not slicer.util.confirmOkCancelDisplay(
+                        _("There is unsaved data in the scene.  Restart Slicer anyway?")):
+                    return
+            slicer.util.restart()

--- a/MorphoDepot/MorphoDepotLib/widget_version.py
+++ b/MorphoDepot/MorphoDepotLib/widget_version.py
@@ -37,10 +37,10 @@ VERSION_POLL_DEADLINE_SECONDS = 120
 
 SHAPE_DESCRIPTIONS = {
     SHAPE_EXTENSION: "Extension Manager",
-    SHAPE_CLONE: "git clone",
-    SHAPE_DEV_CLONE: "git clone (working copy)",
-    SHAPE_BUILD_TREE: "build tree",
-    SHAPE_UNKNOWN: "unrecognized install",
+    SHAPE_CLONE: "Developer checkout",
+    SHAPE_DEV_CLONE: "Developer checkout",
+    SHAPE_BUILD_TREE: "Built from source",
+    SHAPE_UNKNOWN: "Unrecognized installation",
 }
 
 
@@ -80,6 +80,7 @@ class VersionUIMixin:
             "latestDate": self.versionSetting("latestDate"),
             "aheadBy": int(self.versionSetting("aheadBy", "0") or 0),
             "compareUrl": self.versionSetting("compareUrl"),
+            "compareStatus": self.versionSetting("compareStatus"),
             "error": "",
         }
 
@@ -89,6 +90,7 @@ class VersionUIMixin:
         self.setVersionSetting("latestDate", status.get("latestDate", ""))
         self.setVersionSetting("aheadBy", str(status.get("aheadBy", 0)))
         self.setVersionSetting("compareUrl", status.get("compareUrl", ""))
+        self.setVersionSetting("compareStatus", status.get("compareStatus", ""))
         self.setVersionSetting("lastCheckAt", datetime.datetime.now().astimezone().isoformat())
 
     # ---------------------------------------------------------------------- UI
@@ -150,6 +152,12 @@ class VersionUIMixin:
         self.configureUI.installedVersionLabel = qt.QLabel(_("Checking..."))
         self.configureUI.installedVersionLabel.wordWrap = True
         versionLayout.addRow(_("Installed:"), self.configureUI.installedVersionLabel)
+
+        # Where it came from is a separate fact from whether it is current.  Keeping them
+        # on one line made an ordinary state read like a warning.
+        self.configureUI.versionSourceLabel = qt.QLabel("")
+        self.configureUI.versionSourceLabel.wordWrap = True
+        versionLayout.addRow(_("Source:"), self.configureUI.versionSourceLabel)
 
         self.configureUI.versionStatusLabel = qt.QLabel("")
         self.configureUI.versionStatusLabel.wordWrap = True
@@ -286,10 +294,15 @@ class VersionUIMixin:
     # ------------------------------------------------------------------ display
 
     def _versionDisplayName(self, sha, date):
+        """Date first, revision in parentheses.
+
+        A date is what a user can reason about; the revision is kept visible for everyone
+        because it is the first thing worth knowing when diagnosing a report.
+        """
         if not sha:
             return _("unknown")
         label = sha[:7]
-        return f"{label} ({date})" if date else label
+        return f"{date} ({label})" if date else label
 
     def _sameRevision(self, first, second):
         """Whether two revisions are the same commit.
@@ -310,26 +323,41 @@ class VersionUIMixin:
         installed = self._versionInstalled or {}
         status = self._versionStatus or {}
 
+        self.configureUI.installedVersionLabel.text = self._versionDisplayName(
+            installed.get("sha", ""), installed.get("date", ""))
+
         shape = installed.get("shape", SHAPE_UNKNOWN)
-        installedLabel = self._versionDisplayName(installed.get("sha", ""), installed.get("date", ""))
-        self.configureUI.installedVersionLabel.text = "{version} - {shape}".format(
-            version=installedLabel, shape=SHAPE_DESCRIPTIONS.get(shape, shape))
+        source = SHAPE_DESCRIPTIONS.get(shape, shape)
+        branch = installed.get("branch", "")
+        if branch and shape in (SHAPE_CLONE, SHAPE_DEV_CLONE):
+            source = _("{source}, branch '{branch}'").format(source=source, branch=branch)
+        self.configureUI.versionSourceLabel.text = source
 
-        upToDate = self._sameRevision(installed.get("sha", ""), status.get("latestSha", ""))
+        updateAvailable = status.get("available") and not self._sameRevision(
+            installed.get("sha", ""), status.get("latestSha", ""))
+
         if status.get("error"):
-            self.configureUI.versionStatusLabel.text = status["error"]
+            statusText = status["error"]
         elif not status:
-            self.configureUI.versionStatusLabel.text = _("Not checked yet.")
-        elif status.get("available") and not upToDate:
-            self.configureUI.versionStatusLabel.text = _("Update available: {version}").format(
+            statusText = _("Not checked yet.")
+        elif updateAvailable:
+            statusText = _("Update available: {version}").format(
                 version=self._versionDisplayName(status.get("latestSha", ""), status.get("latestDate", "")))
+            # Why an update is being withheld is only worth saying when one is actually
+            # being withheld.  Said unconditionally it read as a warning about a healthy
+            # install.
+            if installed.get("blockedReason"):
+                statusText += "\n" + installed["blockedReason"]
+        elif status.get("compareStatus") == "behind":
+            # We hold commits the tracked branch does not: a development build, which is
+            # not the same thing as being level with the release.
+            statusText = _("This is a development version, ahead of the released one.")
         elif installed.get("sha"):
-            self.configureUI.versionStatusLabel.text = _("Up to date.")
+            statusText = _("Up to date.")
         else:
-            self.configureUI.versionStatusLabel.text = _("The installed version could not be determined.")
-
-        if installed.get("blockedReason"):
-            self.configureUI.versionStatusLabel.text += "\n" + installed["blockedReason"]
+            statusText = installed.get("blockedReason") or _(
+                "The installed version could not be determined.")
+        self.configureUI.versionStatusLabel.text = statusText
 
         self._refreshVersionBanner(installed, status)
 
@@ -346,12 +374,12 @@ class VersionUIMixin:
             self.versionBanner.visible = False
             return
 
-        aheadBy = status.get("aheadBy", 0)
-        message = _("A newer MorphoDepot is available: {latest} (you have {installed}).").format(
+        # Deliberately no commit count: it means nothing to the researchers this is for,
+        # and the two dates already say how far behind they are.  "What's New" is there
+        # for anyone who wants the detail.
+        message = _("MorphoDepot {latest} is available.  You have {installed}.").format(
             latest=self._versionDisplayName(latestSha, status.get("latestDate", "")),
             installed=self._versionDisplayName(installed.get("sha", ""), installed.get("date", "")))
-        if aheadBy:
-            message += " " + _("{count} commits behind.").format(count=aheadBy)
         if installed.get("blockedReason"):
             message += "\n" + installed["blockedReason"]
         self.versionBannerLabel.text = message

--- a/MorphoDepot/MorphoDepotLib/widget_version.py
+++ b/MorphoDepot/MorphoDepotLib/widget_version.py
@@ -168,6 +168,45 @@ class VersionUIMixin:
         self.configureUI.versionCheckNowButton.connect("clicked()", self.onVersionCheckNow)
         self.configureUI.versionCheckEnabledCheckBox.connect("toggled(bool)", self.onVersionCheckEnabledToggled)
 
+        self._setupVersionTestingFields()
+
+    def _setupVersionTestingFields(self):
+        """Let a developer point the check at another repository or branch.
+
+        Lives in the Testing section, which is already developer-mode-gated, because the
+        main use is testing an update against a branch before it reaches main.  It doubles
+        as an escape hatch if the repository moves again, as it has once already.
+        """
+        testingLayout = getattr(self.configureUI, "testingLayout", None)
+        if testingLayout is None:
+            return
+
+        self.configureUI.versionRepositoryLineEdit = qt.QLineEdit()
+        self.configureUI.versionRepositoryLineEdit.text = self.logic.versionCheckRepository()
+        self.configureUI.versionRepositoryLineEdit.toolTip = _(
+            "owner/name of the repository the update check compares against")
+        testingLayout.addRow(_("Update repository:"), self.configureUI.versionRepositoryLineEdit)
+
+        self.configureUI.versionBranchLineEdit = qt.QLineEdit()
+        self.configureUI.versionBranchLineEdit.text = self.logic.versionCheckBranch()
+        self.configureUI.versionBranchLineEdit.toolTip = _(
+            "branch the update check compares against")
+        testingLayout.addRow(_("Update branch:"), self.configureUI.versionBranchLineEdit)
+
+        self.configureUI.versionRepositoryLineEdit.connect(
+            "textChanged(QString)", self.onVersionRepositoryChanged)
+        self.configureUI.versionBranchLineEdit.connect(
+            "textChanged(QString)", self.onVersionBranchChanged)
+
+    def onVersionRepositoryChanged(self, text):
+        self.setVersionSetting("repository", text.strip())
+        # The cached answer was about a different repository.
+        self.setVersionSetting("lastCheckAt", "")
+
+    def onVersionBranchChanged(self, text):
+        self.setVersionSetting("branch", text.strip())
+        self.setVersionSetting("lastCheckAt", "")
+
     # ----------------------------------------------------------------- running
 
     def startVersionCheck(self, force=False):
@@ -197,6 +236,9 @@ class VersionUIMixin:
                 return
 
         installedSha = installed.get("sha", "")
+        # Resolved here, on the main thread: both read QSettings.
+        repository = self.logic.versionCheckRepository()
+        branch = self.logic.versionCheckBranch()
         try:
             environment = slicer.util.startupEnvironment()
         except Exception:
@@ -207,7 +249,8 @@ class VersionUIMixin:
 
         def check():
             try:
-                resultQueue.put(self.logic.fetchUpdateStatus(installedSha, environment))
+                resultQueue.put(self.logic.fetchUpdateStatus(
+                    installedSha, environment, repository=repository, branch=branch))
             except Exception as e:
                 logging.debug(f"MorphoDepot version check failed: {e}")
                 resultQueue.put({"available": False, "error": str(e), "latestSha": "",

--- a/MorphoDepot/Testing/Python/md_tests.py
+++ b/MorphoDepot/Testing/Python/md_tests.py
@@ -154,6 +154,69 @@ def _stress_invalid_repo_name():
     assert not H.w.createUI.createRepository.enabled, "invalid repo name should keep Create disabled"
 
 
+def _version_change_filter():
+    # Issue #203: only commits touching the installed module should raise a notice.
+    logic = H.w.logic
+    assert logic.moduleFilesChanged(["MorphoDepot/MorphoDepotLib/logic_repo.py"], 1), \
+        "a module file should count as a change"
+    assert not logic.moduleFilesChanged([".github/workflows/claude.yml", "README.md"], 2), \
+        "docs and workflow changes should not raise an update notice"
+    assert not logic.moduleFilesChanged(["MorphoDepot/Testing/Python/md_tests.py"], 1), \
+        "Testing/ is stripped by the extension build and should not count"
+    assert logic.moduleFilesChanged(["README.md"], 300), \
+        "a truncated file list should be treated as a change rather than under-reported"
+
+
+def _version_installed_shape():
+    # Whatever the install shape, detection must return a usable record and never claim
+    # it can write somewhere it cannot.
+    logic = H.w.logic
+    installed = logic.installedVersion()
+    assert installed["shape"] in (
+        "extension", "clone", "devclone", "buildtree", "unknown"), f"odd shape {installed['shape']!r}"
+    assert installed["moduleDirectory"], "the module directory should always resolve"
+    if installed["canUpdate"]:
+        assert installed["sha"], "an updatable install must know its revision"
+        assert logic._directoryIsWritable(
+            installed["repositoryRoot"] or installed["moduleDirectory"]), \
+            "canUpdate was set for a directory that is not writable"
+    else:
+        assert installed["blockedReason"], "a non-updatable install should explain why"
+
+
+def _version_banner_hidden_when_current():
+    # The banner is a notification: it must stay out of the way unless there is news.
+    H.w._versionInstalled = {"shape": "extension", "sha": "abc1234", "date": "2026-07-18",
+                             "canUpdate": True, "blockedReason": ""}
+    H.w._versionStatus = {"available": False, "latestSha": "abc1234", "latestDate": "2026-07-18",
+                          "aheadBy": 0, "compareUrl": "", "error": ""}
+    H.w._refreshVersionDisplay()
+    H.pump(20)
+    assert not H.w.versionBanner.visible, "banner should be hidden when up to date"
+
+    H.w._versionStatus = {"available": True, "latestSha": "def5678", "latestDate": "2026-07-27",
+                          "aheadBy": 12, "compareUrl": "https://example.invalid/compare", "error": ""}
+    H.w._refreshVersionDisplay()
+    H.pump(20)
+    assert H.w.versionBanner.visible, "banner should appear when an update is available"
+    assert "def5678" in H.w.versionBannerLabel.text, "banner should name the available version"
+
+    # Dismissing hides that version only, so the next release speaks up again.
+    H.w.onVersionDismiss()
+    H.pump(20)
+    assert not H.w.versionBanner.visible, "dismiss should hide the banner"
+    H.w._refreshVersionDisplay()
+    H.pump(20)
+    assert not H.w.versionBanner.visible, "a dismissed version should stay dismissed"
+    H.w._versionStatus["latestSha"] = "999aaaa"
+    H.w._refreshVersionDisplay()
+    H.pump(20)
+    assert H.w.versionBanner.visible, "a newer version should not stay dismissed"
+    H.w.onVersionDismiss()
+    H.w._versionInstalled = None
+    H.w._versionStatus = None
+
+
 TESTS = [
     ("stress_empty_segmentation_guard", _stress_empty_segmentation_guard),
     ("stress_continuous_colortable_guard", _stress_continuous_colortable_guard),
@@ -170,4 +233,7 @@ TESTS = [
     ("logic_whoami", _logic_whoami),
     ("logic_mixins_touch", _logic_mixins_touch),
     ("baseline_nochange_helper", _baseline_nochange_helper),
+    ("version_change_filter", _version_change_filter),
+    ("version_installed_shape", _version_installed_shape),
+    ("version_banner_hidden_when_current", _version_banner_hidden_when_current),
 ]


### PR DESCRIPTION
Closes #203.

Slicer's extension server only builds MorphoDepot for the Slicer version that is current, so users on an older Slicer silently stop receiving updates. The module now notices that itself and offers to fix it.

## What it does

Entering the module kicks off a background check, at most once a day. A banner appears above the tab widget -- visible from every tab -- only when `main` is ahead of the installed revision **and** the commits in between touch `MorphoDepot/`. Docs, workflow and `Experiments/` changes stay quiet. Updating is always an explicit click; nothing restarts on its own.

## Where the installed revision comes from

No `VERSION` file and no CI step to maintain one. An Extension Manager install already records the upstream commit it was built from in its `.s4ext`; a clone has git. An in-place update writes a marker next to the module recording what it applied, which cannot outlive the patch it describes: Slicer's `updateExtension()` removes the whole install directory before extracting a new build, and the marker also stores the `.s4ext` revision it was written against, so anything that replaces metadata without removing files is caught too.

## What it will and will not write to

Gated on whether writing is safe, not on how the user installed:

| Shape | Update |
|---|---|
| Extension Manager | Slicer's own updater when the server has a newer build, otherwise an in-place patch from the upstream tarball |
| Clean clone on the release branch | `git pull --ff-only` |
| Working clone (dirty, other branch, detached, fork remote) | reported, never touched |
| CMake build tree | reported, never touched -- the next build would revert it |
| Not writable, or unrecognized | reported, with instructions |

The in-place patch backs the old tree up **outside** the module directory (a backup left beside it would be scanned by Slicer's module factory and register duplicate modules), deletes files upstream no longer ships, purges stale bytecode, and verifies every installed file compiles before it stops being able to roll back. Any failure restores the backup.

The installed `qt-scripted-modules` tree is exactly this repository's `MorphoDepot/` directory minus `CMakeLists.txt` and `Testing/`, which is what makes a single copy path serve every install shape. That was verified by diffing a real Extension Manager install against the repository, not assumed -- if `MorphoDepot/CMakeLists.txt` ever ships something generated, `UPDATE_EXCLUDED_FILES` needs to keep up.

## Threading

The check deliberately does not use `MorphoDepotLogic.gh()`: that reports progress through `progressMethod()`, which calls `slicer.app.processEvents()`, and driving the Qt event loop from a worker thread would be a crash waiting to happen. A private `subprocess` wrapper is used instead, with the Windows console-hiding that `slicer.util.launchConsoleProcess` applies.

The worker only puts its result on a `queue.Queue`; a `QTimer` polls that queue from the main thread. This follows the pattern `slicer.util` uses for non-blocking process output. Posting the result with `QTimer.singleShot` from inside the worker -- the obvious approach -- would create a timer on a thread with no event loop, where it would never fire. Everything that reads Slicer state (the installed version, the startup environment, the settings) is resolved on the main thread and handed to the worker.

## Testing

Three tests added to `md_tests.py` cover the path filter, shape detection, and banner visibility including dismiss-per-version.

The in-place patch was also exercised headlessly against a copy of a real Extension Manager install: it downloaded the target revision, replaced the changed file, deleted a planted retired module, purged stale bytecode, wrote the marker, and produced a tree that diffs exactly against upstream. Rollback was tested by forcing the integrity check to fail. Two bugs surfaced that way and are fixed here: colliding backup directory names when two attempts land in the same second (which broke rollback, since the failure happened before a backup existed), and a cached "update available" surviving an update applied through some other route.

Still to be exercised in a live Slicer: banner rendering, `extensionMetadata()` marshalling, and reload-after-patch.

The compared repository and branch are settings, exposed in the developer-mode Testing section, so this can be tested against a branch before it reaches `main` -- otherwise applying a test update removes the feature being tested.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
