### PR TITLE
Sign in to GitHub per repository, through gh

### DIFF
--- a/MorphoDepot/MorphoDepot.py
+++ b/MorphoDepot/MorphoDepot.py
@@ -144,6 +144,25 @@ class EnableModuleMixin:
                 qt.QDesktopServices.openUrl(qt.QUrl("https://github.com/SlicerMorph/SlicerMorphoDepot?tab=readme-ov-file#prerequisites-for-morphodepot"))
             return False
 
+        # check that saving back to GitHub will actually be possible.  Deliberately here and not at
+        # Commit: with a working login but no credential helper, everything looks fine until the
+        # push, so the failure used to land after the segmentation was finished.  This does not
+        # gate the module -- searching and browsing need no credential -- so a failure warns and
+        # continues.
+        if not self.logic.ensureGitCredentialHelper():
+            msgBox = qt.QMessageBox()
+            msgBox.setWindowTitle("MorphoDepot GitHub Sign-in")
+            msgBox.setText("MorphoDepot can read from GitHub, but cannot yet save your work back to it.")
+            informativeText = "Saving a segmentation will fail until this is fixed.\n\n"
+            informativeText += "In a terminal window, run:  gh auth setup-git\n"
+            informativeText += "then come back to Slicer and reopen this module.\n\n"
+            informativeText += "If that command reports that it cannot find git, add the folder holding "
+            informativeText += "git to your system PATH, or install git so that it is on the PATH, and run it again."
+            msgBox.setInformativeText(informativeText)
+            msgBox.setIcon(qt.QMessageBox.Warning)
+            msgBox.addButton(qt.QMessageBox.Ok)
+            msgBox.exec_()
+
         # check local directory
         repoDirectory = self.logic.localRepositoryDirectory()
         if not os.path.exists(repoDirectory):

--- a/MorphoDepot/MorphoDepot.py
+++ b/MorphoDepot/MorphoDepot.py
@@ -144,34 +144,11 @@ class EnableModuleMixin:
                 qt.QDesktopServices.openUrl(qt.QUrl("https://github.com/SlicerMorph/SlicerMorphoDepot?tab=readme-ov-file#prerequisites-for-morphodepot"))
             return False
 
-        # check that saving back to GitHub will actually be possible.  Deliberately here and not at
-        # Commit: with a working login but no credential helper, everything looks fine until the
-        # push, so the failure used to land after the segmentation was finished.  This does not
-        # gate the module -- searching and browsing need no credential -- so a failure warns and
-        # continues.
-        # Warned once per session, not once per enter: a user who cannot fix this right now must
-        # not have to dismiss the same dialog on every visit to the module.  The check itself
-        # still runs each time, so a sign-in fixed elsewhere is picked up without a restart.
-        if not self.logic.ensureGitCredentialHelper() and not getattr(self, "gitCredentialWarningShown", False):
-            self.gitCredentialWarningShown = True
-            msgBox = qt.QMessageBox()
-            msgBox.setWindowTitle("MorphoDepot GitHub Sign-in")
-            msgBox.setText("MorphoDepot can read from GitHub, but cannot yet save your work back to it.")
-            # Does NOT tell the user to run `gh auth setup-git`: that is exactly what MorphoDepot
-            # just tried, under better conditions than a terminal can offer (it hands gh the git
-            # from the Configure tab, #214).  Recommending it again would send the user to a
-            # command that has already failed for them.  What actually helps is the cause.
-            informativeText = "Saving a segmentation will fail until this is fixed, so it is worth "
-            informativeText += "sorting out before you start work.\n\n"
-            informativeText += "MorphoDepot already tried to set this up for you and could not.\n\n"
-            informativeText += "The usual cause is that git is not on your system PATH: add the folder "
-            informativeText += "holding git to it, or install a git that puts itself there, then restart Slicer.\n\n"
-            informativeText += "If git is already on the PATH, open a terminal, run:  gh auth login\n"
-            informativeText += "and complete every step, then reopen this module."
-            msgBox.setInformativeText(informativeText)
-            msgBox.setIcon(qt.QMessageBox.Warning)
-            msgBox.addButton(qt.QMessageBox.Ok)
-            msgBox.exec_()
+        # No credential check here any more.  Signing in is configured per REPOSITORY, at the
+        # moment each one is cloned or created (configureRepositoryCredentials), delegating to the
+        # active gh account -- so there is no global state left to be wrong, nothing to warn about
+        # on the way in, and no probe on the UI thread.  `gh auth status` in checkGitDependencies
+        # above is what establishes that gh can sign in at all, which is now the only requirement.
 
         # check local directory
         repoDirectory = self.logic.localRepositoryDirectory()

--- a/MorphoDepot/MorphoDepot.py
+++ b/MorphoDepot/MorphoDepot.py
@@ -149,15 +149,25 @@ class EnableModuleMixin:
         # push, so the failure used to land after the segmentation was finished.  This does not
         # gate the module -- searching and browsing need no credential -- so a failure warns and
         # continues.
-        if not self.logic.ensureGitCredentialHelper():
+        # Warned once per session, not once per enter: a user who cannot fix this right now must
+        # not have to dismiss the same dialog on every visit to the module.  The check itself
+        # still runs each time, so a sign-in fixed elsewhere is picked up without a restart.
+        if not self.logic.ensureGitCredentialHelper() and not getattr(self, "gitCredentialWarningShown", False):
+            self.gitCredentialWarningShown = True
             msgBox = qt.QMessageBox()
             msgBox.setWindowTitle("MorphoDepot GitHub Sign-in")
             msgBox.setText("MorphoDepot can read from GitHub, but cannot yet save your work back to it.")
-            informativeText = "Saving a segmentation will fail until this is fixed.\n\n"
-            informativeText += "In a terminal window, run:  gh auth setup-git\n"
-            informativeText += "then come back to Slicer and reopen this module.\n\n"
-            informativeText += "If that command reports that it cannot find git, add the folder holding "
-            informativeText += "git to your system PATH, or install git so that it is on the PATH, and run it again."
+            # Does NOT tell the user to run `gh auth setup-git`: that is exactly what MorphoDepot
+            # just tried, under better conditions than a terminal can offer (it hands gh the git
+            # from the Configure tab, #214).  Recommending it again would send the user to a
+            # command that has already failed for them.  What actually helps is the cause.
+            informativeText = "Saving a segmentation will fail until this is fixed, so it is worth "
+            informativeText += "sorting out before you start work.\n\n"
+            informativeText += "MorphoDepot already tried to set this up for you and could not.\n\n"
+            informativeText += "The usual cause is that git is not on your system PATH: add the folder "
+            informativeText += "holding git to it, or install a git that puts itself there, then restart Slicer.\n\n"
+            informativeText += "If git is already on the PATH, open a terminal, run:  gh auth login\n"
+            informativeText += "and complete every step, then reopen this module."
             msgBox.setInformativeText(informativeText)
             msgBox.setIcon(qt.QMessageBox.Warning)
             msgBox.addButton(qt.QMessageBox.Ok)

