### PR TITLE
Let gh find a git that is not on the system PATH

### DIFF
--- a/MorphoDepot/MorphoDepotLib/logic_deps.py
+++ b/MorphoDepot/MorphoDepotLib/logic_deps.py
@@ -105,11 +105,22 @@ class DepsMixin:
         empty dict when the child's PATH already covers both directories.  The child environment
         is the startup environment, not this process's, so that is what is extended.
         """
+        # Windows paths are case-insensitive and a path typed into the Configure tab need not
+        # match the one a QFileDialog produced, so every comparison here is on the normalized
+        # form: C:\Program Files\GitHub CLI and c:\program files\github cli\ are one directory
+        # and must not be prepended twice -- whether the duplication comes from git and gh
+        # living together or from the directory already being on the child's PATH.
+        def pathKey(path):
+            return os.path.normcase(os.path.normpath(path))
+
         directories = []
+        keys = set()
         for executablePath in (self.gitExecutablePath, self.ghExecutablePath):
             directory = os.path.dirname(executablePath) if executablePath else ""
-            if directory and directory not in directories:
-                directories.append(directory)
+            if not directory or pathKey(directory) in keys:
+                continue
+            keys.add(pathKey(directory))
+            directories.append(directory)
         if not directories:
             return {}
         try:
@@ -117,12 +128,8 @@ class DepsMixin:
         except Exception:
             basePath = os.environ.get("PATH", "")
         entries = [entry for entry in basePath.split(os.pathsep) if entry]
-        # Windows paths are case-insensitive and the Configure tab hands back a normalized path,
-        # so compare normalized: C:\Program Files\GitHub CLI and c:\program files\github cli\ are
-        # the same directory and must not be prepended twice.
-        present = {os.path.normcase(os.path.normpath(entry)) for entry in entries}
-        missing = [directory for directory in directories
-                   if os.path.normcase(os.path.normpath(directory)) not in present]
+        present = {pathKey(entry) for entry in entries}
+        missing = [directory for directory in directories if pathKey(directory) not in present]
         if not missing:
             return {}
         return {"PATH": os.pathsep.join(missing + entries)}

--- a/MorphoDepot/MorphoDepotLib/logic_deps.py
+++ b/MorphoDepot/MorphoDepotLib/logic_deps.py
@@ -91,6 +91,42 @@ class DepsMixin:
             return False
         return bool(git.GIT_OK)
 
+    def toolPathEnvironmentUpdate(self):
+        """PATH override that lets a child process find the git and gh we were configured with.
+
+        MorphoDepot always calls git and gh by absolute path, but those two tools call each other
+        BY NAME: `gh repo clone` runs git, and the credential helper `gh auth setup-git` installs
+        runs gh.  So a tool the user selected in the Configure tab -- a portable install that was
+        never added to PATH, which is the whole reason that setting exists -- is invisible to the
+        other one, and gh fails with "unable to find git executable in PATH".
+
+        Returns a dict suitable for slicer.util.launchConsoleProcess's updateEnvironment (which
+        REPLACES a variable rather than extending it, so the full value is built here), or an
+        empty dict when the child's PATH already covers both directories.  The child environment
+        is the startup environment, not this process's, so that is what is extended.
+        """
+        directories = []
+        for executablePath in (self.gitExecutablePath, self.ghExecutablePath):
+            directory = os.path.dirname(executablePath) if executablePath else ""
+            if directory and directory not in directories:
+                directories.append(directory)
+        if not directories:
+            return {}
+        try:
+            basePath = slicer.util.startupEnvironment().get("PATH", "")
+        except Exception:
+            basePath = os.environ.get("PATH", "")
+        entries = [entry for entry in basePath.split(os.pathsep) if entry]
+        # Windows paths are case-insensitive and the Configure tab hands back a normalized path,
+        # so compare normalized: C:\Program Files\GitHub CLI and c:\program files\github cli\ are
+        # the same directory and must not be prepended twice.
+        present = {os.path.normcase(os.path.normpath(entry)) for entry in entries}
+        missing = [directory for directory in directories
+                   if os.path.normcase(os.path.normpath(directory)) not in present]
+        if not missing:
+            return {}
+        return {"PATH": os.pathsep.join(missing + entries)}
+
     def checkGitDependencies(self):
         """Check that git, and gh are available
         """

--- a/MorphoDepot/MorphoDepotLib/logic_github.py
+++ b/MorphoDepot/MorphoDepotLib/logic_github.py
@@ -54,16 +54,21 @@ class GitHubMixin:
         self.progressMethod(" ".join(commandList))
         fullCommandList = [self.ghExecutablePath] + commandList
 
+        # S6: give gh a UTF-8 locale via the child's environment.  The previous code mutated the
+        # Python process C-locale, which (a) raised locale.Error and broke every gh call on hosts
+        # where en_US.UTF-8 isn't generated (minimal Linux/CI), and (b) doesn't even propagate to
+        # the spawned child -- the subprocess env is what gh actually reads.
+        # The PATH entry is what lets `gh repo clone` (and the rest of gh's git-backed commands)
+        # find a git that is not on the system PATH -- a portable git chosen in the Configure tab.
+        updateEnvironment = {"LC_ALL": "en_US.UTF-8", "LANG": "en_US.UTF-8"}
+        updateEnvironment.update(self.toolPathEnvironmentUpdate())
+
         baseDelay = 1
         attempts = 4
         for attempt in range(attempts):
-            # S6: give gh a UTF-8 locale via the child's environment.  The previous code mutated the
-            # Python process C-locale, which (a) raised locale.Error and broke every gh call on hosts
-            # where en_US.UTF-8 isn't generated (minimal Linux/CI), and (b) doesn't even propagate to
-            # the spawned child -- the subprocess env is what gh actually reads.
             process = slicer.util.launchConsoleProcess(
                 fullCommandList,
-                updateEnvironment={"LC_ALL": "en_US.UTF-8", "LANG": "en_US.UTF-8"})
+                updateEnvironment=updateEnvironment)
             try:
                 # S7: a hung or auth-prompting gh child must not block the Slicer UI thread forever.
                 result = process.communicate(timeout=timeout)

--- a/MorphoDepot/Testing/Python/md_tests.py
+++ b/MorphoDepot/Testing/Python/md_tests.py
@@ -80,6 +80,8 @@ def _logic_tool_path_environment():
     entries = {os.path.normcase(os.path.normpath(entry))
                for entry in childPath.split(os.pathsep) if entry}
     for executablePath in (H.logic.gitExecutablePath, H.logic.ghExecutablePath):
+        if not executablePath:
+            continue  # nothing configured yet -- checkGitDependencies() is what reports that
         directory = os.path.normcase(os.path.normpath(os.path.dirname(executablePath)))
         assert directory in entries, f"{executablePath} directory missing from the gh child PATH"
 

--- a/MorphoDepot/Testing/Python/md_tests.py
+++ b/MorphoDepot/Testing/Python/md_tests.py
@@ -70,6 +70,20 @@ def _logic_gitpython_refreshed():
     assert git.GIT_OK, "GitPython has no git executable after the logic was built"
 
 
+def _logic_tool_path_environment():
+    # gh runs git BY NAME, so whatever PATH a gh child gets must contain both tools' directories
+    # -- otherwise a git picked in the Configure tab but absent from the system PATH gives
+    # "unable to find git executable in PATH" on clone.  Empty update == already reachable.
+    import os
+    update = H.logic.toolPathEnvironmentUpdate()
+    childPath = update.get("PATH") or slicer.util.startupEnvironment().get("PATH", "")
+    entries = {os.path.normcase(os.path.normpath(entry))
+               for entry in childPath.split(os.pathsep) if entry}
+    for executablePath in (H.logic.gitExecutablePath, H.logic.ghExecutablePath):
+        directory = os.path.normcase(os.path.normpath(os.path.dirname(executablePath)))
+        assert directory in entries, f"{executablePath} directory missing from the gh child PATH"
+
+
 def _baseline_nochange_helper():
     # Unit-touch of the M6 no-change check: a file compared to itself is 'unchanged'.
     import tempfile, os, shutil
@@ -241,6 +255,7 @@ TESTS = [
     ("logic_whoami", _logic_whoami),
     ("logic_mixins_touch", _logic_mixins_touch),
     ("logic_gitpython_refreshed", _logic_gitpython_refreshed),
+    ("logic_tool_path_environment", _logic_tool_path_environment),
     ("baseline_nochange_helper", _baseline_nochange_helper),
     ("version_change_filter", _version_change_filter),
     ("version_installed_shape", _version_installed_shape),


### PR DESCRIPTION
## Problem

Follow-up to #213, found while testing that fix on Windows. With a valid git selected in the Configure tab, double-clicking an issue in Annotate fails:

```
File ".../MorphoDepotLib/logic_repo.py", line 115, in loadIssue
    self.gh(["repo", "clone", cloneTarget, localDirectory])
RuntimeError: gh command failed: repo clone muratmaga/rana-clamitans-full-body ...
Output: ('unable to find git executable in PATH; please install Git for Windows before retrying\n', None)
```

The Configure tab held `C:\Users\murat\Downloads\PortableGit\bin\git.exe` — a portable git that is not on the system `PATH`.

MorphoDepot always invokes git and gh **by absolute path**, so the Configure setting works for everything MorphoDepot runs itself (and, since #213, for GitPython too). But the two tools invoke **each other by name**:

* `gh repo clone` / `gh repo sync` and friends shell out to `git`;
* the credential helper `gh auth setup-git` installs runs `gh`.

So a tool that is not on `PATH` — precisely the case the Configure tab exists to serve — is invisible to the other one, and gh fails before it does any work. `#213` made the module load and be configurable without git on `PATH`; this makes that configuration actually usable.

## Changes

* **`logic_deps.py`** — new `toolPathEnvironmentUpdate()`. Returns `{"PATH": ...}` built from the startup environment plus the directories holding the configured git and gh, or `{}` when both are already reachable. `launchConsoleProcess`'s `updateEnvironment` *replaces* a variable rather than extending it, so the full value has to be composed here; and the child gets the **startup** environment (not this process's), so that is what gets extended. Comparison is case- and separator-insensitive, since these are Windows paths from a `QFileDialog`.
* **`logic_github.py`** — `gh()` merges that into the child environment it already builds for `LC_ALL`/`LANG`. Moved out of the retry loop, since it is the same for every attempt.
* **`md_tests.py`** — `logic_tool_path_environment` asserts that whatever PATH a gh child ends up with contains both tools' directories, in both the "already on PATH" and "needs prepending" cases.

## Deliberately not changed

The **process-wide** `PATH` is left alone. git spawned by GitPython inherits it, so extending it would also fix the mirror-image case (a portable *gh* invisible to git's credential helper) — but prepending a portable git's `bin` directory puts its `bash.exe` and `sh.exe` ahead of everything else for every subprocess Slicer launches, which is a poor trade for a case nobody has hit. Worth revisiting if it ever shows up.

## Verification

The helper's behavior, exercised with real Windows path semantics (`ntpath`, `;` separator) and the paths from the failing machine:

| case | result |
|---|---|
| git not on PATH, gh is | prepends only `C:\Users\murat\Downloads\PortableGit\bin` |
| both already on PATH | `{}` — PATH untouched |
| PATH entry differs by case / trailing slash | `{}` — recognized as the same directory, not prepended twice |
| neither configured yet | `{}` |

Not yet run against a live clone on the Windows box — that is the check that closes this out.