### PR TITLE
Load the module when git is missing instead of failing to instantiate

### DIFF
--- a/MorphoDepot/MorphoDepot.py
+++ b/MorphoDepot/MorphoDepot.py
@@ -3,7 +3,6 @@ from typing import Annotated, Optional
 import csv
 import datetime
 import fnmatch
-import git
 import glob
 import json
 import locale
@@ -19,6 +18,11 @@ import subprocess
 import sys
 import time
 import traceback
+
+# NOTE: do not add `import git` here.  GitPython raises ImportError at import time when the
+# machine has no git executable, which would stop this module from loading at all; it is imported
+# once, quietly, in MorphoDepotLib/__init__.py (see the explanation there) and reaches this file
+# through the MorphoDepotLib imports below.
 
 import ctk
 import qt
@@ -129,6 +133,7 @@ class EnableModuleMixin:
             msgBox.setWindowTitle("MorphoDepot Dependencies")
             msgBox.setText("The git and gh command line tools must be installed and configured.")
             informativeText = "Be sure that you have logged into Github with 'gh auth login' and then restart Slicer.\n"
+            informativeText += "If they are installed but Slicer cannot find them, set their locations in the Configure tab.\n"
             informativeText += "Click 'Open Documentation' for platform-specific instructions."
             msgBox.setInformativeText(informativeText)
             msgBox.setIcon(qt.QMessageBox.Warning)