--- a/MorphoDepot/MorphoDepotLib/logic_accession.py
+++ b/MorphoDepot/MorphoDepotLib/logic_accession.py
@@ -345,6 +345,9 @@ jobs:
 
         # create initial repo
         repo = git.Repo.init(repoDir, initial_branch='main')
+        # Configured on the freshly created repo, before the push below, for the same
+        # reason as the clones: the push must go up as the active gh account.
+        self.configureRepositoryCredentials(repo)
 
         repoFileNames += [
             "README.md",
@@ -924,6 +927,7 @@ jobs:
             shutil.rmtree(repoDir, ignore_errors=True)
         self.gh(["repo", "clone", nameWithOwner, repoDir])
         self.localRepo = git.Repo(repoDir)
+        self.configureRepositoryCredentials(self.localRepo)
 
         accession = {}
         accessionPath = os.path.join(repoDir, "MorphoDepotAccession.json")

--- a/MorphoDepot/MorphoDepotLib/logic_contribute.py
+++ b/MorphoDepot/MorphoDepotLib/logic_contribute.py
@@ -76,11 +76,20 @@ class ContributeMixin:
         except git.exc.GitCommandError as e:
             if not self.isMissingCredentialError(e):
                 raise
+            # Says what actually helps, not "run gh auth setup-git": the module has already tried
+            # that on the way in, with the git from the Configure tab handed to gh (#214), so a
+            # user reaching this message has watched the recommended command fail.  This is the
+            # worst possible moment to send them somewhere that does not work.
             raise RuntimeError(
                 "Your segmentation was saved on this computer, but could not be sent to GitHub "
-                "because MorphoDepot could not sign in.\n\n"
-                "In a terminal window, run:  gh auth setup-git\n"
-                "then click Commit again -- your work is still here and nothing has been lost.") from e
+                "because MorphoDepot could not sign in. Nothing has been lost -- the work is "
+                "here and will go up once this is sorted out.\n\n"
+                "MorphoDepot already tried to set up the sign-in for you automatically. The usual "
+                "cause is that git is not on your system PATH: add the folder holding git to it, "
+                "or install a git that puts itself there, then restart Slicer, open this issue "
+                "again and click Commit.\n\n"
+                "If git is already on the PATH, open a terminal, run:  gh auth login\n"
+                "and complete every step, then try again.") from e
         for pi in pushInfoList:
             for flag in [pi.REJECTED, pi.REMOTE_REJECTED, pi.REMOTE_FAILURE, pi.ERROR]:
                 if pi.flags & flag:

--- a/MorphoDepot/MorphoDepotLib/logic_contribute.py
+++ b/MorphoDepot/MorphoDepotLib/logic_contribute.py
@@ -28,6 +28,23 @@ from slicer.i18n import translate
 
 
 class ContributeMixin:
+    # What git says when nothing could supply a GitHub credential and it has no one to ask.  The
+    # first is what it reports with prompting disabled (see gitNonInteractiveEnvironment); the
+    # others are what earlier versions surfaced -- an inherited askpass program that failed, or the
+    # raw terminal read failing on a process with no console ("Device not configured" on macOS,
+    # "No such file or directory" on Windows).  Matched so the user gets told what to fix instead
+    # of a traceback, at the one moment that is most expensive: the end of a segmentation session.
+    missingCredentialMarkers = (
+        "could not read Username",
+        "terminal prompts disabled",
+        "failed to execute prompt script",
+    )
+
+    def isMissingCredentialError(self, error):
+        """True when a git failure is 'no GitHub credential available', not a real push rejection."""
+        text = f"{getattr(error, 'stderr', '') or ''}\n{error}"
+        return any(marker in text for marker in self.missingCredentialMarkers)
+
     def commitAndPush(self, message):
         """Create a PR if needed and push current segmentation
         Mark the PR as a draft
@@ -43,16 +60,27 @@ class ContributeMixin:
         branchName = self.localRepo.active_branch.name
         remote = self.localRepo.remote(name="origin")
 
-        # rebase branch if it exists in case other changes have been made (e.g. on another machine)
-        branchNames = [branch.name.split("/")[1] for branch in self.localRepo.remotes['origin'].refs]
-        if branchName in branchNames:
-            pullResult = self.localRepo.git.pull(f"--rebase", "origin", branchName)
-            self.progressMethod(pullResult)
+        # The segmentation is saved and committed locally by this point, so anything that fails
+        # from here on has cost the user nothing but the upload -- which is what the message says.
+        try:
+            # rebase branch if it exists in case other changes have been made (e.g. on another machine)
+            branchNames = [branch.name.split("/")[1] for branch in self.localRepo.remotes['origin'].refs]
+            if branchName in branchNames:
+                pullResult = self.localRepo.git.pull(f"--rebase", "origin", branchName)
+                self.progressMethod(pullResult)
 
-        # Workaround for missing origin.push().raise_if_error() in 3.1.14
-        # (see https://github.com/gitpython-developers/GitPython/issues/621):
-        # https://github.com/gitpython-developers/GitPython/issues/621
-        pushInfoList = remote.push(branchName)
+            # Workaround for missing origin.push().raise_if_error() in 3.1.14
+            # (see https://github.com/gitpython-developers/GitPython/issues/621):
+            # https://github.com/gitpython-developers/GitPython/issues/621
+            pushInfoList = remote.push(branchName)
+        except git.exc.GitCommandError as e:
+            if not self.isMissingCredentialError(e):
+                raise
+            raise RuntimeError(
+                "Your segmentation was saved on this computer, but could not be sent to GitHub "
+                "because MorphoDepot could not sign in.\n\n"
+                "In a terminal window, run:  gh auth setup-git\n"
+                "then click Commit again -- your work is still here and nothing has been lost.") from e
         for pi in pushInfoList:
             for flag in [pi.REJECTED, pi.REMOTE_REJECTED, pi.REMOTE_FAILURE, pi.ERROR]:
                 if pi.flags & flag:

--- a/MorphoDepot/MorphoDepotLib/logic_contribute.py
+++ b/MorphoDepot/MorphoDepotLib/logic_contribute.py
@@ -28,12 +28,22 @@ from slicer.i18n import translate
 
 
 class ContributeMixin:
-    # What git says when nothing could supply a GitHub credential and it has no one to ask.  The
-    # first is what it reports with prompting disabled (see gitNonInteractiveEnvironment); the
-    # others are what earlier versions surfaced -- an inherited askpass program that failed, or the
-    # raw terminal read failing on a process with no console ("Device not configured" on macOS,
-    # "No such file or directory" on Windows).  Matched so the user gets told what to fix instead
-    # of a traceback, at the one moment that is most expensive: the end of a segmentation session.
+    # What git says when nothing could supply a GitHub credential and it has no one to ask.
+    #
+    # Only the FIRST of these is load-bearing, and it is worth knowing why it is safe: git raises
+    # it from prompt.c as die("could not read %s%s", ...), which upstream does NOT wrap in _().
+    # That string is therefore never translated, so matching it survives a non-English install --
+    # the kind of assumption someone later "fixes" by forcing a locale, so it is written down.
+    #
+    # The other two are historical and defensive.  "terminal prompts disabled" is the tail of the
+    # same message once GIT_TERMINAL_PROMPT=0 is in force (see gitNonInteractiveEnvironment), and
+    # "failed to execute prompt script" is a Git-for-Windows flavor, not an upstream string at all
+    # -- current git emits "unable to read askpass response from ..." or "cannot exec ..." there.
+    # Those are deliberately absent: every one of them is accompanied by "could not read Username"
+    # on the following line, so the first marker already covers them.
+    #
+    # Matched so the user gets told what to fix instead of a traceback, at the one moment that is
+    # most expensive: the end of a segmentation session.
     missingCredentialMarkers = (
         "could not read Username",
         "terminal prompts disabled",
@@ -76,20 +86,16 @@ class ContributeMixin:
         except git.exc.GitCommandError as e:
             if not self.isMissingCredentialError(e):
                 raise
-            # Says what actually helps, not "run gh auth setup-git": the module has already tried
-            # that on the way in, with the git from the Configure tab handed to gh (#214), so a
-            # user reaching this message has watched the recommended command fail.  This is the
-            # worst possible moment to send them somewhere that does not work.
+            # This repository is configured to sign in through gh (configureRepositoryCredentials),
+            # so reaching here means gh itself could not produce a credential -- signed out, or a
+            # token that has expired or been revoked.  There is nothing about git configuration
+            # for the user to fix, so the message names the one thing that does help.
             raise RuntimeError(
                 "Your segmentation was saved on this computer, but could not be sent to GitHub "
                 "because MorphoDepot could not sign in. Nothing has been lost -- the work is "
-                "here and will go up once this is sorted out.\n\n"
-                "MorphoDepot already tried to set up the sign-in for you automatically. The usual "
-                "cause is that git is not on your system PATH: add the folder holding git to it, "
-                "or install a git that puts itself there, then restart Slicer, open this issue "
-                "again and click Commit.\n\n"
-                "If git is already on the PATH, open a terminal, run:  gh auth login\n"
-                "and complete every step, then try again.") from e
+                "here and will go up once you are signed in again.\n\n"
+                "Open a terminal window, run:  gh auth login\n"
+                "and complete every step, then come back and click Commit again.") from e
         for pi in pushInfoList:
             for flag in [pi.REJECTED, pi.REMOTE_REJECTED, pi.REMOTE_FAILURE, pi.ERROR]:
                 if pi.flags & flag:

--- a/MorphoDepot/MorphoDepotLib/logic_deps.py
+++ b/MorphoDepot/MorphoDepotLib/logic_deps.py
@@ -197,7 +197,14 @@ class DepsMixin:
         empty credential.helper resets the accumulated list, so only this one runs.  (That is the
         same two-entry shape `gh auth setup-git` writes globally.)
 
-        Returns True when the repository was configured.
+        The reset also suppresses a helper the user configured DELIBERATELY for github.com --
+        inside MorphoDepot's own clones, and nowhere else.  That is the intent (it is what closes
+        the wrong-account hazard above), but it is a real behavior change for anyone with a
+        curated credential setup, so it is written down rather than left to be discovered.
+
+        Returns True when the repository was configured.  Callers do not check it: the only way
+        to fail early is a missing gh, which checkGitDependencies() has already made impossible
+        by gating the UI, and a later failure is undone below rather than left half-applied.
         """
         if not self.ghExecutablePath:
             logging.warning("MorphoDepot: no gh to configure repository credentials with")
