### PR TITLE
Read work state live from GitHub instead of from the RepoClerk journal

### DIFF
--- a/MorphoDepot/CMakeLists.txt
+++ b/MorphoDepot/CMakeLists.txt
@@ -24,6 +24,7 @@ set(MODULE_PYTHON_SCRIPTS
   ${MODULE_NAME}Lib/logic_repoclerk.py
   ${MODULE_NAME}Lib/logic_search.py
   ${MODULE_NAME}Lib/logic_version.py
+  ${MODULE_NAME}Lib/logic_workstate.py
   ${MODULE_NAME}Lib/screenshot_dialog.py
   ${MODULE_NAME}Lib/search_form.py
   ${MODULE_NAME}Lib/widget_annotate.py

--- a/MorphoDepot/MorphoDepot.py
+++ b/MorphoDepot/MorphoDepot.py
@@ -50,6 +50,7 @@ from MorphoDepotLib.logic_github import GitHubMixin
 from MorphoDepotLib.logic_controlplane import ControlPlaneMixin
 from MorphoDepotLib.logic_objectstore import ObjectStoreMixin
 from MorphoDepotLib.logic_repoclerk import RepoClerkMixin
+from MorphoDepotLib.logic_workstate import WorkStateMixin
 from MorphoDepotLib.logic_repo import RepoMixin
 from MorphoDepotLib.logic_contribute import ContributeMixin
 from MorphoDepotLib.logic_release import ReleaseMixin
@@ -836,7 +837,7 @@ class MorphoDepotWidget(ScriptedLoadableModuleWidget, VTKObservationMixin, Enabl
             self._refreshArchivalAvailability()
             self.refreshStagedReposList()
 
-class MorphoDepotLogic(ScriptedLoadableModuleLogic, DepsMixin, GitHubMixin, ControlPlaneMixin, ObjectStoreMixin, RepoClerkMixin, RepoMixin, ContributeMixin, ReleaseMixin, AccessionMixin, SearchMixin, CollectionsMixin, VersionMixin):
+class MorphoDepotLogic(ScriptedLoadableModuleLogic, DepsMixin, GitHubMixin, ControlPlaneMixin, ObjectStoreMixin, RepoClerkMixin, WorkStateMixin, RepoMixin, ContributeMixin, ReleaseMixin, AccessionMixin, SearchMixin, CollectionsMixin, VersionMixin):
     """This class should implement all the actual
     computation done by your module.  The interface
     should be such that other python code can import
@@ -1069,18 +1070,15 @@ class MorphoDepotTest(ScriptedLoadableModuleTest):
         # 9. Switch to Annotator to work on issues
         switchUser(annotator)
         self.delayDisplay("Annotator listing assigned issues")
-        # Avoid logic.issueList() here: it relies on GitHub's repository search index
-        # (topic:MorphoDepot), which lags for newly-created repos. A direct REST query
-        # against the known repo is immediate. Synthesize the dict shape loadIssue expects.
-        rawIssues = logic.ghJSON(
-            f"issue list --repo {repoNameWithOwner} --assignee {annotator} --state open --json number,title"
-        )
+        # This is the real Annotate-tab path, not a stand-in.  It used to be one: issueList()
+        # read the RepoClerk journal, which is populated from GitHub's repository search index
+        # and lags for a repo created a minute ago, so the test had to query REST directly and
+        # synthesize the dict shape.  issueList() is now that direct query (see
+        # MorphoDepotLib/logic_workstate.py), so the test exercises what the annotator uses.
+        # Filtered to the test repo because the endpoint is account-wide.
         repoNameOnly = repoNameWithOwner.split("/")[1]
-        annotatorIssues = [
-            {'number': i['number'], 'title': i['title'],
-             'repository': {'name': repoNameOnly, 'nameWithOwner': repoNameWithOwner}}
-            for i in rawIssues
-        ]
+        annotatorIssues = [i for i in logic.issueList()
+                           if i['repository']['nameWithOwner'] == repoNameWithOwner]
         self.assertEqual(len(annotatorIssues), 2, f"Annotator should have 2 issues for repo {repoNameWithOwner}.")
 
         # 10. Annotator loads each issue, makes a change, and creates a PR.
@@ -1108,10 +1106,11 @@ class MorphoDepotTest(ScriptedLoadableModuleTest):
             widget.onCommit()
             slicer.app.processEvents()
 
-            # 11. Mark PR as ready. widget.onRequestReview -> requestReview -> issuePR ->
-            # prList -> search index, which lags for the freshly created PR (silent failure
-            # would leave the PR in draft and break the later merge). Find the PR via direct
-            # REST and use gh directly.
+            # 11. Mark PR as ready, via gh rather than widget.onRequestReview.  The original
+            # reason (onRequestReview -> requestReview -> issuePR -> prList -> the lagging
+            # search index) no longer holds: prList() is a live query now.  Kept direct for the
+            # moment so this change does not rewrite the release-path assertions in the same
+            # commit that changes the query layer — converting it is a deliberate follow-up.
             self.delayDisplay(f"Requesting review for work on issue #{issue['number']}")
             branchName = f"issue-{issue['number']}"
             rawPRs = logic.ghJSON(f"pr list --repo {repoNameWithOwner} --state open --json number,title")
@@ -1132,8 +1131,11 @@ class MorphoDepotTest(ScriptedLoadableModuleTest):
             issueID = f"issue-{issue['number']}"
             issueIDs.append(issueID)
             issuesByID[issueID] = issue
-        # Avoid logic.prList("reviewer") here for the same reason as issueList above:
-        # it relies on the topic search index. Direct REST against the known repo is reliable.
+        # Avoid logic.prList("reviewer") here, but no longer because of the search index.  The
+        # reviewer list is the union of "repos I own" and "org repos whose CURATOR names me",
+        # and this test repo is in the MorphoDepotTesting scratch org — owned by neither the
+        # creator nor the MorphoDepot org, so neither half reaches it.  (That gap predates this
+        # change: the old owner-of-the-closing-issue test missed it for the same reason.)
         rawPRs = logic.ghJSON(
             f"pr list --repo {repoNameWithOwner} --state open --json number,title,author"
         )
@@ -1150,10 +1152,10 @@ class MorphoDepotTest(ScriptedLoadableModuleTest):
         prToRequestChanges = repoPRsByIssueID[issueIDs[1]]
         issueToChange = issuesByID[issueIDs[1]]
 
-        # Approve the first PR. logic.approvePR() and logic.requestChanges() resolve the PR
-        # via logic.issuePR() -> logic.prList() -> ghTopicData() -> the topic search index, which
-        # lags for freshly created PRs. We have the PR numbers from the REST query above, so
-        # invoke gh directly to avoid the indexing dependency.
+        # Approve the first PR.  logic.approvePR() and logic.requestChanges() resolve the PR via
+        # logic.issuePR() -> logic.prList(role="reviewer"), which cannot see a MorphoDepotTesting
+        # repo for the reason given just above.  We have the PR numbers from the REST query, so
+        # invoke gh directly.
         self.delayDisplay(f"Approving and merging PR #{prToApprove['number']}")
         logic.loadPR(prToApprove, repoDirectory)
         approveNum = str(prToApprove['number'])

--- a/MorphoDepot/MorphoDepotLib/logic_contribute.py
+++ b/MorphoDepot/MorphoDepotLib/logic_contribute.py
@@ -102,12 +102,12 @@ class ContributeMixin:
                     self.progressMethod(f"Push failed with {flag}")
                     return False
 
-        # Create a PR if one does not already exist.  Check AUTHORITATIVELY (direct gh), NOT via the
-        # RepoClerk journal that issuePR()/prList() read: the journal lags minutes behind GitHub, so
-        # right after the first push it still reports "no PR" and the old `if not self.issuePR()`
-        # guard would try to open a SECOND PR for the same head->base.  gh rejects that ("a pull
-        # request ... already exists"), which surfaced as a spurious "Failed to commit and push"
-        # even though the push succeeded -- for repo owners and outside segmenters alike.
+        # Create a PR if one does not already exist.  Ask about THIS branch specifically rather
+        # than going through issuePR()/prList(): those answer "which PRs concern me", which is a
+        # superset and was historically cached, and the old `if not self.issuePR()` guard would
+        # try to open a SECOND PR for the same head->base.  gh rejects that ("a pull request ...
+        # already exists"), which surfaced as a spurious "Failed to commit and push" even though
+        # the push succeeded -- for repo owners and outside segmenters alike.
         upstreamNameWithOwner = self.nameWithOwner("upstream")
         originNameWithOwner = self.nameWithOwner("origin")
         originOwner = originNameWithOwner.split("/")[0]

--- a/MorphoDepot/MorphoDepotLib/logic_contribute.py
+++ b/MorphoDepot/MorphoDepotLib/logic_contribute.py
@@ -145,9 +145,10 @@ class ContributeMixin:
         upstreamNameWithOwner = self.nameWithOwner("upstream")
         pr = self.issuePR(role="segmenter")
         if not pr:
-            # The RepoClerk journal that issuePR() reads lags, so a just-opened PR may not appear
-            # there yet -- fall back to an authoritative direct lookup before giving up (same root
-            # cause as the commitAndPush duplicate-PR bug).
+            # issuePR() -> prList() is a live query now, so this is no longer a lag fallback.
+            # It is kept because it asks a narrower question: issuePR() matches by PR *title*
+            # against the branch name, which misses a PR someone retitled, while this matches the
+            # head branch itself -- the thing that actually decides whether a PR exists.
             branchName = self.localRepo.active_branch.name
             originOwner = self.nameWithOwner("origin").split("/")[0]
             pr = self._openPRForBranch(upstreamNameWithOwner, originOwner, branchName)

--- a/MorphoDepot/MorphoDepotLib/logic_github.py
+++ b/MorphoDepot/MorphoDepotLib/logic_github.py
@@ -250,19 +250,9 @@ class GitHubMixin:
                        "--add-topic", f"md-{speciesTopicString}", "--remove-topic", self.stagingTopic]
         self.gh(command)
 
-    def issueList(self):
-        me = self.whoami()
-        repoData = self.ghTopicData()
-        issueList = []
-        for repo in repoData:
-            for issue in repo['issues']['nodes']:
-                assignees = [node['login'] for node in issue['assignees']['nodes']]
-                if me in assignees:
-                    repoName = repo['nameWithOwner'].split("/")[1]
-                    issueList.append({'number': issue['number'],
-                                      'title': issue['title'],
-                                      'repository': { 'name': repoName, 'nameWithOwner': repo['nameWithOwner']}})
-        return issueList
+    # issueList() and prList() live in logic_workstate.WorkStateMixin: they are per-user
+    # questions answered live from GitHub, not fleet-scale questions answered from the
+    # RepoClerk journal.  See that module's docstring for why.
 
     def administratedRepoList(self):
         # Releases are ARCHIVAL-ONLY (org-design Sec.9.6): only MorphoDepot-org repos the user
@@ -285,39 +275,6 @@ class GitHubMixin:
                 repo['nameWithOwner'] = f"{ownerLogin}/{repo['name']}"
                 returnRepos.append(repo)
         return returnRepos
-
-    def prList(self, role="segmenter"):
-        """
-        Fetch a list of open pull requests for the user, either as 'segmenter' or reviewer.
-        Returns PRs, their associated issue titles, and repository topics.
-        """
-        me = self.whoami()
-        repoData = self.ghTopicData()
-        prList = []
-        for repo in repoData:
-            for pr in repo['pullRequests']['nodes']:
-                prAuthor = (pr.get('author') or {}).get('login')  # None for a deleted/ghost account
-                if role == "segmenter":
-                    parties = [prAuthor] if prAuthor else []
-                elif role == "reviewer":
-                    parties = [issue['repository']['owner']['login'] for issue in pr['closingIssuesReferences']['nodes']]
-                    # In-org (archival) repos are owned by the MorphoDepot org, not the curator's
-                    # login, so owner-keying alone hides every in-org PR from its curator.  Add the
-                    # journaled curator — the same owner-vs-curator fix administratedRepoList() applies.
-                    if repo.get('curator'):
-                        parties.append(repo['curator'])
-                else:
-                    raise BaseException(f"Unknown role {role}")
-                issueTitles = [issue['title'] for issue in pr['closingIssuesReferences']['nodes']]
-                if me in parties:
-                    repoName = repo['nameWithOwner'].split("/")[1]
-                    prList.append({'number': pr['number'],
-                                      'title': pr['title'],
-                                      'issueTitles': issueTitles,
-                                      'isDraft': pr['isDraft'],
-                                      'author': {'login': prAuthor},
-                                      'repository': { 'name': repoName, 'nameWithOwner': repo['nameWithOwner']}})
-        return prList
 
     def repositoryList(self):
         # --limit 1000: gh defaults to 30, which would make loadIssue's fork-exists check
@@ -370,11 +327,13 @@ class GitHubMixin:
 
     def _openPRForBranch(self, upstreamNameWithOwner, headOwner, branchName):
         """Authoritative check for an already-open PR whose head is headOwner:branchName into the
-        upstream repo, queried DIRECTLY from GitHub (gh api) rather than the lagging RepoClerk
-        journal that prList()/issuePR() read.  Returns the PR dict or None (None also on any query
-        error, so the caller falls through to PR creation, which is itself guarded against
-        duplicates).  The journal lags minutes behind GitHub, so it cannot answer "does a PR exist
-        for this branch right now" — the moment that matters when deciding whether to open one."""
+        upstream repo.  Returns the PR dict or None (None also on any query error, so the caller
+        falls through to PR creation, which is itself guarded against duplicates).
+
+        prList() is live now too, so this is no longer a way around a lagging cache — it is kept
+        because it asks the narrower question directly: not "which of my PRs are open" but "is
+        there an open PR for *this branch* right now", which is the one that decides whether to
+        open another."""
         try:
             prs = self.ghJSON(["api",
                                f"repos/{upstreamNameWithOwner}/pulls?head={headOwner}:{branchName}&state=open"])

--- a/MorphoDepot/MorphoDepotLib/logic_repoclerk.py
+++ b/MorphoDepot/MorphoDepotLib/logic_repoclerk.py
@@ -101,55 +101,17 @@ class RepoClerkMixin:
                 pass
         return False
 
-    def _journalsToTopicData(self, journals):
-        """Convert RepoClerk journal list to the dict shape that ghTopicData() returned."""
-        result = []
-        for j in journals:
-            issues_nodes = [
-                {
-                    "number": issue["number"],
-                    "title": issue["title"],
-                    "url": issue["url"],
-                    "author": {"login": issue["author"]} if issue.get("author") else None,
-                    "assignees": {"nodes": [{"login": a} for a in issue.get("assignees", [])]},
-                }
-                for issue in j.get("openIssues", [])
-            ]
-            prs_nodes = [
-                {
-                    "number": pr["number"],
-                    "title": pr["title"],
-                    "isDraft": pr["isDraft"],
-                    "url": pr["url"],
-                    "author": {"login": pr["author"]} if pr.get("author") else None,
-                    "closingIssuesReferences": {
-                        "nodes": [
-                            {
-                                "number": pr["closingIssue"]["number"],
-                                "title": pr["closingIssue"]["title"],
-                                "repository": {"owner": {"login": pr["closingIssue"]["repoOwner"]}},
-                            }
-                        ] if pr.get("closingIssue") else []
-                    },
-                }
-                for pr in j.get("openPRs", [])
-            ]
-            result.append({
-                "nameWithOwner": j["nameWithOwner"],
-                "curator": j.get("curator"),
-                "pullRequests": {"nodes": prs_nodes},
-                "issues": {"nodes": issues_nodes},
-            })
-        return result
-
-    def ghTopicData(self, topic="MorphoDepot"):
-        clonePath = self.refreshRepoClerk()
-        if clonePath:
-            journals = self.repoClerkJournals(clonePath)
-            if journals:
-                return self._journalsToTopicData(journals)
-        logging.warning("RepoClerk journals unavailable — returning empty topic data")
-        return []
+    # ghTopicData() lived here: it read every journal, reshaped it into the fleet-wide
+    # {repo: {issues, pullRequests}} form, and the Annotate and Review tabs then filtered it
+    # client-side for the current user.  It is gone, deliberately and not just because it has no
+    # callers left — while it existed, "what am I assigned?" could be answered from a cache that
+    # only refreshes when a sweep notices, which is exactly how the 2026-08-07 classroom outage
+    # happened.  Those two questions are per-user and are now asked of GitHub directly; see
+    # MorphoDepotLib/logic_workstate.py.
+    #
+    # morphoRepos() below still carries issue and PR counts from the journal.  That is the
+    # Release tab's fleet-wide view of org repos (counts, announcement targets, tooltips), not a
+    # per-user work list, so it stays index-side.
 
     def morphoRepos(self):
         clonePath = self.refreshRepoClerk()

--- a/MorphoDepot/MorphoDepotLib/logic_workstate.py
+++ b/MorphoDepot/MorphoDepotLib/logic_workstate.py
@@ -1,0 +1,327 @@
+"""MorphoDepotLogic WorkStateMixin — live per-user issues and pull requests.
+
+**Work state is read from GitHub, not from the RepoClerk journal.**
+
+RepoClerk exists because *discovery* is a fleet-scale question: "which repos are there, and what
+species/modality/spacing do they have" has to be computed once, centrally, and shared, or every
+client re-crawls the whole fleet.  Work state is not that question.  "What am I assigned?" and
+"what am I reviewing?" are bounded by the repos *one person* works on, which does not grow when
+the fleet grows.  Measured across the logins appearing in journals: median 1 repo, mean 2.0.
+
+Answering a per-user question from a fleet-scale cache is what caused the 2026-08-07 classroom
+outage: five issues were created and assigned, no journal refresh fired, and the Annotate tab
+showed an empty list that was indistinguishable from "you have no work".  The queries below
+cannot go stale, because there is nothing between them and GitHub.
+
+Measured cost, 2026-08-07 (limits: REST 5,000/hour, GraphQL 5,000 points/hour):
+
+    assigned issues          1 REST call, both tiers, topics inline
+    my open PRs              1 GraphQL request, 2 points
+    repos I curate           1 GraphQL request per 100 owned repos, 1 point each
+    PRs in those repos       1 GraphQL request per 50 repos, ~2 points
+
+None of these scale with fleet size.  The rejected alternative -- one query listing every repo's
+issues and PRs and filtering client-side, which is what `ghTopicData()` did -- costs 202 points
+against the 30-per-minute search endpoint at 80 repos, and grows linearly with the fleet.
+
+See MorphoDepot/RepoClerk `design/index-vs-work-state.md` for the full argument, and
+`design/near-realtime-ingestion.md` for the incident.
+
+What still comes from the journal, and why: the *set* of repos a curator is responsible for is
+not answerable from GitHub alone.  An org repo is owned by the MorphoDepot org, not by its
+curator, so no owner-keyed query finds it; the CURATOR file is a committed file, hence index
+data, hence journaled.  `curatedRepositories()` is a union of a live owner query and that
+journaled set -- see its docstring.
+"""
+import json
+import logging
+import re
+
+
+# Repos carry this topic once published; it is what separates a MorphoDepot dataset from the
+# rest of a user's GitHub account in the per-user queries below.
+MORPHODEPOT_TOPIC = "morphodepot"
+
+# GraphQL aliases are built from these, so anything that is not a plain GitHub name is dropped
+# rather than interpolated into a query string.
+_SAFE_NAME = re.compile(r"^[A-Za-z0-9._-]+$")
+
+# One request per this many repos in the batched pull-request query.  50 keeps the request well
+# inside GitHub's node limit while keeping the request count at ceil(curated / 50).
+_PR_BATCH = 50
+
+# Open PRs fetched per repo, and repos/PRs fetched per page.  A MorphoDepot repo with more than
+# 50 simultaneously open PRs does not occur -- one per issue under review -- but the cap is
+# explicit so the query cost is bounded rather than open-ended.
+_PRS_PER_REPO = 50
+_PAGE = 100
+_MAX_PAGES = 20  # backstop so a pathological account cannot loop forever
+
+
+def splitNameWithOwner(nameWithOwner):
+    """("owner", "name") for a well-formed `owner/name`, or None.
+
+    The batched pull-request query interpolates these straight into GraphQL string literals, so
+    anything that is not a plain GitHub name is rejected here rather than escaped there.
+    """
+    parts = (nameWithOwner or "").split("/")
+    if len(parts) != 2:
+        return None
+    if not (_SAFE_NAME.match(parts[0]) and _SAFE_NAME.match(parts[1])):
+        return None
+    return parts[0], parts[1]
+
+
+class WorkStateMixin:
+
+    # --- queries -------------------------------------------------------------------------
+
+    def _graphql(self, query, **variables):
+        """Run a GraphQL query through `gh` and return its `data` object.
+
+        Raises (via gh()) if the request fails, which is deliberate: an empty work list and a
+        failed query must not look the same to the user.  That ambiguity is the substance of
+        SlicerMorph/SlicerMorphoDepot#212 -- when the journal was unreachable the tabs showed
+        nothing at all, with no indication that anything had gone wrong.
+        """
+        command = ["api", "graphql", "-f", f"query={query}"]
+        for name, value in variables.items():
+            # `-f` (string) rather than `-F` (typed): every variable here is a String!, and gh's
+            # typed form would coerce an all-digit page cursor into an Int and fail the query.
+            # An omitted variable defaults to null, which is what "first page" means.
+            if value is not None:
+                command += ["-f", f"{name}={value}"]
+        raw = self.gh(command)
+        try:
+            payload = json.loads(raw)
+        except (ValueError, json.JSONDecodeError) as e:
+            raise RuntimeError(f"Could not parse the GitHub GraphQL response: {e}")
+        if payload.get("errors"):
+            # A GraphQL error arrives with HTTP 200, so gh exits 0 and nothing above notices.
+            messages = "; ".join(e.get("message", "?") for e in payload["errors"])
+            raise RuntimeError(f"GitHub GraphQL error: {messages}")
+        return payload.get("data") or {}
+
+    def _hasMorphoTopic(self, repositoryNode):
+        topics = [n["topic"]["name"]
+                  for n in ((repositoryNode.get("repositoryTopics") or {}).get("nodes") or [])]
+        return MORPHODEPOT_TOPIC in topics
+
+    def assignedIssues(self):
+        """Open issues assigned to the active user on MorphoDepot repos, newest GitHub state.
+
+        `GET /issues?filter=assigned` is a real-time REST endpoint -- not backed by the search
+        index that lags for freshly created repos -- and it answers for both tiers in one call:
+        personal repos and MorphoDepot-org repos come back together, with no tier distinction
+        anywhere in this method.
+
+        The response carries `repository.topics` inline, so the MorphoDepot filter costs no extra
+        request.  Filtering on the topic (rather than on the journal's repo list) is what keeps a
+        repo published minutes ago from being invisible here.
+
+        The endpoint returns pull requests alongside issues; those carry a `pull_request` key and
+        are dropped, since the Annotate tab lists work to start, not work already submitted.
+        """
+        raw = self.ghJSON(["api", "--paginate",
+                           f"/issues?filter=assigned&state=open&per_page={_PAGE}"])
+        if not isinstance(raw, list):
+            return []
+        issues = []
+        for entry in raw:
+            if not isinstance(entry, dict) or "pull_request" in entry:
+                continue
+            repository = entry.get("repository") or {}
+            if MORPHODEPOT_TOPIC not in (repository.get("topics") or []):
+                continue
+            nameWithOwner = repository.get("full_name") or ""
+            if not nameWithOwner:
+                continue
+            issues.append({
+                "number": entry["number"],
+                "title": entry.get("title", ""),
+                "url": entry.get("html_url", ""),
+                "repository": {"name": nameWithOwner.split("/")[-1],
+                               "nameWithOwner": nameWithOwner},
+            })
+        return issues
+
+    def authoredPullRequests(self):
+        """Open pull requests the active user opened, on MorphoDepot repos.
+
+        One request for every PR the user has open anywhere on GitHub, filtered here by topic.
+        This is the segmenter's view: the PRs they are responsible for moving along.
+        """
+        query = """
+          query($cursor: String) {
+            viewer {
+              pullRequests(states: OPEN, first: %d, after: $cursor,
+                           orderBy: {field: UPDATED_AT, direction: DESC}) {
+                pageInfo { hasNextPage endCursor }
+                nodes {
+                  number title isDraft url
+                  author { login }
+                  repository {
+                    nameWithOwner
+                    repositoryTopics(first: 20) { nodes { topic { name } } }
+                  }
+                  closingIssuesReferences(first: 10) {
+                    nodes { number title repository { owner { login } } }
+                  }
+                }
+              }
+            }
+          }
+        """ % _PAGE
+        pullRequests = []
+        cursor = None
+        for _ in range(_MAX_PAGES):
+            data = self._graphql(query, cursor=cursor)
+            connection = ((data.get("viewer") or {}).get("pullRequests") or {})
+            for node in (connection.get("nodes") or []):
+                repository = node.get("repository") or {}
+                if not self._hasMorphoTopic(repository):
+                    continue
+                pullRequests.append(self._prRecord(node, repository.get("nameWithOwner", "")))
+            pageInfo = connection.get("pageInfo") or {}
+            if not pageInfo.get("hasNextPage"):
+                break
+            cursor = pageInfo.get("endCursor")
+        return pullRequests
+
+    def curatedRepositories(self):
+        """`nameWithOwner` for every MorphoDepot repo the active user is the reviewer for.
+
+        A union of two sources, not a tier branch -- both queries always run and their results
+        merge:
+
+          * repos the user **owns** that carry the topic, from a live owner-keyed query.  These
+            are the personal-tier datasets; GitHub can enumerate them directly because the user
+            owns them.
+          * repos in the MorphoDepot org whose committed **CURATOR** file names the user, from
+            the journal.  An owner-keyed query cannot find these -- the org owns them -- and
+            CURATOR is a file in the repo, so it only changes on a push and belongs in the index
+            on exactly the same grounds as species or modality.
+
+        Forks are excluded: a segmenter's fork of a dataset is not a repo they review.  Its pull
+        requests target the upstream, where the upstream's curator already sees them.
+        """
+        query = """
+          query($cursor: String) {
+            viewer {
+              repositories(ownerAffiliations: OWNER, isFork: false, first: %d, after: $cursor) {
+                pageInfo { hasNextPage endCursor }
+                nodes {
+                  nameWithOwner
+                  repositoryTopics(first: 20) { nodes { topic { name } } }
+                }
+              }
+            }
+          }
+        """ % _PAGE
+        owned = []
+        cursor = None
+        for _ in range(_MAX_PAGES):
+            data = self._graphql(query, cursor=cursor)
+            connection = ((data.get("viewer") or {}).get("repositories") or {})
+            for node in (connection.get("nodes") or []):
+                if self._hasMorphoTopic(node) and node.get("nameWithOwner"):
+                    owned.append(node["nameWithOwner"])
+            pageInfo = connection.get("pageInfo") or {}
+            if not pageInfo.get("hasNextPage"):
+                break
+            cursor = pageInfo.get("endCursor")
+
+        curated = set(owned)
+        try:
+            for repo in self.administratedRepoList():
+                if repo.get("nameWithOwner"):
+                    curated.add(repo["nameWithOwner"])
+        except Exception as e:
+            # The journal half is a supplement, not the whole answer.  If RepoClerk is
+            # unreachable the user's own repos still list, so degrade rather than fail --
+            # but say so, because in-org PRs will be missing from the list.
+            logging.warning(f"Could not read curated org repos from RepoClerk: {e}")
+        return sorted(curated)
+
+    def openPullRequestsForRepositories(self, nameWithOwners):
+        """Open pull requests across the named repos, batched into as few requests as possible.
+
+        Aliased `repository(...)` fields rather than a search: search is the 30-per-minute
+        endpoint and lags behind reality for anything created in the last few seconds, which is
+        precisely the moment the Review tab is refreshed after a student clicks Request review.
+        """
+        pullRequests = []
+        targets = []
+        for nameWithOwner in nameWithOwners:
+            parts = splitNameWithOwner(nameWithOwner)
+            if parts is None:
+                logging.warning(f"Skipping malformed repository name {nameWithOwner!r}")
+                continue
+            targets.append(parts)
+        for start in range(0, len(targets), _PR_BATCH):
+            batch = targets[start:start + _PR_BATCH]
+            fields = "\n".join(
+                f'    r{index}: repository(owner: "{owner}", name: "{name}") {{ ...prs }}'
+                for index, (owner, name) in enumerate(batch))
+            query = """
+              query {
+              %s
+              }
+              fragment prs on Repository {
+                nameWithOwner
+                pullRequests(states: OPEN, first: %d, orderBy: {field: UPDATED_AT, direction: DESC}) {
+                  nodes {
+                    number title isDraft url
+                    author { login }
+                    closingIssuesReferences(first: 10) {
+                      nodes { number title repository { owner { login } } }
+                    }
+                  }
+                }
+              }
+            """ % (fields, _PRS_PER_REPO)
+            data = self._graphql(query)
+            for index, (owner, name) in enumerate(batch):
+                repository = data.get(f"r{index}")
+                if not repository:
+                    continue  # deleted, renamed, or no longer visible to this user
+                nameWithOwner = repository.get("nameWithOwner") or f"{owner}/{name}"
+                for node in ((repository.get("pullRequests") or {}).get("nodes") or []):
+                    pullRequests.append(self._prRecord(node, nameWithOwner))
+        return pullRequests
+
+    # --- shaping -------------------------------------------------------------------------
+
+    def _prRecord(self, node, nameWithOwner):
+        """The dict shape the Annotate and Review tabs consume, from a GraphQL PR node."""
+        closing = ((node.get("closingIssuesReferences") or {}).get("nodes") or [])
+        return {
+            "number": node["number"],
+            "title": node.get("title", ""),
+            "url": node.get("url", ""),
+            "isDraft": bool(node.get("isDraft")),
+            # None for a deleted or ghost account, which the Review tab already tolerates.
+            "author": {"login": (node.get("author") or {}).get("login")},
+            "issueTitles": [issue.get("title", "") for issue in closing],
+            "repository": {"name": nameWithOwner.split("/")[-1], "nameWithOwner": nameWithOwner},
+        }
+
+    # --- the two entry points the tabs call ----------------------------------------------
+
+    def issueList(self):
+        """Issues assigned to the active user — the Annotate tab's list."""
+        return self.assignedIssues()
+
+    def prList(self, role="segmenter"):
+        """Open pull requests relevant to the active user in `role`.
+
+        `segmenter` — the PRs they opened; `reviewer` — the PRs open on the repos they curate.
+        The reviewer half no longer infers responsibility from a PR's closing-issue owner: it
+        starts from the repo set (see `curatedRepositories`) and lists what is open there, which
+        is both cheaper and correct for a PR whose issue link is missing or malformed.
+        """
+        if role == "segmenter":
+            return self.authoredPullRequests()
+        if role == "reviewer":
+            return self.openPullRequestsForRepositories(self.curatedRepositories())
+        raise ValueError(f"Unknown role {role}")

--- a/MorphoDepot/MorphoDepotLib/logic_workstate.py
+++ b/MorphoDepot/MorphoDepotLib/logic_workstate.py
@@ -102,6 +102,29 @@ class WorkStateMixin:
             raise RuntimeError(f"GitHub GraphQL error: {messages}")
         return payload.get("data") or {}
 
+    def _paginate(self, query, connectionKey, what):
+        """Every node of `viewer.<connectionKey>`, following pages until GitHub says stop.
+
+        `_MAX_PAGES` is a backstop against an unbounded loop, not a supported limit, so hitting
+        it is reported rather than passed over: a truncated answer here is a Review tab that
+        quietly lists fewer pull requests than the user actually has, with nothing on screen to
+        say so.  A silently short list is the failure mode this whole module exists to remove.
+        """
+        nodes = []
+        cursor = None
+        for _ in range(_MAX_PAGES):
+            data = self._graphql(query, cursor=cursor)
+            connection = ((data.get("viewer") or {}).get(connectionKey) or {})
+            nodes.extend(connection.get("nodes") or [])
+            pageInfo = connection.get("pageInfo") or {}
+            if not pageInfo.get("hasNextPage"):
+                return nodes
+            cursor = pageInfo.get("endCursor")
+        logging.warning(
+            f"Stopped after {_MAX_PAGES} pages of {what} ({len(nodes)} fetched); "
+            "the list shown is incomplete.")
+        return nodes
+
     def _hasMorphoTopic(self, repositoryNode):
         topics = [n["topic"]["name"]
                   for n in ((repositoryNode.get("repositoryTopics") or {}).get("nodes") or [])]
@@ -134,7 +157,10 @@ class WorkStateMixin:
             if MORPHODEPOT_TOPIC not in (repository.get("topics") or []):
                 continue
             nameWithOwner = repository.get("full_name") or ""
-            if not nameWithOwner:
+            if not nameWithOwner or entry.get("number") is None:
+                # Every other field has a sensible empty value; a number does not -- loadIssue()
+                # builds the branch name and the fork checkout from it.  Skip rather than emit an
+                # entry that would fail later, and rather than KeyError out of the whole list.
                 continue
             issues.append({
                 "number": entry["number"],
@@ -173,19 +199,11 @@ class WorkStateMixin:
           }
         """ % _PAGE
         pullRequests = []
-        cursor = None
-        for _ in range(_MAX_PAGES):
-            data = self._graphql(query, cursor=cursor)
-            connection = ((data.get("viewer") or {}).get("pullRequests") or {})
-            for node in (connection.get("nodes") or []):
-                repository = node.get("repository") or {}
-                if not self._hasMorphoTopic(repository):
-                    continue
-                pullRequests.append(self._prRecord(node, repository.get("nameWithOwner", "")))
-            pageInfo = connection.get("pageInfo") or {}
-            if not pageInfo.get("hasNextPage"):
-                break
-            cursor = pageInfo.get("endCursor")
+        for node in self._paginate(query, "pullRequests", "your open pull requests"):
+            repository = node.get("repository") or {}
+            if not self._hasMorphoTopic(repository):
+                continue
+            pullRequests.append(self._prRecord(node, repository.get("nameWithOwner", "")))
         return pullRequests
 
     def curatedRepositories(self):
@@ -218,20 +236,10 @@ class WorkStateMixin:
             }
           }
         """ % _PAGE
-        owned = []
-        cursor = None
-        for _ in range(_MAX_PAGES):
-            data = self._graphql(query, cursor=cursor)
-            connection = ((data.get("viewer") or {}).get("repositories") or {})
-            for node in (connection.get("nodes") or []):
-                if self._hasMorphoTopic(node) and node.get("nameWithOwner"):
-                    owned.append(node["nameWithOwner"])
-            pageInfo = connection.get("pageInfo") or {}
-            if not pageInfo.get("hasNextPage"):
-                break
-            cursor = pageInfo.get("endCursor")
-
-        curated = set(owned)
+        curated = set()
+        for node in self._paginate(query, "repositories", "the repositories you own"):
+            if self._hasMorphoTopic(node) and node.get("nameWithOwner"):
+                curated.add(node["nameWithOwner"])
         try:
             for repo in self.administratedRepoList():
                 if repo.get("nameWithOwner"):
@@ -286,7 +294,15 @@ class WorkStateMixin:
                 if not repository:
                     continue  # deleted, renamed, or no longer visible to this user
                 nameWithOwner = repository.get("nameWithOwner") or f"{owner}/{name}"
-                for node in ((repository.get("pullRequests") or {}).get("nodes") or []):
+                nodes = ((repository.get("pullRequests") or {}).get("nodes") or [])
+                if len(nodes) >= _PRS_PER_REPO:
+                    # Not paginated: _PRS_PER_REPO is set well above what a MorphoDepot repo
+                    # sees (one open PR per issue under review).  If it is ever reached the
+                    # list is short by an unknown amount, which must not pass unremarked.
+                    logging.warning(
+                        f"{nameWithOwner} has at least {_PRS_PER_REPO} open pull requests; "
+                        "the Review list is truncated.")
+                for node in nodes:
                     pullRequests.append(self._prRecord(node, nameWithOwner))
         return pullRequests
 

--- a/MorphoDepot/MorphoDepotLib/widget_configure.py
+++ b/MorphoDepot/MorphoDepotLib/widget_configure.py
@@ -138,18 +138,17 @@ class ConfigureTabMixin:
     # Review
 
     def onRefresh(self):
+        # No RepoClerk wait here any more: both lists are queried live from GitHub (see
+        # MorphoDepotLib/logic_workstate.py), so there is no journal update to wait for and
+        # nothing that can be stale.  Refresh is one round of queries and it is done.
         self.annotateUI.repoClerkStatusLabel.text = "Updating..."
         self.annotateUI.repoClerkStatusLabel.show()
         slicer.app.processEvents()
-        with slicer.util.tryWithErrorDisplay("Failed to refresh from GitHub", waitCursor=True):
-            self.annotateUI.issueList.clear()
-            self.annotateUI.prList.clear()
-            self.updateIssueList()
-            self.updateAnnotatePRList()
-        if self._waitForRepoClerkUpdate(self.annotateUI.repoClerkStatusLabel):
+        try:
             with slicer.util.tryWithErrorDisplay("Failed to refresh from GitHub", waitCursor=True):
                 self.annotateUI.issueList.clear()
                 self.annotateUI.prList.clear()
                 self.updateIssueList()
                 self.updateAnnotatePRList()
-        self.annotateUI.repoClerkStatusLabel.hide()
+        finally:
+            self.annotateUI.repoClerkStatusLabel.hide()

--- a/MorphoDepot/MorphoDepotLib/widget_review.py
+++ b/MorphoDepot/MorphoDepotLib/widget_review.py
@@ -31,15 +31,19 @@ from MorphoDepotLib.screenshot_dialog import ScreenshotReviewDialog
 
 class ReviewTabMixin:
     def onReviewRefresh(self):
+        # The PR list is queried live from GitHub (MorphoDepotLib/logic_workstate.py), so there
+        # is no RepoClerk journal update to wait for -- a student who clicks Request review is
+        # visible on the next refresh, not on the next sweep.  The journal is still consulted for
+        # *which* in-org repos this user curates (the committed CURATOR file), which is index
+        # data and changes only on a push.
         self.reviewUI.repoClerkStatusLabel.text = "Updating..."
         self.reviewUI.repoClerkStatusLabel.show()
         slicer.app.processEvents()
-        with slicer.util.tryWithErrorDisplay("Failed to update PR list", waitCursor=True):
-            self.updateReviewPRList()
-        if self._waitForRepoClerkUpdate(self.reviewUI.repoClerkStatusLabel):
+        try:
             with slicer.util.tryWithErrorDisplay("Failed to update PR list", waitCursor=True):
                 self.updateReviewPRList()
-        self.reviewUI.repoClerkStatusLabel.hide()
+        finally:
+            self.reviewUI.repoClerkStatusLabel.hide()
         # Re-evaluate the reviewer section here (with a FRESH team-membership check), because Slicer's
         # module Reload rebuilds the widget but does NOT call enter() — so without this a repoadminteam
         # change (or the section being rebuilt hidden on reload) is only reflected on a full module

--- a/MorphoDepot/Testing/Python/test_workstate.py
+++ b/MorphoDepot/Testing/Python/test_workstate.py
@@ -1,0 +1,386 @@
+#!/usr/bin/env python3
+"""Unit tests for MorphoDepotLib/logic_workstate.py — the live per-user work-state queries.
+
+Run: python3 MorphoDepot/Testing/Python/test_workstate.py   (no Slicer, no deps, no network)
+
+logic_workstate.py imports only json/logging/re, so it loads outside Slicer and its filtering and
+shaping can be tested against recorded GitHub responses.  The recorded shapes below are trimmed
+from real responses taken 2026-08-07 against the muratmaga account.
+
+The bugs these guard against are the ones the 2026-08-07 classroom outage was made of:
+
+  * a repo published minutes ago must not be filtered out (so the MorphoDepot test is the repo's
+    live topic list, never a cached set of known repos)
+  * the org and personal tiers must come back from the same query with no branch between them,
+    because a tier-conditional path is what let personal repos rot while org repos worked
+  * a failed query must not look like an empty work list
+"""
+import importlib.util
+import json
+from pathlib import Path
+
+_LIB = Path(__file__).resolve().parents[2] / "MorphoDepotLib" / "logic_workstate.py"
+_spec = importlib.util.spec_from_file_location("logic_workstate", _LIB)
+workstate = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(workstate)
+
+
+def check(name, cond):
+    print(f"  {'PASS' if cond else 'FAIL'}  {name}")
+    assert cond, name
+
+
+class FakeLogic(workstate.WorkStateMixin):
+    """A WorkStateMixin with the two GitHub call sites stubbed.
+
+    `graphqlPages` is consumed in order, one per _graphql() call, so pagination and batching are
+    observable.  Every query string sent is recorded in `queries` so the tests can assert on what
+    was actually asked of GitHub, not only on what came back.
+    """
+
+    def __init__(self, restResponse=None, graphqlPages=None, curated=None, curatedError=None):
+        self.restResponse = restResponse if restResponse is not None else []
+        self.graphqlPages = list(graphqlPages or [])
+        self.curated = curated or []
+        self.curatedError = curatedError
+        self.queries = []
+        self.restCommands = []
+
+    def ghJSON(self, command):
+        self.restCommands.append(command)
+        return self.restResponse
+
+    def gh(self, command):
+        query = next(part[len("query="):] for part in command if part.startswith("query="))
+        self.queries.append(query)
+        if not self.graphqlPages:
+            raise AssertionError("more GraphQL calls than recorded pages")
+        return json.dumps(self.graphqlPages.pop(0))
+
+    def administratedRepoList(self):
+        if self.curatedError:
+            raise self.curatedError
+        return self.curated
+
+
+# --- recorded shapes ---------------------------------------------------------------------
+
+def restIssue(number, title, fullName, topics, isPR=False):
+    entry = {"number": number, "title": title,
+             "html_url": f"https://github.com/{fullName}/issues/{number}",
+             "repository": {"full_name": fullName, "topics": topics}}
+    if isPR:
+        entry["pull_request"] = {"url": "..."}
+    return entry
+
+
+def prNode(number, title, author="student", draft=False, closing=(), repo=None):
+    node = {"number": number, "title": title, "isDraft": draft,
+            "url": f"https://github.com/x/pull/{number}",
+            "author": {"login": author} if author else None,
+            "closingIssuesReferences": {
+                "nodes": [{"number": n, "title": t,
+                           "repository": {"owner": {"login": o}}} for n, t, o in closing]}}
+    if repo is not None:
+        node["repository"] = repoNode(*repo)
+    return node
+
+
+def repoNode(nameWithOwner, topics):
+    return {"nameWithOwner": nameWithOwner,
+            "repositoryTopics": {"nodes": [{"topic": {"name": t}} for t in topics]}}
+
+
+MD = ["md-rana-clamitans", "morphodepot"]
+
+
+# --- assigned issues (Annotate) ----------------------------------------------------------
+
+def test_assigned_issues_span_both_tiers_from_one_query():
+    """The property that makes the outage structurally impossible: no tier branch exists.
+
+    `GET /issues?filter=assigned` returns personal and MorphoDepot-org issues in the same
+    response.  Nothing downstream inspects the owner, so there is no path on which one tier can
+    be fresh and the other stale.
+    """
+    logic = FakeLogic(restResponse=[
+        restIssue(2, "Segment the premaxilla", "muratmaga/rana-clamitans-full-body", MD),
+        restIssue(3, "Tongue segmentation", "MorphoDepot/mus-musculus-E15",
+                  ["md-mus-musculus", "morphodepot"]),
+    ])
+    issues = logic.issueList()
+    owners = {i["repository"]["nameWithOwner"].split("/")[0] for i in issues}
+    check("personal and org issues arrive together", owners == {"muratmaga", "MorphoDepot"})
+    check("one REST call for both tiers", len(logic.restCommands) == 1)
+    check("the call is paginated", "--paginate" in logic.restCommands[0])
+
+
+def test_non_morphodepot_repos_are_dropped():
+    # The endpoint is account-wide: it returns every issue assigned to the user anywhere on
+    # GitHub.  Recorded live -- MorphoCloudAnalytics issues really do come back in this response.
+    logic = FakeLogic(restResponse=[
+        restIssue(6, "Monthly SU snapshot", "MorphoCloud/MorphoCloudAnalytics", []),
+        restIssue(2, "Segment the premaxilla", "muratmaga/rana-clamitans-full-body", MD),
+    ])
+    issues = logic.issueList()
+    check("only morphodepot-topic repos survive",
+          [i["repository"]["nameWithOwner"] for i in issues] == ["muratmaga/rana-clamitans-full-body"])
+
+
+def test_the_topic_test_is_live_not_a_known_repo_set():
+    """A repo published two minutes ago carries the topic and has no journal entry yet.
+
+    Filtering against the journal's repo list instead would reproduce the original bug at one
+    remove: the issue exists, the assignment exists, and the tab is still empty because the index
+    has not caught up.  The topic comes back inline on the same response, so there is no reason
+    to consult anything else.
+    """
+    logic = FakeLogic(restResponse=[
+        restIssue(1, "Segment the skull", "instructor/published-90-seconds-ago", ["morphodepot"]),
+    ])
+    check("a repo with no journal entry still lists", len(logic.issueList()) == 1)
+
+
+def test_pull_requests_are_not_listed_as_issues():
+    # /issues returns PRs too; the Annotate issue list is work to start, not work submitted.
+    logic = FakeLogic(restResponse=[
+        restIssue(2, "Segment the premaxilla", "muratmaga/rana-clamitans-full-body", MD),
+        restIssue(8, "issue-2", "muratmaga/rana-clamitans-full-body", MD, isPR=True),
+    ])
+    check("the PR entry is dropped", [i["number"] for i in logic.issueList()] == [2])
+
+
+def test_issue_shape_is_what_the_tab_consumes():
+    # updateIssueList() reads title, repository.nameWithOwner and number; loadIssue() reads
+    # repository.name.  A shape change here is a silent KeyError in the UI.
+    logic = FakeLogic(restResponse=[
+        restIssue(2, "Segment the premaxilla", "muratmaga/rana-clamitans-full-body", MD)])
+    issue = logic.issueList()[0]
+    check("number/title/repository.name/nameWithOwner all present",
+          (issue["number"], issue["title"], issue["repository"]["name"],
+           issue["repository"]["nameWithOwner"])
+          == (2, "Segment the premaxilla", "rana-clamitans-full-body",
+              "muratmaga/rana-clamitans-full-body"))
+
+
+def test_malformed_entries_do_not_break_the_list():
+    logic = FakeLogic(restResponse=[
+        {"number": 9, "title": "no repository key"},
+        restIssue(2, "Segment the premaxilla", "muratmaga/rana-clamitans-full-body", MD),
+    ])
+    check("a junk entry is skipped rather than raising", len(logic.issueList()) == 1)
+
+
+# --- authored pull requests (Annotate, segmenter) ----------------------------------------
+
+def _viewerPRPage(nodes, hasNext=False, cursor=None):
+    return {"data": {"viewer": {"pullRequests": {
+        "pageInfo": {"hasNextPage": hasNext, "endCursor": cursor}, "nodes": nodes}}}}
+
+
+def test_authored_prs_filter_by_topic():
+    logic = FakeLogic(graphqlPages=[_viewerPRPage([
+        prNode(8, "issue-2", repo=("muratmaga/rana-clamitans-full-body", MD)),
+        prNode(5, "docs typo", repo=("MorphoCloud/docs", [])),
+    ])])
+    prs = logic.prList(role="segmenter")
+    check("only morphodepot PRs are listed", [p["number"] for p in prs] == [8])
+
+
+def test_authored_prs_paginate():
+    logic = FakeLogic(graphqlPages=[
+        _viewerPRPage([prNode(1, "issue-1", repo=("o/r", ["morphodepot"]))], hasNext=True, cursor="c1"),
+        _viewerPRPage([prNode(2, "issue-2", repo=("o/r", ["morphodepot"]))]),
+    ])
+    prs = logic.prList(role="segmenter")
+    check("both pages are collected", [p["number"] for p in prs] == [1, 2])
+    check("the second request carries the cursor", len(logic.queries) == 2)
+
+
+def test_pr_shape_is_what_the_tabs_consume():
+    # updateAnnotatePRList()/updateReviewPRList() read title, issueTitles, isDraft and
+    # repository.nameWithOwner; onPRSelectionChanged reads author.login.
+    logic = FakeLogic(graphqlPages=[_viewerPRPage([
+        prNode(8, "issue-2", author="student", draft=True,
+               closing=((2, "Segment the premaxilla", "muratmaga"),),
+               repo=("muratmaga/rana-clamitans-full-body", MD))])])
+    pr = logic.prList(role="segmenter")[0]
+    check("issueTitles come from the closing-issue references",
+          pr["issueTitles"] == ["Segment the premaxilla"])
+    check("draft status is carried", pr["isDraft"] is True)
+    check("author login is carried", pr["author"]["login"] == "student")
+    check("repository is split into name and nameWithOwner",
+          pr["repository"] == {"name": "rana-clamitans-full-body",
+                               "nameWithOwner": "muratmaga/rana-clamitans-full-body"})
+
+
+def test_ghost_author_does_not_raise():
+    # author is null for a deleted account; the Review tab already tolerates a None login.
+    logic = FakeLogic(graphqlPages=[_viewerPRPage([
+        prNode(8, "issue-2", author=None, repo=("o/r", ["morphodepot"]))])])
+    check("a deleted author becomes login None",
+          logic.prList(role="segmenter")[0]["author"]["login"] is None)
+
+
+def test_a_pr_with_no_linked_issue_still_lists():
+    # Under the old reviewer path a PR whose closing-issue link was missing had no "party" and
+    # vanished from the list.  Nothing here depends on the link.
+    logic = FakeLogic(graphqlPages=[_viewerPRPage([
+        prNode(8, "issue-2", closing=(), repo=("o/r", ["morphodepot"]))])])
+    prs = logic.prList(role="segmenter")
+    check("an unlinked PR is listed with empty issueTitles",
+          len(prs) == 1 and prs[0]["issueTitles"] == [])
+
+
+# --- curated repositories (Review) -------------------------------------------------------
+
+def _viewerRepoPage(nodes, hasNext=False, cursor=None):
+    return {"data": {"viewer": {"repositories": {
+        "pageInfo": {"hasNextPage": hasNext, "endCursor": cursor}, "nodes": nodes}}}}
+
+
+def test_curated_repos_are_a_union_of_owned_and_journaled():
+    """Owned repos come live from GitHub; in-org repos come from the journaled CURATOR file.
+
+    Both queries always run and merge -- nothing classifies a repo first and then picks a source.
+    The org half has to come from the journal because the org owns those repos, so an
+    owner-keyed query cannot reach them, and CURATOR is a committed file, hence index data.
+    """
+    logic = FakeLogic(
+        graphqlPages=[_viewerRepoPage([repoNode("muratmaga/rana-clamitans-full-body", MD),
+                                       repoNode("muratmaga/SlicerMorph", [])])],
+        curated=[{"nameWithOwner": "MorphoDepot/mus-musculus-E15"}])
+    check("owned morphodepot repos and curated org repos merge",
+          logic.curatedRepositories() == ["MorphoDepot/mus-musculus-E15",
+                                          "muratmaga/rana-clamitans-full-body"])
+
+
+def test_forks_are_not_requested():
+    # A segmenter's fork is not a repo they review: its PRs target the upstream, where the
+    # upstream's curator sees them.  Asserted on the query, since the filter is server-side.
+    logic = FakeLogic(graphqlPages=[_viewerRepoPage([])])
+    logic.curatedRepositories()
+    check("the owner query excludes forks", "isFork: false" in logic.queries[0])
+
+
+def test_a_repo_owned_and_curated_appears_once():
+    logic = FakeLogic(graphqlPages=[_viewerRepoPage([repoNode("muratmaga/r", ["morphodepot"])])],
+                      curated=[{"nameWithOwner": "muratmaga/r"}])
+    check("the union deduplicates", logic.curatedRepositories() == ["muratmaga/r"])
+
+
+def test_unreachable_journal_still_lists_owned_repos():
+    # RepoClerk being down must not empty the Review tab for a personal-tier curator.  In-org PRs
+    # are missing in that state, which is why it logs a warning rather than passing silently.
+    logic = FakeLogic(graphqlPages=[_viewerRepoPage([repoNode("muratmaga/r", ["morphodepot"])])],
+                      curatedError=RuntimeError("RepoClerk clone failed"))
+    check("owned repos survive a journal failure", logic.curatedRepositories() == ["muratmaga/r"])
+
+
+# --- batched pull requests (Review) ------------------------------------------------------
+
+def _batchPage(mapping):
+    """mapping: alias -> (nameWithOwner, [prNode, ...]); None value means the repo is gone."""
+    data = {}
+    for alias, value in mapping.items():
+        data[alias] = None if value is None else {
+            "nameWithOwner": value[0], "pullRequests": {"nodes": value[1]}}
+    return {"data": data}
+
+
+def test_batched_prs_map_back_to_their_repos():
+    logic = FakeLogic(graphqlPages=[_batchPage({
+        "r0": ("muratmaga/rana-clamitans-full-body", [prNode(8, "issue-2")]),
+        "r1": ("MorphoDepot/mus-musculus-E15", [prNode(4, "issue-3")]),
+    })])
+    prs = logic.openPullRequestsForRepositories(
+        ["muratmaga/rana-clamitans-full-body", "MorphoDepot/mus-musculus-E15"])
+    check("each PR keeps its own repository",
+          [(p["number"], p["repository"]["nameWithOwner"]) for p in prs]
+          == [(8, "muratmaga/rana-clamitans-full-body"), (4, "MorphoDepot/mus-musculus-E15")])
+    check("one request covers both repos", len(logic.queries) == 1)
+
+
+def test_a_vanished_repo_is_skipped():
+    # A repo deleted, renamed, or made private between the two queries comes back as a null alias.
+    logic = FakeLogic(graphqlPages=[_batchPage({"r0": None,
+                                                "r1": ("o/live", [prNode(1, "issue-1")])})])
+    prs = logic.openPullRequestsForRepositories(["o/gone", "o/live"])
+    check("the null alias does not shift the others",
+          [p["repository"]["nameWithOwner"] for p in prs] == ["o/live"])
+
+
+def test_batching_splits_at_the_configured_size():
+    names = [f"owner/repo{n}" for n in range(workstate._PR_BATCH + 1)]
+    logic = FakeLogic(graphqlPages=[
+        _batchPage({f"r{i}": (names[i], []) for i in range(workstate._PR_BATCH)}),
+        _batchPage({"r0": (names[-1], [prNode(1, "issue-1")])}),
+    ])
+    prs = logic.openPullRequestsForRepositories(names)
+    check("51 repos take two requests", len(logic.queries) == 2)
+    check("aliases restart at r0 in the second batch",
+          [p["repository"]["nameWithOwner"] for p in prs] == [names[-1]])
+
+
+def test_malformed_names_never_reach_the_query():
+    # Names are interpolated into GraphQL string literals, so anything that is not a plain
+    # GitHub name is dropped rather than escaped.
+    logic = FakeLogic(graphqlPages=[_batchPage({"r0": ("o/good", [])})])
+    logic.openPullRequestsForRepositories(['o/bad") { x } #', "no-slash", "o/good"])
+    check("only the well-formed name is queried",
+          logic.queries[0].count("repository(owner:") == 1)
+    check('the injection attempt is absent', '") { x }' not in logic.queries[0])
+
+
+def test_split_name_with_owner():
+    check("a normal name splits", workstate.splitNameWithOwner("o/r") == ("o", "r"))
+    check("dots and dashes are fine",
+          workstate.splitNameWithOwner("Morpho-Depot/mus.musculus_E15")
+          == ("Morpho-Depot", "mus.musculus_E15"))
+    check("a missing slash is rejected", workstate.splitNameWithOwner("noslash") is None)
+    check("an extra slash is rejected", workstate.splitNameWithOwner("a/b/c") is None)
+    check("a quote is rejected", workstate.splitNameWithOwner('o/r") {') is None)
+    check("empty is rejected", workstate.splitNameWithOwner("") is None)
+    check("None is rejected", workstate.splitNameWithOwner(None) is None)
+
+
+# --- failure is loud ---------------------------------------------------------------------
+
+def test_graphql_errors_raise_rather_than_returning_empty():
+    """A GraphQL error arrives with HTTP 200, so gh exits 0 and nothing above would notice.
+
+    An empty list that means "GitHub said no" is indistinguishable from one that means "you have
+    no work assigned" -- the ambiguity behind SlicerMorph/SlicerMorphoDepot#212 and much of the
+    2026-08-07 investigation.  The tabs wrap these calls in tryWithErrorDisplay, so raising is
+    what puts the reason on screen.
+    """
+    logic = FakeLogic(graphqlPages=[{"errors": [{"message": "API rate limit exceeded"}]}])
+    try:
+        logic.prList(role="segmenter")
+    except RuntimeError as e:
+        check("the error message reaches the caller", "rate limit" in str(e))
+    else:
+        check("a GraphQL error raises", False)
+
+
+def test_unknown_role_raises():
+    check("an unknown role is a programming error, not an empty list",
+          _raises(lambda: FakeLogic().prList(role="bystander"), ValueError))
+
+
+def _raises(fn, exceptionType):
+    try:
+        fn()
+    except exceptionType:
+        return True
+    except Exception:
+        return False
+    return False
+
+
+if __name__ == "__main__":
+    for name, fn in sorted(globals().items()):
+        if name.startswith("test_") and callable(fn):
+            print(name)
+            fn()
+    print("\nall work-state tests passed")

--- a/MorphoDepot/Testing/Python/test_workstate.py
+++ b/MorphoDepot/Testing/Python/test_workstate.py
@@ -30,6 +30,18 @@ def check(name, cond):
     assert cond, name
 
 
+def _captureWarnings(fn):
+    """Run fn() and return the warning messages it logged, so 'it warns' is assertable."""
+    captured = []
+    original = workstate.logging.warning
+    workstate.logging.warning = lambda message, *a, **k: captured.append(str(message))
+    try:
+        fn()
+    finally:
+        workstate.logging.warning = original
+    return captured
+
+
 class FakeLogic(workstate.WorkStateMixin):
     """A WorkStateMixin with the two GitHub call sites stubbed.
 
@@ -171,6 +183,23 @@ def test_malformed_entries_do_not_break_the_list():
     check("a junk entry is skipped rather than raising", len(logic.issueList()) == 1)
 
 
+def test_an_entry_with_no_number_is_skipped_not_fatal():
+    """Every other field has a sensible empty value; a number does not.
+
+    loadIssue() builds the branch name and the fork checkout from it, so an entry without one
+    cannot be acted on.  The point is that it takes the rest of the list down with it if it
+    raises -- one malformed row must not empty the Annotate tab.
+    """
+    entry = restIssue(2, "Segment the premaxilla", "muratmaga/rana-clamitans-full-body", MD)
+    del entry["number"]
+    logic = FakeLogic(restResponse=[
+        entry,
+        restIssue(3, "Segment the skull", "muratmaga/rana-clamitans-full-body", MD),
+    ])
+    check("the numberless entry is skipped and the rest survive",
+          [i["number"] for i in logic.issueList()] == [3])
+
+
 # --- authored pull requests (Annotate, segmenter) ----------------------------------------
 
 def _viewerPRPage(nodes, hasNext=False, cursor=None):
@@ -195,6 +224,29 @@ def test_authored_prs_paginate():
     prs = logic.prList(role="segmenter")
     check("both pages are collected", [p["number"] for p in prs] == [1, 2])
     check("the second request carries the cursor", len(logic.queries) == 2)
+
+
+def test_hitting_the_page_backstop_is_reported():
+    """A truncated list must not look like a complete one.
+
+    _MAX_PAGES is a runaway guard, not a supported limit.  If it is ever reached the Review or
+    Annotate tab shows fewer items than the user has, and a short list that says nothing about
+    being short is the exact failure this module was written to remove.
+    """
+    page = _viewerPRPage([prNode(1, "issue-1", repo=("o/r", ["morphodepot"]))],
+                         hasNext=True, cursor="c")
+    logic = FakeLogic(graphqlPages=[page] * workstate._MAX_PAGES)
+    warnings = _captureWarnings(lambda: logic.prList(role="segmenter"))
+    check("the loop stops at the backstop", len(logic.queries) == workstate._MAX_PAGES)
+    check("and says so", any("Stopped after" in w for w in warnings))
+
+
+def test_a_repo_at_the_per_repo_pr_cap_is_reported():
+    nodes = [prNode(n, f"issue-{n}") for n in range(workstate._PRS_PER_REPO)]
+    logic = FakeLogic(graphqlPages=[_batchPage({"r0": ("o/busy", nodes)})])
+    warnings = _captureWarnings(lambda: logic.openPullRequestsForRepositories(["o/busy"]))
+    check("a repo at the un-paginated PR cap warns",
+          any("truncated" in w for w in warnings))
 
 
 def test_pr_shape_is_what_the_tabs_consume():


### PR DESCRIPTION
First implementation step for [`design/index-vs-work-state.md`](https://github.com/MorphoDepot/RepoClerk/blob/main/design/index-vs-work-state.md) — the extension half. It has to land before RepoClerk can stop journaling personal work state, or clients would go dark.

## The problem

The Annotate and Review tabs answered **"what am I assigned?"** and **"what am I reviewing?"** by downloading the whole fleet's issues and pull requests from the RepoClerk journal and filtering client-side. Those are per-user questions — bounded by the repos one person works on (median 1, mean 2.0 across the logins appearing in journals) — answered from a fleet-scale cache.

On 2026-08-07 the cache did not refresh, five assigned issues never reached the journal, and a class saw an empty Annotate tab indistinguishable from having no work. See [`design/near-realtime-ingestion.md`](https://github.com/MorphoDepot/RepoClerk/blob/main/design/near-realtime-ingestion.md).

## What this does

New `MorphoDepotLib/logic_workstate.py` (`WorkStateMixin`) owns `issueList()` and `prList()`:

| question | query | cost |
|---|---|---|
| assigned issues | `GET /issues?filter=assigned` | 1 REST call, both tiers, `repository.topics` inline |
| my open PRs | `viewer.pullRequests` | 1 request, 2 GraphQL points |
| repos I curate | `viewer.repositories(isFork: false)` ∪ journaled `CURATOR` | 1 point per 100 owned repos |
| PRs in those repos | aliased `repository()` fields, 50 per request | ~2 points per batch |

None of these scale with fleet size. The path they replace cost **202 GraphQL points against the 30-per-minute search endpoint** at 80 repos and grew linearly.

Measured end to end against live GitHub on this branch: **under a second per query, five requests** for a full Annotate + Review refresh, and the incident's PR (`clara1379` on `rana-clamitans-full-body#7`) lists immediately.

The MorphoDepot test is the repo's **live topic list**, never a known-repo set — filtering against the index would reproduce the original bug at one remove, since a repo published two minutes ago has no journal entry yet.

## Consequences worth reviewing

- **`ghTopicData()` and `_journalsToTopicData()` are deleted, not merely orphaned.** While they existed, work state could still be answered from a cache. Removing them makes that structurally impossible rather than merely unused.
- **The up-to-2-minute "Github update pending..." wait is gone from both tabs.** There is no journal update to wait for. `_waitForRepoClerkUpdate()` stays for Search, which does read the index.
- **A failed query raises instead of returning `[]`** — including GraphQL errors, which arrive with HTTP 200 and would otherwise pass silently. An empty work list and a failed one are no longer the same thing on screen (SlicerMorphoDepot#212).
- **The reviewer list starts from the repo set** rather than inferring responsibility from a PR's closing-issue owner, so a PR whose issue link is missing or malformed still lists.
- Repo names are interpolated into GraphQL string literals in the batched query; `splitNameWithOwner()` rejects anything that is not a plain GitHub name rather than escaping it. There is a test for the injection shape.

## What the journal keeps

Species, modality, spacing, dimensions, screenshots, volume size, checksum, `CURATOR`, collection membership — all push-gated, all fleet-scale, all still read by Search and Release. `morphoRepos()` still carries issue/PR counts for the Release tab's org-wide view; that is a fleet question, not a per-user one.

The **one** place a tier distinction survives is deliberate and documented in `curatedRepositories()`: an org repo is owned by the MorphoDepot org, not by its curator, so no owner-keyed query can find it, and `CURATOR` is a committed file — index data on the same grounds as species. It is a union of two sources, not a branch on tier.

## Testing

`MorphoDepot/Testing/Python/test_workstate.py` — 20 cases, no Slicer, no network, plain `python3`. Recorded response shapes are trimmed from real 2026-08-07 responses.

```
python3 MorphoDepot/Testing/Python/test_workstate.py
```

The e2e self-test's step 9 now goes through the real `issueList()` rather than the REST stand-in it needed while that path was cached.

## Deliberately not in this PR

- **Converting e2e steps 11–13 to the real `prList()` paths.** They bypass it for a reason that is no longer the search index but is still real: the test repo lives in the `MorphoDepotTesting` scratch org, which neither the owner query nor the `CURATOR` journal reaches. Comments corrected to say so. (That gap predates this change — the old owner-of-the-closing-issue test missed it identically.)
- **The RepoClerk side** — dropping personal work state from the journal, and the `notifyRepoClerk()`/#469 removal that follows. Order matters: clients read live first, journal stops writing second.
- **`refreshRepoClerk()`'s missing offline fallback.** Its docstring still claims one; unchanged here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
