### PR TITLE
Show a date for an Extension Manager install, not a bare revision

### DIFF
--- a/MorphoDepot/MorphoDepotLib/logic_version.py
+++ b/MorphoDepot/MorphoDepotLib/logic_version.py
@@ -461,8 +461,8 @@ class VersionMixin:
 
         BACKGROUND THREAD SAFE -- subprocess and json only.  `repository` and `branch` are
         resolved by the caller on the main thread, since reading them touches QSettings.
-        Returns a dict with `available`, `latestSha`, `latestDate`, `aheadBy`, `compareUrl`
-        and `error`.
+        Returns a dict with `available`, `latestSha`, `latestDate`, `installedDate`,
+        `aheadBy`, `compareUrl` and `error`.
         """
         repository = repository or VERSION_CHECK_REPO
         branch = branch or VERSION_CHECK_BRANCH
@@ -470,6 +470,7 @@ class VersionMixin:
             "available": False,
             "latestSha": "",
             "latestDate": "",
+            "installedDate": "",
             "aheadBy": 0,
             "compareUrl": "",
             "compareStatus": "",
@@ -488,8 +489,12 @@ class VersionMixin:
             status["latestDate"] = (latest.get("date") or "")[:10]
             return status
 
+        # `base_date` is the installed commit's own date.  The comparison already carries it,
+        # so asking for it here costs nothing and lets the Configure tab date an install that
+        # has no update marker to read one from (a fresh Extension Manager install).
         jqFilter = (
             "{status: .status, ahead_by: .ahead_by, html_url: .html_url,"
+            " base_date: .base_commit.commit.committer.date,"
             " head_sha: (.commits | last | .sha),"
             " head_date: (.commits | last | .commit.committer.date),"
             " file_count: ((.files // []) | length),"
@@ -509,6 +514,7 @@ class VersionMixin:
         status["aheadBy"] = comparison.get("ahead_by", 0) or 0
         status["latestSha"] = comparison.get("head_sha") or installedSha
         status["latestDate"] = (comparison.get("head_date") or "")[:10]
+        status["installedDate"] = (comparison.get("base_date") or "")[:10]
 
         if comparison.get("status") == "diverged":
             # The installed revision is not an ancestor of the release branch, so "behind"

--- a/MorphoDepot/MorphoDepotLib/widget_version.py
+++ b/MorphoDepot/MorphoDepotLib/widget_version.py
@@ -301,8 +301,13 @@ class VersionUIMixin:
         installed = self._versionInstalled or {}
         status = self._versionStatus or {}
 
+        # An Extension Manager install knows its revision from the .s4ext but has no date until
+        # it has self-updated once and written a marker, so it would otherwise show a bare SHA --
+        # the one thing a researcher cannot reason about.  The update check's comparison already
+        # carries the installed commit's date; use it as the fallback.
+        installedDate = installed.get("date", "") or status.get("installedDate", "")
         self.configureUI.installedVersionLabel.text = self._versionDisplayName(
-            installed.get("sha", ""), installed.get("date", ""))
+            installed.get("sha", ""), installedDate)
 
         shape = installed.get("shape", SHAPE_UNKNOWN)
         source = SHAPE_DESCRIPTIONS.get(shape, shape)

--- a/MorphoDepot/MorphoDepotLib/widget_version.py
+++ b/MorphoDepot/MorphoDepotLib/widget_version.py
@@ -361,9 +361,14 @@ class VersionUIMixin:
         # Deliberately no commit count: it means nothing to the researchers this is for,
         # and the two dates already say how far behind they are.  "What's New" is there
         # for anyone who wants the detail.
+        # Same marker-then-comparison fallback as the Configure tab: without it the "two dates"
+        # this comment relies on are one date and a bare SHA on exactly the installs that have
+        # never self-updated.
         message = _("MorphoDepot {latest} is available.  You have {installed}.").format(
             latest=self._versionDisplayName(latestSha, status.get("latestDate", "")),
-            installed=self._versionDisplayName(installed.get("sha", ""), installed.get("date", "")))
+            installed=self._versionDisplayName(
+                installed.get("sha", ""),
+                installed.get("date", "") or status.get("installedDate", "")))
         if installed.get("blockedReason"):
             message += "\n" + installed["blockedReason"]
         self.versionBannerLabel.text = message


### PR DESCRIPTION
## Problem

The Configure tab renders the installed version as **"date (revision)"** — dates lead, because a date is what a researcher can reason about and the revision is there for diagnosing reports. But an Extension Manager install has no date to render:

- the `.s4ext` records only the **revision**
- the **date** comes from the update marker, which `applyUpdate` writes

So an install that hasn't self-updated yet — the common case, and the first thing a new user sees — falls back to a bare SHA:

```
Installed:  5d1a6b9
```

## Fix

The update check's comparison already carries the installed commit as `base_commit`, so its date is available **for free** — no extra API call, just two more fields through a path that already runs once per session (#207). The widget prefers the marker's date when there is one and falls back to the comparison's:

```python
installedDate = installed.get("date", "") or status.get("installedDate", "")
```

Result:

```
Installed:  2026-07-27 (5d1a6b9)
```

## Verification

Ran the **exact shipped jq filter** against the live API in both states:

| comparison | status | `base_date` | `head_date` |
|---|---|---|---|
| `compare/000f781...main` | `ahead` | `2026-07-27` | `2026-07-27` |
| `compare/5d1a6b9...main` | `identical` | `2026-07-27` | `null` |

The **identical** case is the one worth calling out, because it's what an up-to-date install hits. The comparison returns no commits, so `head_sha`/`head_date` come back `null` and fall back exactly as they already did — while `base_date` is still present. The date therefore appears even when there is no update to offer, which is precisely the state most installs are in most of the time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)