@@ -218,6 +225,17 @@ class DepsMixin:
             repo.git.config("--local", "credential.interactive", "false")
         except Exception as e:
             logging.warning(f"MorphoDepot: could not configure repository credentials: {e}")
+            # Undo a PARTIAL write.  The two commands are not atomic, and the order matters: if
+            # the reset lands but the helper does not, the repository is left WORSE than before
+            # this ran -- an empty accumulated list suppresses the machine's own helpers with
+            # nothing put in their place, so the push fails and commitAndPush tells the user to
+            # run `gh auth login`, which cannot fix a local config write.  Unsetting the key
+            # returns the repository to its previous behavior (whatever global helper it had),
+            # which may well work.  Failing open beats failing closed and misdiagnosed.
+            try:
+                repo.git.config("--local", "--unset-all", helperKey)
+            except Exception:
+                pass
             return False
         return True
 

--- a/MorphoDepot/MorphoDepotLib/logic_deps.py
+++ b/MorphoDepot/MorphoDepotLib/logic_deps.py
@@ -69,6 +69,37 @@ class DepsMixin:
             return False
         return True
 
+    # Environment that makes git fail instead of trying to ask a human for a password.  git only
+    # reaches for a prompt when no credential helper answered, and inside Slicer there is nobody
+    # to ask: there is no console for the terminal prompt, and an askpass program inherited from
+    # whatever launched Slicer (VS Code sets GIT_ASKPASS for the terminals it spawns) is no longer
+    # connected to anything.  Without this, a push with no credential dies deep in git with
+    # "failed to execute prompt script" / "could not read Username", which says nothing about the
+    # actual problem; with it, the failure is immediate and identifiable ("terminal prompts
+    # disabled"), which is what commitAndPush turns into an explanation the user can act on.
+    #
+    # Empty strings rather than deletions: these variables can be INHERITED from the process that
+    # launched Slicer, and GitPython layers its own overrides over os.environ, so removing them
+    # here would not keep them out of the child.  git tests the askpass value with `*askpass`, so
+    # an empty string reads as "none configured" -- which is exactly what is wanted.
+    gitNonInteractiveEnvironment = {
+        "GIT_TERMINAL_PROMPT": "0",
+        "GIT_ASKPASS": "",
+        "SSH_ASKPASS": "",
+    }
+
+    def applyGitNonInteractiveEnvironment(self):
+        """Apply gitNonInteractiveEnvironment to this process, for every git child that follows.
+
+        Set process-wide rather than per-repository on purpose: GitPython copies os.environ at
+        each invocation, so this reaches the pushes in logic_contribute/logic_release/
+        logic_accession and any added later, with no per-call-site plumbing to forget.  Only the
+        GIT_*/SSH_* variables are set this way -- PATH is deliberately left alone (#214), since
+        prepending a portable git's directory would put its bash.exe and sh.exe ahead of
+        everything for every subprocess Slicer launches.
+        """
+        os.environ.update(self.gitNonInteractiveEnvironment)
+
     def refreshGitPython(self):
         """Point GitPython at the git executable this logic resolved.
 
@@ -82,6 +113,8 @@ class DepsMixin:
         user has not installed or configured one yet) and is reported by checkGitDependencies(),
         which is what gates the UI -- so it is logged here, not raised.
         """
+        # Done here because this runs before any git child does, whether or not a git was resolved.
+        self.applyGitNonInteractiveEnvironment()
         if not self.gitExecutablePath:
             return False
         try:
@@ -133,6 +166,77 @@ class DepsMixin:
         if not missing:
             return {}
         return {"PATH": os.pathsep.join(missing + entries)}
