### PR TITLE
Keep the current screenshots on the release README

### DIFF
--- a/MorphoDepot/MorphoDepotLib/logic_accession.py
+++ b/MorphoDepot/MorphoDepotLib/logic_accession.py
@@ -193,7 +193,9 @@ Repository for segmentation of a specimen scan.  See [this JSON file](MorphoDepo
 
     def _readScreenshotCaptions(self, repoDir):
         """Read an existing repo's screenshots/captions.json into an ordered list of
-        (filename, caption) so the README can be regenerated without the live screenshots."""
+        (filename, caption) so the README can be regenerated without the live screenshots.
+        Ordered by screenshot NUMBER, not by name: screenshots are numbered sequentially as
+        releases add them, and a plain sort puts screenshot-10 before screenshot-2."""
         captionsPath = os.path.join(repoDir, "screenshots", "captions.json")
         if not os.path.exists(captionsPath):
             return []
@@ -202,7 +204,13 @@ Repository for segmentation of a specimen scan.  See [this JSON file](MorphoDepo
                 captions = json.load(fp)
         except Exception:
             return []
-        return [(name, captions[name]) for name in sorted(captions.keys())]
+
+        def order(name):
+            match = re.match(r"^screenshot-(\d+)\.png$", name)
+            # Anything not following the naming scheme sorts after, by name, so it still appears.
+            return (0, int(match.group(1)), "") if match else (1, 0, name)
+
+        return [(name, captions[name]) for name in sorted(captions.keys(), key=order)]
 
     def _speciesFromReadme(self, repoDir):
         """Extract the already-recorded species from a repo's committed README (the

--- a/MorphoDepot/MorphoDepotLib/logic_release.py
+++ b/MorphoDepot/MorphoDepotLib/logic_release.py
@@ -114,8 +114,10 @@ class ReleaseMixin:
     def generateReleaseReadme(self, newTag, newScreenshotEntries):
         """Build a new README.md body for the given release. Reuses metadata from
         MorphoDepotAccession.json. Links each previous release to its tag's tree on
-        GitHub so the reader sees the repository at that release stage. Lists only
-        screenshots from this release flow (older screenshots stay in their archived READMEs)."""
+        GitHub so the reader sees the repository at that release stage. Shows every
+        screenshot the repo currently carries, so the front page keeps its images through
+        a release that adds none (`newScreenshotEntries` is the fallback if captions.json
+        can't be read); older screenshots also remain in their archived READMEs."""
         repoDir = self.localRepo.working_dir
         accessionPath = os.path.join(repoDir, "MorphoDepotAccession.json")
         accession = {}
@@ -178,10 +180,16 @@ class ReleaseMixin:
         lines.append(f"* Dimensions: {scanDimensions}")
         lines.append(f"* Spacing (mm): {scanSpacing}")
 
-        if newScreenshotEntries:
+        # Every screenshot the repo currently carries -- not just this release's additions.  A
+        # release that adds none (a metadata-only one, e.g. reissuing a DOI) would otherwise strip
+        # the images off the front page even though they are still committed.  The caller has
+        # already folded this release's screenshots into captions.json, so this covers old and new
+        # alike; `newScreenshotEntries` remains the fallback if captions.json is missing/unreadable.
+        screenshotItems = self._readScreenshotCaptions(repoDir) or list(newScreenshotEntries or [])
+        if screenshotItems:
             lines.append("")
-            lines.append(f"## Screenshots for {newTag}")
-            for name, caption in newScreenshotEntries:
+            lines.append("## Screenshots")
+            for name, caption in screenshotItems:
                 altText = caption or name
                 lines.append(f"![{altText}](screenshots/{name})")
                 if caption:

--- a/MorphoDepot/MorphoDepotLib/logic_release.py
+++ b/MorphoDepot/MorphoDepotLib/logic_release.py
@@ -116,8 +116,8 @@ class ReleaseMixin:
         MorphoDepotAccession.json. Links each previous release to its tag's tree on
         GitHub so the reader sees the repository at that release stage. Shows every
         screenshot the repo currently carries, so the front page keeps its images through
-        a release that adds none (`newScreenshotEntries` is the fallback if captions.json
-        can't be read); older screenshots also remain in their archived READMEs."""
+        a release that adds none (`newScreenshotEntries` is the fallback whenever
+        captions.json yields nothing); older screenshots also remain in their archived READMEs."""
         repoDir = self.localRepo.working_dir
         accessionPath = os.path.join(repoDir, "MorphoDepotAccession.json")
         accession = {}
@@ -184,7 +184,8 @@ class ReleaseMixin:
         # release that adds none (a metadata-only one, e.g. reissuing a DOI) would otherwise strip
         # the images off the front page even though they are still committed.  The caller has
         # already folded this release's screenshots into captions.json, so this covers old and new
-        # alike; `newScreenshotEntries` remains the fallback if captions.json is missing/unreadable.
+        # alike; `newScreenshotEntries` takes over whenever that yields nothing -- missing, corrupt,
+        # or an empty captions.json -- which is also the right answer when there simply are none.
         screenshotItems = self._readScreenshotCaptions(repoDir) or list(newScreenshotEntries or [])
         if screenshotItems:
             lines.append("")


### PR DESCRIPTION
Follow-up to a real regression seen on [MorphoDepot/mus-musculus-E15](https://github.com/MorphoDepot/mus-musculus-E15).

### The problem

`generateReleaseReadme` listed only `newScreenshotEntries` — the screenshots added *during that release* — under a `## Screenshots for vN` heading. So a release that adds no screenshots produces a README with no screenshot section at all, and the repo's front page loses its images even though they are still committed and unchanged.

That happened for real: `mus-musculus-E15` v2 exists purely to reissue its DOI (the original was minted against Zenodo's sandbox), so it added nothing, and the specimen screenshot vanished from the front page. It's been restored by hand in that repo; this stops it recurring.

### The change

Render every screenshot the repo currently carries, under a plain `## Screenshots` heading. The `Screenshots for vN` wording was already misleading the moment the list stopped being release-scoped.

`prepareReleaseSnapshot` folds this release's additions into `screenshots/captions.json` *before* calling the generator, so reading the current set covers old and new alike — no separate merge needed. `newScreenshotEntries` is kept as the fallback for a missing or unreadable `captions.json`, so a corrupt captions file can't silently strip the images (the failure mode being fixed).

Older screenshots continue to appear in the archived `README-vN.md`, unchanged.

### Also: screenshot ordering (separable — easy to drop if unwanted)

`_readScreenshotCaptions` sorted `captions.keys()` lexicographically, which puts `screenshot-10.png` before `screenshot-2.png`. That was latent while the release README only showed one release's additions; listing the full set makes it visible for any repo that accumulates ten or more screenshots across releases. It now orders by the screenshot number, with names outside the `screenshot-N.png` scheme sorting after by name so nothing is dropped. This also corrects the create-time README, which already read the full set through the same helper.

### Testing

The repo has no unit-test harness for the logic mixins (they import `slicer` at module scope), so verification was:

- `py_compile` on both changed modules.
- The real `_readScreenshotCaptions` extracted from source via `ast` and executed against a fixture — confirms `1, 2, 3, 10, 11` ordering, that a non-conforming name still appears last, that captions survive, and that a missing `captions.json` returns `[]` so the fallback engages.
- The generator's new screenshot section was ported line-for-line and used to produce the corrected `mus-musculus-E15` README that is now live; that README was then diffed byte-for-byte against the ported generator's output — identical.

🤖 Generated with [Claude Code](https://claude.com/claude-code)