### PR TITLE
Say what actually happens to an unfinished repo after staging

### DIFF
--- a/MorphoDepot/MorphoDepotLib/widget_create.py
+++ b/MorphoDepot/MorphoDepotLib/widget_create.py
@@ -813,7 +813,8 @@ class CreateTabMixin:
                 "Staging completed",
                 "Staging is completed. Scene is reset.\n\n"
                 "You can go back and edit the repo by double-clicking it in the staged-only repos list.\n\n"
-                "Repos that are not requested to be made public within 14 days of staging will be discarded.")
+                "We will email you a reminder if it is still unfinished after a week. Unfinished "
+                "repositories may be removed by a MorphoDepot administrator after four weeks.")
 
     def _enterGoLiveState(self, stagedNameWithOwner):
         """Reveal the Go-live gate after a repo has been staged privately."""


### PR DESCRIPTION
The staging confirmation has always ended with:

> Repos that are not requested to be made public within 14 days of staging will be discarded.

Nothing ever enforced that — no sweep, no reminder, no deletion — so it read as an empty threat, and repos have sat staged for weeks with no contact of any kind.

MorphoDepot/morphodepot-intake#58 adds the weekly sweep that makes it real: a reminder email to the curator after a week, then weekly, and a final notice at four weeks after which an administrator may remove the repository. This changes the message to describe that ladder instead.

```
We will email you a reminder if it is still unfinished after a week. Unfinished
repositories may be removed by a MorphoDepot administrator after four weeks.
```

No behaviour change in the extension — Publish and Discard work exactly as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)