+
+    def gitCredentialsConfigured(self):
+        """True when git can obtain a GitHub credential without asking a human.
+
+        The credential helper is written by `gh auth setup-git` (run for the user as part of
+        `gh auth login`), and that can only happen if gh can RUN git -- which is not the case on a
+        machine whose git is a portable install that was never put on PATH.  That is #214's
+        dependency in the other direction, and it fails silently: gh authenticates fine, `gh auth
+        status` is green, the Configure tab is green, every gh-driven operation works, and the one
+        operation that goes through GitPython instead -- the push in commitAndPush -- is the one
+        that fails, after the segmentation work is done.
+
+        Asks git rather than reading config, so any working helper counts (osxkeychain on macOS,
+        manager on Windows) and not just the one gh installs.  `credential fill` consults the
+        helpers and returns what git would use for a push; with prompting disabled it fails
+        outright when nothing answers, so this never blocks on input.
+        """
+        if not self.gitExecutablePath:
+            return False
+        environment = os.environ.copy()
+        environment.update(self.gitNonInteractiveEnvironment)
+        popenArguments = {}
+        if os.name == "nt":
+            # Hide the console window, the way slicer.util.launchConsoleProcess does.
+            startupInfo = subprocess.STARTUPINFO()
+            startupInfo.dwFlags = 1
+            startupInfo.wShowWindow = 0
+            popenArguments["startupinfo"] = startupInfo
+        try:
+            completed = subprocess.run(
+                [self.gitExecutablePath, "credential", "fill"],
+                input="protocol=https\nhost=github.com\n\n",
+                capture_output=True,
+                text=True,
+                timeout=30,
+                env=environment,
+                **popenArguments)
+        except (OSError, subprocess.SubprocessError) as e:
+            logging.warning(f"MorphoDepot: could not ask git for a GitHub credential: {e}")
+            return False
+        # NEVER log or progressMethod this stdout: on success it contains the access token itself.
+        return completed.returncode == 0 and "password=" in (completed.stdout or "")
+
+    def ensureGitCredentialHelper(self):
+        """Make sure git has a credential source for github.com, installing one if it has none.
+
+        Running `gh auth setup-git` through self.gh() is what makes this work in the case that
+        breaks: gh is handed a PATH containing the configured git (#214), so it can write the
+        credential config even when git is not on the system PATH and the same command typed in a
+        terminal would fail.  Returns True when git ends up able to answer.
+
+        A False is reported to the user, not raised: searching and browsing work without a push
+        credential, so this warns rather than gating the module.
+        """
+        # Cached like whoami(), and for the same reason: this runs on every module enter, and a
+        # helper that answered once will answer again for the life of this logic instance.  Only
+        # the success is cached -- a user who goes and fixes their sign-in gets a fresh check on
+        # the next enter rather than being told it is still broken.
+        if getattr(self, "_gitCredentialsCache", False):
+            return True
+        if self.gitCredentialsConfigured():
+            self._gitCredentialsCache = True
+            return True
+        self.progressMethod("Setting up GitHub sign-in for git...")
+        try:
+            self.gh(["auth", "setup-git"])
+        except Exception as e:
+            logging.warning(f"MorphoDepot: `gh auth setup-git` did not succeed: {e}")
+            return False
+        self._gitCredentialsCache = self.gitCredentialsConfigured()
+        return self._gitCredentialsCache
 
     def checkGitDependencies(self):
         """Check that git, and gh are available

--- a/MorphoDepot/MorphoDepotLib/logic_deps.py
+++ b/MorphoDepot/MorphoDepotLib/logic_deps.py
@@ -93,10 +93,16 @@ class DepsMixin:
 
         Set process-wide rather than per-repository on purpose: GitPython copies os.environ at
         each invocation, so this reaches the pushes in logic_contribute/logic_release/
-        logic_accession and any added later, with no per-call-site plumbing to forget.  Only the
-        GIT_*/SSH_* variables are set this way -- PATH is deliberately left alone (#214), since
-        prepending a portable git's directory would put its bash.exe and sh.exe ahead of
-        everything for every subprocess Slicer launches.
+        logic_accession and any added later, with no per-call-site plumbing to forget.  The
+        scoped alternative exists -- repo.git.update_environment() applies to one Repo -- and is
+        rejected for that reason, not because nothing else is affected: Slicer's own Extension
+        Wizard pushes through GitPython in this same process (ExtensionWizard.py), so once this
+        logic has been built, an extension publish from the same session also gets prompting
+        disabled.  That is judged acceptable because a git prompt inside Slicer has nowhere to
+        appear either way -- the Wizard user gets a clear failure instead of a hang.
+
+        PATH is deliberately NOT set this way (#214): prepending a portable git's directory would
+        put its bash.exe and sh.exe ahead of everything for every subprocess Slicer launches.
         """
         os.environ.update(self.gitNonInteractiveEnvironment)
 
@@ -189,9 +195,10 @@ class DepsMixin:
         A user who has switched a remote to SSH by hand still needs one to reach upstream, so a
         False here is not a false alarm for them either -- but their push, alone, would work.
 
-        The timeout is a backstop against a credential helper that hangs, since this runs on the
-        way into the module: generous enough for a keychain that has to be unlocked, short enough
-        that a wedged helper does not hold the UI.
+        The timeout is a backstop against a credential helper that HANGS, not a budget for the
+        normal path: this runs on every module enter, and when nothing is configured git exits
+        immediately, so the cost of the common failing case is milliseconds.  Kept short anyway,
+        because enter() must not stall the UI (see its own no-hang contract).
         """
         if not self.gitExecutablePath:
             return False
@@ -210,7 +217,7 @@ class DepsMixin:
                 input="protocol=https\nhost=github.com\n\n",
                 capture_output=True,
                 text=True,
-                timeout=20,
+                timeout=10,
                 env=environment,
                 **popenArguments)
         except (OSError, subprocess.SubprocessError) as e:
@@ -239,14 +246,21 @@ class DepsMixin:
         if self.gitCredentialsConfigured():
             self._gitCredentialsCache = True
             return True
-        self.progressMethod("Setting up GitHub sign-in for git...")
+        # Said plainly because this WRITES to the user's global git configuration, affecting git
+        # everywhere else on their machine -- and a probe failure is not proof that no helper
+        # exists (a locked keychain reads the same way), so the change can be made on a false
+        # premise.  Judged worth it for this audience: the alternative is a segmenter losing a
+        # session's work to a failure they cannot diagnose.
+        self.progressMethod("Adding GitHub sign-in to your global git configuration...")
         try:
-            # Bounded, unlike the default gh timeout: this sits in front of module entry, and it
-            # runs again on every enter for as long as the problem lasts.  Retrying rather than
-            # attempting once per session is deliberate -- a user who fixes the underlying cause
-            # (puts git on PATH, finishes a login) is then repaired automatically on the way back
-            # in, instead of having to know to run setup-git themselves.
-            self.gh(["auth", "setup-git"], timeout=60)
+            # Bounded well below gh()'s 300s default: this sits in front of module entry, which
+            # must not stall, and it runs again on every enter for as long as the problem lasts.
+            # Retrying rather than attempting once per session is deliberate -- a user who fixes
+            # the underlying cause (finishes a `gh auth login`, installs git) is then repaired
+            # automatically on the way back in, instead of having to know setup-git exists.  The
+            # cost of that retry is small: when gh cannot do the job it fails in well under a
+            # second, and the timeout is only a backstop against a wedged child.
+            self.gh(["auth", "setup-git"], timeout=20)
         except Exception as e:
             logging.warning(f"MorphoDepot: `gh auth setup-git` did not succeed: {e}")
             return False

--- a/MorphoDepot/MorphoDepotLib/logic_deps.py
+++ b/MorphoDepot/MorphoDepotLib/logic_deps.py
@@ -199,6 +199,12 @@ class DepsMixin:
         normal path: this runs on every module enter, and when nothing is configured git exits
         immediately, so the cost of the common failing case is milliseconds.  Kept short anyway,
         because enter() must not stall the UI (see its own no-hang contract).
+
+        Note that a helper CAN put a dialog on screen from here: an osxkeychain entry whose
+        keychain is locked prompts the user to unlock it, so the first entry into the module on
+        such a machine may raise a system password box that was not asked for.  Answering it
+        leaves the probe true; dismissing it reads as "no credential", which is also what the
+        subsequent push would hit -- so the warning that follows is not a false alarm.
         """
         if not self.gitExecutablePath:
             return False