@@ -858,11 +863,9 @@ class MorphoDepotLogic(ScriptedLoadableModuleLogic, DepsMixin, GitHubMixin, Cont
         self.executableExtension = '.exe' if os.name == 'nt' else ''
         modulePath = os.path.split(slicer.modules.morphodepot.path)[0]
         self.resourcesPath = os.path.normpath(modulePath + "/Resources")
-        self.pixiInstallDir = os.path.normpath(self.resourcesPath + "/pixi")
 
         # use configured git and gh paths if selected,
         # else use system installed git and gh if available
-        # Optionally install with pixi, but only if requireSystemGit is False
         # note: normpath returns "." when given ""
         gitPath = os.path.normpath(slicer.util.settingsValue("MorphoDepot/gitPath", "") or "")
         ghPath = os.path.normpath(slicer.util.settingsValue("MorphoDepot/ghPath", "") or "")
@@ -875,6 +878,11 @@ class MorphoDepotLogic(ScriptedLoadableModuleLogic, DepsMixin, GitHubMixin, Cont
 
         qt.QSettings().setValue("MorphoDepot/gitPath", self.gitExecutablePath)
         qt.QSettings().setValue("MorphoDepot/ghPath", self.ghExecutablePath)
+
+        # GitPython was imported without a git executable (see MorphoDepotLib/__init__.py), so
+        # hand it the one we just resolved.  Re-runs whenever the logic is rebuilt, which is what the
+        # Configure tab does after the user picks a git path.
+        self.refreshGitPython()
 
 class MorphoDepotTest(ScriptedLoadableModuleTest):
     """

--- a/MorphoDepot/MorphoDepotLib/__init__.py
+++ b/MorphoDepot/MorphoDepotLib/__init__.py
@@ -6,3 +6,34 @@ Everything else is split into this package by domain; the main file keeps those
 four thin and inherits behavior from per-domain mixins here. See
 docs/refactor-and-test-plan.md.
 """
+import os
+
+# GitPython runs `git version` when it is first imported and raises ImportError when no git
+# executable can be found.  Nearly every module in this package imports it, so on a machine
+# without git that ImportError propagates all the way out of MorphoDepot.py and Slicer reports
+# "Fail to instantiate module MorphoDepot" -- the module simply disappears from the module list
+# instead of telling the user what is missing.  A missing git is a condition MorphoDepot reports
+# and lets the user fix (install it, or point at it in the Configure tab), never a reason to fail
+# to load, so GitPython is imported HERE, once, with its executable search silenced.  Every
+# `import git` in this package then gets this already-initialized module.  GitPython is given a
+# real git later, by MorphoDepotLogic.refreshGitPython().
+#
+# GIT_PYTHON_REFRESH is read only while the git package is being imported, so it is restored
+# immediately: leaving it set would silence the same error for unrelated code in the Slicer
+# process (another extension importing GitPython would get a quiet, broken module rather than a
+# clear ImportError), and would override a value the user set deliberately.
+#
+# This runs in the package initializer, which Python executes before any MorphoDepotLib module,
+# so importing any part of this package -- from MorphoDepot.py, a test, or the Python console --
+# is safe.  Slicer's own git-using code imports GitPython lazily, inside functions, for the same
+# reason.
+_previousRefreshSetting = os.environ.get("GIT_PYTHON_REFRESH")
+os.environ["GIT_PYTHON_REFRESH"] = "quiet"
+try:
+    import git  # noqa: F401  (imported for its side effect: initializing GitPython quietly)
+finally:
+    if _previousRefreshSetting is None:
+        del os.environ["GIT_PYTHON_REFRESH"]
+    else:
+        os.environ["GIT_PYTHON_REFRESH"] = _previousRefreshSetting
+    del _previousRefreshSetting

--- a/MorphoDepot/MorphoDepotLib/logic_deps.py
+++ b/MorphoDepot/MorphoDepotLib/logic_deps.py
@@ -69,6 +69,28 @@ class DepsMixin:
             return False
         return True
 
+    def refreshGitPython(self):
+        """Point GitPython at the git executable this logic resolved.
+
+        GitPython's import-time search for a git executable is silenced (see __init__.py), so
+        it starts up with no git configured and every git.Repo() call would fail until it is
+        refreshed here.  This is also what makes a git chosen in the Configure tab usable when it
+        is not on PATH: without it that setting would reach the gh/subprocess calls but leave
+        GitPython pointed at nothing.
+
+        Returns True when GitPython has a working git.  A missing or unusable git is expected (the
+        user has not installed or configured one yet) and is reported by checkGitDependencies(),
+        which is what gates the UI -- so it is logged here, not raised.
+        """
+        if not self.gitExecutablePath:
+            return False
+        try:
+            git.refresh(path=self.gitExecutablePath)
+        except Exception as e:
+            logging.warning(f"MorphoDepot: GitPython could not use {self.gitExecutablePath}: {e}")
+            return False
+        return bool(git.GIT_OK)
+
     def checkGitDependencies(self):
         """Check that git, and gh are available
         """

--- a/MorphoDepot/Testing/Python/md_tests.py
+++ b/MorphoDepot/Testing/Python/md_tests.py
@@ -62,6 +62,14 @@ def _logic_mixins_touch():
     assert H.logic.volumeChecksumIndexURL(), "ObjectStoreMixin.volumeChecksumIndexURL empty"
 
 
+def _logic_gitpython_refreshed():
+    # GitPython is imported with its executable search silenced so a machine without git can
+    # still load the module, which means the logic MUST hand it a git for git.Repo() to work.
+    import git
+    assert H.logic.refreshGitPython(), "refreshGitPython() failed for a resolved git"
+    assert git.GIT_OK, "GitPython has no git executable after the logic was built"
+
+
 def _baseline_nochange_helper():
     # Unit-touch of the M6 no-change check: a file compared to itself is 'unchanged'.
     import tempfile, os, shutil
@@ -232,6 +240,7 @@ TESTS = [
     ("annotate_tab_touch", _annotate_tab_touch),
     ("logic_whoami", _logic_whoami),
     ("logic_mixins_touch", _logic_mixins_touch),
+    ("logic_gitpython_refreshed", _logic_gitpython_refreshed),
     ("baseline_nochange_helper", _baseline_nochange_helper),
     ("version_change_filter", _version_change_filter),
     ("version_installed_shape", _version_installed_shape),


### PR DESCRIPTION
## Problem

A user on Windows (Slicer 5.12.3, rev 34627) reported that MorphoDepot does not appear in the module list. The log ends with:

```
File ".../qt-scripted-modules/MorphoDepot.py", line 6, in <module>
    import git
  ...
ImportError: Failed to initialize: Bad git executable.
loadSourceAsModule - Failed to load file ".../MorphoDepot.py" as module "MorphoDepot" !
Fail to instantiate module "MorphoDepot"
```

`MorphoDepot.py` imported GitPython at module scope. GitPython runs `git version` while it is being imported and raises `ImportError` when it cannot find a git executable, so on a machine without git the import failed before any MorphoDepot code ran. The consequences:

* The module fails to instantiate and disappears from the module list.
* The user sees a raw Python traceback instead of "git and gh must be installed".
* The Configure tab — which exists precisely so the user can point at a git that is not on `PATH` — is unreachable, because the module never loads.

Nothing here is Windows-specific in mechanism; it reproduces on macOS with Slicer's own bundled GitPython (`env PATH=/nonexistent python3 -c "import git"` → the same `ImportError`). It only shows up on Windows in practice because macOS ships `/usr/bin/git` and Linux images include git, while on Windows git must be installed deliberately and its installer offers an option that keeps it off `PATH`.

This is a regression from `7391059` ("Remove unused non-system git option", 2025-09-23). Before it, GitPython was imported lazily and only when a git executable existed:

```python
self.git = None
if os.path.exists(self.gitExecutablePath):
    self.importGitPython()   # set GIT_PYTHON_GIT_EXECUTABLE, import git, git.refresh(path=...)
```

With no git, `self.git` stayed `None`, the module loaded, and the dependency dialog told the user what to install. That commit deleted `importGitPython()`, added the top-level `import git`, and rewrote every `self.git.X` to `git.X`.

## Changes

* **`MorphoDepotLib/__init__.py`** — import GitPython once, in the package initializer, with `GIT_PYTHON_REFRESH=quiet` so the executable probe cannot raise. The variable is restored immediately afterwards (it is read only while the git package is being imported), so the setting does not leak to other code in the Slicer process — another extension importing GitPython still gets a normal, loud `ImportError` rather than a quiet, broken module. Every `import git` in the package then binds the already-initialized module, and `MorphoDepot.py` picks it up through its `MorphoDepotLib` imports.
* **`MorphoDepot.py`** — drop the top-level `import git` (the file never used the name directly; its one use is `logic.localRepo.git.pull(...)`, an attribute), with a note not to re-add it.
* **`MorphoDepotLib/logic_deps.py`** — new `MorphoDepotLogic.refreshGitPython()`, restoring the `git.refresh(path=...)` that went out with `importGitPython()`. Called from `MorphoDepotLogic.__init__` once the git path is resolved, and therefore re-run whenever the Configure tab rebuilds the logic after the user picks a path. Without it GitPython would remain unusable even where git *is* installed, and a git configured in Configure but absent from `PATH` would work for the gh/subprocess calls while every `git.Repo()` call failed. A missing or unusable git is logged, not raised — `checkGitDependencies()` is what gates the UI.
* **`MorphoDepot.py`** — the dependency dialog now also says the locations can be set in the Configure tab, which is the actionable step when git is installed but not on `PATH`.
* Dropped two leftover `pixi` references (`self.pixiInstallDir` and a stale comment) in the block being edited; pixi was removed in `7391059`.
* **`Testing/Python/md_tests.py`** — `logic_gitpython_refreshed` asserts `refreshGitPython()` succeeds and `git.GIT_OK` is set, so the refresh wiring cannot be dropped again silently.

## Behavior after this change

| | before | after |
|---|---|---|
| git installed and on `PATH` | works | works (GitPython now explicitly refreshed onto that git) |
| git installed, not on `PATH`, path set in Configure | gh calls work, every `git.Repo()` fails | works |
| no git at all | module fails to instantiate, raw traceback | module loads; tabs stay disabled and the dependency dialog explains what to install |

## Verification

Against Slicer's own bundled GitPython (3.1.50 locally; Slicer pins 3.1.45), with `PATH` emptied so no git is findable:

* the package initializer imports cleanly, `git.GIT_OK` is `False`, and `GIT_PYTHON_REFRESH` is back to unset afterwards;
* `git.refresh(path="/usr/bin/git")` then sets `GIT_OK` to `True` and `git.Repo.init()` works with an empty `PATH` — i.e. the Configure-tab path really is enough;
* `git.refresh()` on a bad path raises `GitCommandNotFound`, which `refreshGitPython()` catches and reports as `False`.

Not yet exercised inside a running Slicer on a git-less Windows box — that is the case the reporter can confirm.