--- a/MorphoDepot/MorphoDepotLib/logic_deps.py
+++ b/MorphoDepot/MorphoDepotLib/logic_deps.py
@@ -182,6 +182,16 @@ class DepsMixin:
         manager on Windows) and not just the one gh installs.  `credential fill` consults the
         helpers and returns what git would use for a push; with prompting disabled it fails
         outright when nothing answers, so this never blocks on input.
+
+        HTTPS only, deliberately: MorphoDepot builds its remotes as https://github.com/... itself
+        (_ensureUpstream, and the origin set by the accession path), so an HTTPS credential is
+        needed for the normal workflow no matter what protocol gh was configured to clone with.
+        A user who has switched a remote to SSH by hand still needs one to reach upstream, so a
+        False here is not a false alarm for them either -- but their push, alone, would work.
+
+        The timeout is a backstop against a credential helper that hangs, since this runs on the
+        way into the module: generous enough for a keychain that has to be unlocked, short enough
+        that a wedged helper does not hold the UI.
         """
         if not self.gitExecutablePath:
             return False
@@ -191,8 +201,8 @@ class DepsMixin:
         if os.name == "nt":
             # Hide the console window, the way slicer.util.launchConsoleProcess does.
             startupInfo = subprocess.STARTUPINFO()
-            startupInfo.dwFlags = 1
-            startupInfo.wShowWindow = 0
+            startupInfo.dwFlags = subprocess.STARTF_USESHOWWINDOW
+            startupInfo.wShowWindow = subprocess.SW_HIDE
             popenArguments["startupinfo"] = startupInfo
         try:
             completed = subprocess.run(
@@ -200,7 +210,7 @@ class DepsMixin:
                 input="protocol=https\nhost=github.com\n\n",
                 capture_output=True,
                 text=True,
-                timeout=30,
+                timeout=20,
                 env=environment,
                 **popenArguments)
         except (OSError, subprocess.SubprocessError) as e:
@@ -231,7 +241,12 @@ class DepsMixin:
             return True
         self.progressMethod("Setting up GitHub sign-in for git...")
         try:
-            self.gh(["auth", "setup-git"])
+            # Bounded, unlike the default gh timeout: this sits in front of module entry, and it
+            # runs again on every enter for as long as the problem lasts.  Retrying rather than
+            # attempting once per session is deliberate -- a user who fixes the underlying cause
+            # (puts git on PATH, finishes a login) is then repaired automatically on the way back
+            # in, instead of having to know to run setup-git themselves.
+            self.gh(["auth", "setup-git"], timeout=60)
         except Exception as e:
             logging.warning(f"MorphoDepot: `gh auth setup-git` did not succeed: {e}")
             return False

--- a/MorphoDepot/MorphoDepotLib/logic_deps.py
+++ b/MorphoDepot/MorphoDepotLib/logic_deps.py
@@ -173,105 +173,53 @@ class DepsMixin:
             return {}
         return {"PATH": os.pathsep.join(missing + entries)}
 
-    def gitCredentialsConfigured(self):
-        """True when git can obtain a GitHub credential without asking a human.
+    def configureRepositoryCredentials(self, repo):
+        """Make this repository sign in to GitHub as the gh account MorphoDepot is actually using.
 
-        The credential helper is written by `gh auth setup-git` (run for the user as part of
-        `gh auth login`), and that can only happen if gh can RUN git -- which is not the case on a
-        machine whose git is a portable install that was never put on PATH.  That is #214's
-        dependency in the other direction, and it fails silently: gh authenticates fine, `gh auth
-        status` is green, the Configure tab is green, every gh-driven operation works, and the one
-        operation that goes through GitPython instead -- the push in commitAndPush -- is the one
-        that fails, after the segmentation work is done.
+        Written into the repository's OWN config, not the user's global one (which is what
+        `gh auth setup-git` edits).  Three things that buys:
 
-        Asks git rather than reading config, so any working helper counts (osxkeychain on macOS,
-        manager on Windows) and not just the one gh installs.  `credential fill` consults the
-        helpers and returns what git would use for a push; with prompting disabled it fails
-        outright when nothing answers, so this never blocks on input.
+        * It authenticates as the RIGHT account.  A host-keyed helper -- osxkeychain, or Windows'
+          Credential Manager -- answers for github.com with whatever credential was stored there
+          by whoever stored it, and `gh auth switch` does not touch it.  On a shared teaching
+          machine, in the three-persona test harness, or on any computer where the user pushed to
+          GitHub before installing MorphoDepot, that means commits going up as somebody else
+          while whoami() reports the account they picked.  Delegating to `gh auth git-credential`
+          follows the active gh account by construction, so the question cannot arise.
+        * It changes nothing outside MorphoDepot's own clones.  setup-git rewrites the global
+          config, and with no --hostname it does so for EVERY host the user is logged into, not
+          just github.com.
+        * It does not depend on setup-git succeeding -- which it cannot when gh has no git to run
+          (#214), the failure this whole change exists to fix.
 
-        HTTPS only, deliberately: MorphoDepot builds its remotes as https://github.com/... itself
-        (_ensureUpstream, and the origin set by the accession path), so an HTTPS credential is
-        needed for the normal workflow no matter what protocol gh was configured to clone with.
-        A user who has switched a remote to SSH by hand still needs one to reach upstream, so a
-        False here is not a false alarm for them either -- but their push, alone, would work.
+        The empty value written first is what makes the first point hold: git ACCUMULATES helpers
+        across config scopes, so a global osxkeychain entry would still answer first and win.  An
+        empty credential.helper resets the accumulated list, so only this one runs.  (That is the
+        same two-entry shape `gh auth setup-git` writes globally.)
 
-        The timeout is a backstop against a credential helper that HANGS, not a budget for the
-        normal path: this runs on every module enter, and when nothing is configured git exits
-        immediately, so the cost of the common failing case is milliseconds.  Kept short anyway,
-        because enter() must not stall the UI (see its own no-hang contract).
-
-        Note that a helper CAN put a dialog on screen from here: an osxkeychain entry whose
-        keychain is locked prompts the user to unlock it, so the first entry into the module on
-        such a machine may raise a system password box that was not asked for.  Answering it
-        leaves the probe true; dismissing it reads as "no credential", which is also what the
-        subsequent push would hit -- so the warning that follows is not a false alarm.
+        Returns True when the repository was configured.
         """
-        if not self.gitExecutablePath:
+        if not self.ghExecutablePath:
+            logging.warning("MorphoDepot: no gh to configure repository credentials with")
             return False
-        environment = os.environ.copy()
-        environment.update(self.gitNonInteractiveEnvironment)
-        popenArguments = {}
-        if os.name == "nt":
-            # Hide the console window, the way slicer.util.launchConsoleProcess does.
-            startupInfo = subprocess.STARTUPINFO()
-            startupInfo.dwFlags = subprocess.STARTF_USESHOWWINDOW
-            startupInfo.wShowWindow = subprocess.SW_HIDE
-            popenArguments["startupinfo"] = startupInfo
+        # Quoted because the path routinely contains spaces (C:\Program Files\GitHub CLI), and
+        # git hands this string to a shell.  The escape covers the pathological apostrophe.
+        quotedGhPath = self.ghExecutablePath.replace("'", "'\\''")
+        helper = f"!'{quotedGhPath}' auth git-credential"
+        helperKey = "credential.https://github.com.helper"
         try:
-            completed = subprocess.run(
-                [self.gitExecutablePath, "credential", "fill"],
-                input="protocol=https\nhost=github.com\n\n",
-                capture_output=True,
-                text=True,
-                timeout=10,
-                env=environment,
-                **popenArguments)
-        except (OSError, subprocess.SubprocessError) as e:
-            logging.warning(f"MorphoDepot: could not ask git for a GitHub credential: {e}")
-            return False
-        # NEVER log or progressMethod this stdout: on success it contains the access token itself.
-        return completed.returncode == 0 and "password=" in (completed.stdout or "")
-
-    def ensureGitCredentialHelper(self):
-        """Make sure git has a credential source for github.com, installing one if it has none.
-
-        Running `gh auth setup-git` through self.gh() is what makes this work in the case that
-        breaks: gh is handed a PATH containing the configured git (#214), so it can write the
-        credential config even when git is not on the system PATH and the same command typed in a
-        terminal would fail.  Returns True when git ends up able to answer.
-
-        A False is reported to the user, not raised: searching and browsing work without a push
-        credential, so this warns rather than gating the module.
-        """
-        # Cached like whoami(), and for the same reason: this runs on every module enter, and a
-        # helper that answered once will answer again for the life of this logic instance.  Only
-        # the success is cached -- a user who goes and fixes their sign-in gets a fresh check on
-        # the next enter rather than being told it is still broken.
-        if getattr(self, "_gitCredentialsCache", False):
-            return True
-        if self.gitCredentialsConfigured():
-            self._gitCredentialsCache = True
-            return True
-        # Said plainly because this WRITES to the user's global git configuration, affecting git
-        # everywhere else on their machine -- and a probe failure is not proof that no helper
-        # exists (a locked keychain reads the same way), so the change can be made on a false
-        # premise.  Judged worth it for this audience: the alternative is a segmenter losing a
-        # session's work to a failure they cannot diagnose.
-        self.progressMethod("Adding GitHub sign-in to your global git configuration...")
-        try:
-            # Bounded well below gh()'s 300s default: this sits in front of module entry, which
-            # must not stall, and it runs again on every enter for as long as the problem lasts.
-            # Retrying rather than attempting once per session is deliberate -- a user who fixes
-            # the underlying cause (finishes a `gh auth login`, installs git) is then repaired
-            # automatically on the way back in, instead of having to know setup-git exists.  The
-            # cost of that retry is small: when gh cannot do the job it fails in well under a
-            # second, and the timeout is only a backstop against a wedged child.
-            self.gh(["auth", "setup-git"], timeout=20)
+            repo.git.config("--local", "--replace-all", helperKey, "")
+            repo.git.config("--local", "--add", helperKey, helper)
+            # GIT_TERMINAL_PROMPT stops git asking on a terminal, but it does not stop a HELPER
+            # from opening its own window: Git Credential Manager has a separate interactivity
+            # switch, and without this one it can raise a browser sign-in flow that nothing in
+            # the UI asked for.  Belt and braces, since the reset above already leaves GCM out of
+            # the chain for this repository.
+            repo.git.config("--local", "credential.interactive", "false")
         except Exception as e:
-            logging.warning(f"MorphoDepot: `gh auth setup-git` did not succeed: {e}")
+            logging.warning(f"MorphoDepot: could not configure repository credentials: {e}")
             return False
-        self._gitCredentialsCache = self.gitCredentialsConfigured()
-        return self._gitCredentialsCache
+        return True
 
     def checkGitDependencies(self):
         """Check that git, and gh are available

--- a/MorphoDepot/MorphoDepotLib/logic_repo.py
+++ b/MorphoDepot/MorphoDepotLib/logic_repo.py
@@ -114,6 +114,9 @@ class RepoMixin:
             isFork = True
         self.gh(["repo", "clone", cloneTarget, localDirectory])
         self.localRepo = git.Repo(localDirectory)
+        # Before any fetch/pull/push below: this is what makes them authenticate as the active
+        # gh account rather than whatever credential the machine had stored for github.com.
+        self.configureRepositoryCredentials(self.localRepo)
         self._ensureUpstream(sourceRepository)
 
         # D2: keep a genuine fork's default branch current with upstream (GitHub forks do not
@@ -194,6 +197,7 @@ class RepoMixin:
 
         self.gh(["repo", "clone", headNameWithOwner, localDirectory])
         self.localRepo = git.Repo(localDirectory)
+        self.configureRepositoryCredentials(self.localRepo)
         self._ensureUpstream(baseRepo)
         self.localRepo.remotes.origin.fetch()
         self.localRepo.git.checkout(branchName)
@@ -212,6 +216,7 @@ class RepoMixin:
         self.gh(["repo", "clone", repoNameWithOwner, localDirectory])
 
         self.localRepo = git.Repo(localDirectory)
+        self.configureRepositoryCredentials(self.localRepo)
         self.localRepo.git.checkout("main")
         self.loadFromLocalRepository(remoteName="origin", configuration="release")
         return True
@@ -225,6 +230,7 @@ class RepoMixin:
         self.gh(["repo", "clone", repoNameWithOwner, localDirectory])
 
         self.localRepo = git.Repo(localDirectory)
+        self.configureRepositoryCredentials(self.localRepo)
         self.localRepo.git.checkout("main")
         self.loadFromLocalRepository(remoteName="origin", configuration="preview")
         return True

--- a/MorphoDepot/MorphoDepotLib/logic_repo.py
+++ b/MorphoDepot/MorphoDepotLib/logic_repo.py
@@ -149,7 +149,13 @@ class RepoMixin:
         logging.debug("Making new branch")
         if originBranchID in originBranchIDs:
             logging.debug("Checking out existing from origin")
-            self.localRepo.git.execute(f"git checkout --track {originBranchID}".split())
+            # git.checkout(), NOT git.execute(["git", ...]): execute() runs the argv it is given,
+            # so a literal "git" there is looked up on PATH and ignores the executable GitPython
+            # was pointed at (refreshGitPython, #213).  On a machine whose git is a portable
+            # install off the PATH -- the case the Configure tab exists for -- this was the one
+            # call in the module that could not find git, and it is on the path a segmenter takes
+            # to RESUME work: it only runs when the issue branch already exists on origin.
+            self.localRepo.git.checkout("--track", originBranchID)
         else:
             # D1: branch off upstream/main (latest published state).  Fall back to origin/main
             # only if upstream/main is somehow unavailable, preserving the prior behavior.

--- a/MorphoDepot/Testing/Python/md_tests.py
+++ b/MorphoDepot/Testing/Python/md_tests.py
@@ -96,11 +96,31 @@ def _logic_git_noninteractive_environment():
         assert os.environ.get(key) == value, f"{key} was not applied to the git child environment"
 
 
-def _logic_credential_probe_answers():
-    # The probe backs the module-entry check, so it must return an answer on any machine -- with a
-    # helper, without one, and with no git configured at all -- and must never block on input.
-    result = H.logic.gitCredentialsConfigured()
-    assert isinstance(result, bool), f"gitCredentialsConfigured() returned {result!r}, not a bool"
+def _logic_repository_credentials():
+    # The one path here that WRITES configuration.  Two invariants matter, and the second is the
+    # one that keeps a shared machine honest: the helper must delegate to gh (so the push follows
+    # the active gh account rather than whatever credential the machine had stored for github.com),
+    # and it must be preceded by an empty entry, because git ACCUMULATES helpers across config
+    # scopes -- without the reset a global osxkeychain/manager entry answers first and wins.
+    import os, tempfile, shutil, git
+    repoDirectory = tempfile.mkdtemp(prefix="md-credential-test-")
+    try:
+        repo = git.Repo.init(repoDirectory, initial_branch="main")
+        assert H.logic.configureRepositoryCredentials(repo), "configureRepositoryCredentials failed"
+
+        values = repo.git.config("--local", "--get-all", "credential.https://github.com.helper")
+        entries = values.split("\n")
+        assert entries[0] == "", f"helper list is not reset first: {entries!r}"
+        assert len(entries) == 2, f"expected a reset plus one helper, got {entries!r}"
+        assert "auth git-credential" in entries[1], f"helper does not delegate to gh: {entries[1]!r}"
+        assert H.logic.ghExecutablePath in entries[1], f"helper is not the configured gh: {entries[1]!r}"
+
+        # Written to THIS repository only -- the user's global config is not MorphoDepot's to edit.
+        assert repo.git.config("--local", "credential.interactive") == "false"
+        localConfig = os.path.join(repoDirectory, ".git", "config")
+        assert "auth git-credential" in open(localConfig).read(), "helper did not land in the repo config"
+    finally:
+        shutil.rmtree(repoDirectory, ignore_errors=True)
 
 
 def _logic_missing_credential_detection():
@@ -291,7 +311,7 @@ TESTS = [
     ("logic_gitpython_refreshed", _logic_gitpython_refreshed),
     ("logic_tool_path_environment", _logic_tool_path_environment),
     ("logic_git_noninteractive_environment", _logic_git_noninteractive_environment),
-    ("logic_credential_probe_answers", _logic_credential_probe_answers),
+    ("logic_repository_credentials", _logic_repository_credentials),
     ("logic_missing_credential_detection", _logic_missing_credential_detection),
     ("baseline_nochange_helper", _baseline_nochange_helper),
     ("version_change_filter", _version_change_filter),

--- a/MorphoDepot/Testing/Python/md_tests.py
+++ b/MorphoDepot/Testing/Python/md_tests.py
@@ -86,6 +86,38 @@ def _logic_tool_path_environment():
         assert directory in entries, f"{executablePath} directory missing from the gh child PATH"
 
 
+def _logic_git_noninteractive_environment():
+    # A git child that finds no credential must FAIL rather than try to ask: Slicer has no console
+    # for a terminal prompt, and an askpass inherited from whatever launched it is not connected to
+    # anything.  Building the logic is what applies this, so it holds for every git child that
+    # follows -- the pushes in contribute/release/accession included.
+    import os
+    for key, value in H.logic.gitNonInteractiveEnvironment.items():
+        assert os.environ.get(key) == value, f"{key} was not applied to the git child environment"
+
+
+def _logic_credential_probe_answers():
+    # The probe backs the module-entry check, so it must return an answer on any machine -- with a
+    # helper, without one, and with no git configured at all -- and must never block on input.
+    result = H.logic.gitCredentialsConfigured()
+    assert isinstance(result, bool), f"gitCredentialsConfigured() returned {result!r}, not a bool"
+
+
+def _logic_missing_credential_detection():
+    # The three ways git reports "nobody could give me a credential", across platforms and across
+    # whether prompting was disabled.  A real push rejection must NOT be mistaken for one, or the
+    # user would be told to fix their sign-in when the actual problem is something else.
+    import git
+    for stderr in ("fatal: could not read Username for 'https://github.com': Device not configured",
+                   "fatal: could not read Username for 'https://github.com': terminal prompts disabled",
+                   "error: failed to execute prompt script (exit code 1)"):
+        error = git.exc.GitCommandError(["git", "push"], 128, stderr)
+        assert H.logic.isMissingCredentialError(error), f"not recognized: {stderr}"
+    rejected = git.exc.GitCommandError(
+        ["git", "push"], 1, "! [rejected] main -> main (non-fast-forward)")
+    assert not H.logic.isMissingCredentialError(rejected), "a push rejection was read as a sign-in failure"
+
+
 def _baseline_nochange_helper():
     # Unit-touch of the M6 no-change check: a file compared to itself is 'unchanged'.
     import tempfile, os, shutil
@@ -258,6 +290,9 @@ TESTS = [
     ("logic_mixins_touch", _logic_mixins_touch),
     ("logic_gitpython_refreshed", _logic_gitpython_refreshed),
     ("logic_tool_path_environment", _logic_tool_path_environment),
+    ("logic_git_noninteractive_environment", _logic_git_noninteractive_environment),
+    ("logic_credential_probe_answers", _logic_credential_probe_answers),
+    ("logic_missing_credential_detection", _logic_missing_credential_detection),
     ("baseline_nochange_helper", _baseline_nochange_helper),
     ("version_change_filter", _version_change_filter),
     ("version_installed_shape", _version_installed_shape),


### PR DESCRIPTION
## Problem

Follow-up to #214, from the same Windows box — and the same root cause seen from the other side.

A segmenter finishes their work, clicks **Commit**, and gets:

```
git.exc.GitCommandError: Cmd('C:\Users\murat\Downloads\PortableGit\bin\git.exe') failed due to: exit code(128)
  cmdline: git.exe push --porcelain -- origin issue-2
  stderr: 'error: failed to execute prompt script (exit code 1)
fatal: could not read Username for 'https://github.com': No such file or directory'
```

The same failure was reported by a user on macOS, where the last line reads `Device not configured`.

`git config --list` shows the user's name and email, `gh auth status` is green, the Configure tab is green, and every gh-driven operation works — repo list, issues, clone, PR creation. Only the push fails, because it is the only operation that goes through GitPython rather than `gh`, and so the only one needing git's **own** credentials. There were none: `git config --list --show-origin | Select-String credential` on the failing machine returned nothing at all.

**Why there were none.** `gh auth setup-git` — run for the user as part of `gh auth login` — is what writes that config, and it can only do so if gh can *run* git: it shells out to `git config --global`. On a machine whose git is a portable install never added to `PATH`, it can't. gh authenticates anyway (the OAuth half needs no git) and silently skips the git half. That is #214's "these two tools invoke each other by name" defect, in the direction #214 didn't cover, because `gh auth login` runs in a terminal outside the module.

## Approach

The first version of this PR ran `gh auth setup-git` from the module. Review found that fixes the reported failure while leaving a worse one in place, so the mechanism changed: **sign-in is now configured per repository, delegating to gh.**

At every clone or init, MorphoDepot writes into that repository's own config:

```
[credential "https://github.com"]
	helper =
	helper = !'<absolute gh path>' auth git-credential
```

Why this rather than the global `gh auth setup-git`:

* **It authenticates as the right account.** A probe for "can git get a credential" is not the same question as "can git get *this account's* credential". Host-keyed helpers — osxkeychain, Windows Credential Manager — answer for `github.com` with whatever credential was stored there by whoever stored it, and `gh auth switch` does not touch them. On a shared teaching machine, in the three-persona test harness, or on any computer where the user pushed to GitHub before installing MorphoDepot, pushes would go up **as somebody else** while `whoami()` reported the account they picked. Delegating to `gh auth git-credential` follows the active gh account by construction.
* **It touches nothing outside MorphoDepot's clones.** `setup-git` rewrites the user's global config — and with no `--hostname` it does so for *every* host they are logged into, not just github.com.
* **It does not depend on `setup-git` succeeding**, which it cannot in the very case this PR exists to fix.

**The empty first entry is load-bearing.** git *accumulates* credential helpers across config scopes, so a global helper still answers first and wins. An empty value resets the accumulated list. This is not a detail I assumed — see the verification table: a naive per-repository helper *without* the reset still resolves to the wrong account.

Because sign-in is now per repository, there is no global state left to be wrong: the module-entry probe and its warning dialog are gone, along with the subprocess on the UI thread and any chance of a keychain-unlock or GCM browser window raised by clicking into the module.

## Changes

* **`logic_deps.py`** — `configureRepositoryCredentials(repo)` writes the reset-plus-gh-helper pair and `credential.interactive=false` into the repository's local config. `gitNonInteractiveEnvironment` / `applyGitNonInteractiveEnvironment()` set `GIT_TERMINAL_PROMPT=0` and empty `GIT_ASKPASS`/`SSH_ASKPASS` process-wide from `refreshGitPython()`, so a git child with no credential fails identifiably instead of trying to ask a human who cannot answer.
* **`logic_repo.py`, `logic_accession.py`** — called at all six repository creation sites, before any fetch/pull/push. Every clone is fresh (`cacheOldVersion` archives any existing directory), so coverage is complete rather than partial.
* **`logic_contribute.py`** — `commitAndPush()` translates a credential failure into an explanation ("your work is here… run `gh auth login`") instead of a traceback. A real push rejection still raises unchanged.
* **`MorphoDepot.py`** — the module-entry credential check is removed; `gh auth status` in `checkGitDependencies()` is now the only requirement.
* **`md_tests.py`** — the config-*writing* path is what is tested now, including the reset ordering; plus the non-interactive environment and the error-marker matching.

### On the process-wide environment variables

Setting `GIT_*`/`SSH_*` process-wide is **not** free of side effects, and an earlier version of this description claiming otherwise was wrong: Slicer's own Extension Wizard pushes through GitPython in the same process (`ExtensionWizard.py`, three push sites), so once MorphoDepot's logic has been built, an extension publish from that session also gets prompting disabled. The trade is judged acceptable — a git prompt inside Slicer has nowhere to appear either way, so that user gets a clear failure instead of a hang — and the reason to prefer process-wide over `repo.git.update_environment()` is that there is no per-call-site plumbing to forget. `PATH` is still left alone, per #214.

## Verification

The account-correctness claim, against a real git and a stand-in host-keyed helper holding another account's credential (`GIT_CONFIG_GLOBAL` pointing at a config with a fake helper):

| configuration | `credential fill` returns |
|---|---|
| inherited global helper only — today's behavior on a shared machine | `username=someone-elses-account` |
| per-repo gh helper **without** the reset | `username=someone-elses-account` — still wrong |
| per-repo gh helper **with** the reset, as written by this PR | `username=muratmaga` — the active gh account |
| same, after `gh auth switch --user amm554` | `username=amm554` — follows the switch |

The prompting behavior, on git 2.49:

| case | result |
|---|---|
| empty `GIT_ASKPASS` | reads as "none configured"; git reports `could not read Username … terminal prompts disabled`, exit 128 |
| host with no helper, prompting disabled | exit 128, no hang |

The failure-detection, against the exact stderr from both reported machines:

| stderr | recognized |
|---|---|
| `could not read Username … Device not configured` (macOS) | yes |
| `could not read Username … No such file or directory` (Windows) | yes |
| `could not read Username … terminal prompts disabled` | yes |
| `failed to execute prompt script (exit code 1)` | yes |
| `! [rejected] main -> main (non-fast-forward)` | no — still raises |
| `remote: Permission to … denied` | no — still raises |

### End-to-end, in Slicer, on Windows

Run on a Windows machine scrubbed back to a clean slate: global/system/portable git configs deleted, Windows Credential Manager cleared of every github entry, gh logged out and its config removed, MorphoDepot's cached paths stripped from Slicer's settings. git was a PortableGit in `Downloads`, deliberately **not** on the system `PATH`.

`gh auth login -s user:email`, accepting every default — including **Yes** to "Authenticate Git with your GitHub credentials?" — ends like this:

```
✓ Authentication complete.
- gh config set -h github.com git_protocol https
✓ Configured git protocol
unable to find git executable in PATH; please install Git for Windows before retrying
```

That is the bug, stated by gh itself, as the last line of a flow whose preceding lines are green checkmarks. `gh auth status` is then fully green and `git config --list --show-origin | Select-String credential` prints nothing. Note this rules out the "user declined the prompt" explanation: the prompt was accepted.

| build | result |
|---|---|
| installed build (pre-PR) | `git push` fails: `failed to execute prompt script (exit code 1)` / `could not read Username for 'https://github.com': No such file or directory` |
| this branch | issue loads, segmentation commits and pushes, **no credential setup performed by the user** |

Afterwards, on the pushed clone:

| check | result |
|---|---|
| `config --local --get-all credential.https://github.com.helper` | two entries — the empty reset, then `!'C:\Program Files\GitHub CLI\gh.EXE' auth git-credential` |
| `config --global --list \| findstr credential` | nothing — the user's global configuration was not touched |

The `failed to execute prompt script` line appearing on a machine with **no** `askpass` anywhere in git config also confirms it is a Git-for-Windows built-in fallback rather than configuration, which is why it stays in the marker list.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

